### PR TITLE
adds tag bson to structs model

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/golang-fhir-models" vcs="Git" />
+  </component>
+</project>

--- a/fhir-models-gen/cmd/genResources.go
+++ b/fhir-models-gen/cmd/genResources.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"github.com/samply/golang-fhir-models/fhir-models-gen/fhir"
+	"fhir-models-gen/fhir"
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"

--- a/fhir-models-gen/cmd/genResources.go
+++ b/fhir-models-gen/cmd/genResources.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen/fhir"
+	"github.com/samply/golang-fhir-models/fhir-models-gen/fhir"
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"

--- a/fhir-models-gen/cmd/genResources.go
+++ b/fhir-models-gen/cmd/genResources.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"fhir-models-gen/fhir"
+	"github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen/fhir"
 	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"

--- a/fhir-models-gen/cmd/genResources.go
+++ b/fhir-models-gen/cmd/genResources.go
@@ -423,9 +423,9 @@ func appendFields(resources ResourceMap, requiredTypes map[string]bool, required
 					}
 
 					if *element.Min == 0 {
-						statement.Tag(map[string]string{"json": pathParts[level] + ",omitempty"})
+						statement.Tag(map[string]string{"json": pathParts[level] + ",omitempty", "bson": pathParts[level] + ",omitempty"})
 					} else {
-						statement.Tag(map[string]string{"json": pathParts[level]})
+						statement.Tag(map[string]string{"json": pathParts[level],  "bson": pathParts[level]})
 					}
 				}
 			}

--- a/fhir-models-gen/cmd/genResources.go
+++ b/fhir-models-gen/cmd/genResources.go
@@ -343,7 +343,7 @@ func appendFields(resources ResourceMap, requiredTypes map[string]bool, required
 						for _, pathPart := range Split((*element.ContentReference)[1:], ".") {
 							typeIdentifier = typeIdentifier + Title(pathPart)
 						}
-						statement.Id(typeIdentifier).Tag(map[string]string{"json": pathParts[level] + ",omitempty"})
+						statement.Id(typeIdentifier).Tag(map[string]string{"json": pathParts[level] + ",omitempty", "bson": pathParts[level] + ",omitempty"})
 					}
 				// support polymorphic elements later
 				case 1:

--- a/fhir-models-gen/cmd/valueSet.go
+++ b/fhir-models-gen/cmd/valueSet.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"fhir-models-gen/fhir"
+	"github.com/Universal-Health-Chain/golang-fhir-models/fhir-models/fhir"
 	"strings"
 )
 

--- a/fhir-models-gen/cmd/valueSet.go
+++ b/fhir-models-gen/cmd/valueSet.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"github.com/Universal-Health-Chain/golang-fhir-models/fhir-models/fhir"
+	"github.com/samply/golang-fhir-models/fhir-models-gen/fhir"
 	"strings"
 )
 

--- a/fhir-models-gen/cmd/valueSet.go
+++ b/fhir-models-gen/cmd/valueSet.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dave/jennifer/jen"
-	"github.com/samply/golang-fhir-models/fhir-models-gen/fhir"
+	"fhir-models-gen/fhir"
 	"strings"
 )
 

--- a/fhir-models-gen/fhir/bundle.go
+++ b/fhir-models-gen/fhir/bundle.go
@@ -21,63 +21,63 @@ import "encoding/json"
 
 // Bundle is documented here http://hl7.org/fhir/StructureDefinition/Bundle
 type Bundle struct {
-	Id            *string       `json:"id,omitempty"`
-	Meta          *Meta         `json:"meta,omitempty"`
-	ImplicitRules *string       `json:"implicitRules,omitempty"`
-	Language      *string       `json:"language,omitempty"`
-	Identifier    *Identifier   `json:"identifier,omitempty"`
-	Type          BundleType    `json:"type"`
-	Timestamp     *string       `json:"timestamp,omitempty"`
-	Total         *int          `json:"total,omitempty"`
-	Link          []BundleLink  `json:"link,omitempty"`
-	Entry         []BundleEntry `json:"entry,omitempty"`
-	Signature     *Signature    `json:"signature,omitempty"`
+	Id            *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta          *Meta         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules *string       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language      *string       `bson:"language,omitempty" json:"language,omitempty"`
+	Identifier    *Identifier   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type          BundleType    `bson:"type" json:"type"`
+	Timestamp     *string       `bson:"timestamp,omitempty" json:"timestamp,omitempty"`
+	Total         *int          `bson:"total,omitempty" json:"total,omitempty"`
+	Link          []BundleLink  `bson:"link,omitempty" json:"link,omitempty"`
+	Entry         []BundleEntry `bson:"entry,omitempty" json:"entry,omitempty"`
+	Signature     *Signature    `bson:"signature,omitempty" json:"signature,omitempty"`
 }
 type BundleLink struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Relation          string      `json:"relation"`
-	Url               string      `json:"url"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Relation          string      `bson:"relation" json:"relation"`
+	Url               string      `bson:"url" json:"url"`
 }
 type BundleEntry struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Link              []BundleLink         `json:"link,omitempty"`
-	FullUrl           *string              `json:"fullUrl,omitempty"`
-	Resource          json.RawMessage      `json:"resource,omitempty"`
-	Search            *BundleEntrySearch   `json:"search,omitempty"`
-	Request           *BundleEntryRequest  `json:"request,omitempty"`
-	Response          *BundleEntryResponse `json:"response,omitempty"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Link              []BundleLink         `bson:"link,omitempty" json:"link,omitempty"`
+	FullUrl           *string              `bson:"fullUrl,omitempty" json:"fullUrl,omitempty"`
+	Resource          json.RawMessage      `bson:"resource,omitempty" json:"resource,omitempty"`
+	Search            *BundleEntrySearch   `bson:"search,omitempty" json:"search,omitempty"`
+	Request           *BundleEntryRequest  `bson:"request,omitempty" json:"request,omitempty"`
+	Response          *BundleEntryResponse `bson:"response,omitempty" json:"response,omitempty"`
 }
 type BundleEntrySearch struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Mode              *SearchEntryMode `json:"mode,omitempty"`
-	Score             *string          `json:"score,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              *SearchEntryMode `bson:"mode,omitempty" json:"mode,omitempty"`
+	Score             *string          `bson:"score,omitempty" json:"score,omitempty"`
 }
 type BundleEntryRequest struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Method            HTTPVerb    `json:"method"`
-	Url               string      `json:"url"`
-	IfNoneMatch       *string     `json:"ifNoneMatch,omitempty"`
-	IfModifiedSince   *string     `json:"ifModifiedSince,omitempty"`
-	IfMatch           *string     `json:"ifMatch,omitempty"`
-	IfNoneExist       *string     `json:"ifNoneExist,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Method            HTTPVerb    `bson:"method" json:"method"`
+	Url               string      `bson:"url" json:"url"`
+	IfNoneMatch       *string     `bson:"ifNoneMatch,omitempty" json:"ifNoneMatch,omitempty"`
+	IfModifiedSince   *string     `bson:"ifModifiedSince,omitempty" json:"ifModifiedSince,omitempty"`
+	IfMatch           *string     `bson:"ifMatch,omitempty" json:"ifMatch,omitempty"`
+	IfNoneExist       *string     `bson:"ifNoneExist,omitempty" json:"ifNoneExist,omitempty"`
 }
 type BundleEntryResponse struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Status            string          `json:"status"`
-	Location          *string         `json:"location,omitempty"`
-	Etag              *string         `json:"etag,omitempty"`
-	LastModified      *string         `json:"lastModified,omitempty"`
-	Outcome           json.RawMessage `json:"outcome,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Status            string          `bson:"status" json:"status"`
+	Location          *string         `bson:"location,omitempty" json:"location,omitempty"`
+	Etag              *string         `bson:"etag,omitempty" json:"etag,omitempty"`
+	LastModified      *string         `bson:"lastModified,omitempty" json:"lastModified,omitempty"`
+	Outcome           json.RawMessage `bson:"outcome,omitempty" json:"outcome,omitempty"`
 }
 type OtherBundle Bundle
 

--- a/fhir-models-gen/fhir/codeSystem.go
+++ b/fhir-models-gen/fhir/codeSystem.go
@@ -21,82 +21,82 @@ import "encoding/json"
 
 // CodeSystem is documented here http://hl7.org/fhir/StructureDefinition/CodeSystem
 type CodeSystem struct {
-	Id                *string                     `json:"id,omitempty"`
-	Meta              *Meta                       `json:"meta,omitempty"`
-	ImplicitRules     *string                     `json:"implicitRules,omitempty"`
-	Language          *string                     `json:"language,omitempty"`
-	Text              *Narrative                  `json:"text,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Url               *string                     `json:"url,omitempty"`
-	Identifier        []Identifier                `json:"identifier,omitempty"`
-	Version           *string                     `json:"version,omitempty"`
-	Name              *string                     `json:"name,omitempty"`
-	Title             *string                     `json:"title,omitempty"`
-	Status            PublicationStatus           `json:"status"`
-	Experimental      *bool                       `json:"experimental,omitempty"`
-	Date              *string                     `json:"date,omitempty"`
-	Publisher         *string                     `json:"publisher,omitempty"`
-	Contact           []ContactDetail             `json:"contact,omitempty"`
-	Description       *string                     `json:"description,omitempty"`
-	UseContext        []UsageContext              `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept           `json:"jurisdiction,omitempty"`
-	Purpose           *string                     `json:"purpose,omitempty"`
-	Copyright         *string                     `json:"copyright,omitempty"`
-	CaseSensitive     *bool                       `json:"caseSensitive,omitempty"`
-	ValueSet          *string                     `json:"valueSet,omitempty"`
-	HierarchyMeaning  *CodeSystemHierarchyMeaning `json:"hierarchyMeaning,omitempty"`
-	Compositional     *bool                       `json:"compositional,omitempty"`
-	VersionNeeded     *bool                       `json:"versionNeeded,omitempty"`
-	Content           CodeSystemContentMode       `json:"content"`
-	Supplements       *string                     `json:"supplements,omitempty"`
-	Count             *int                        `json:"count,omitempty"`
-	Filter            []CodeSystemFilter          `json:"filter,omitempty"`
-	Property          []CodeSystemProperty        `json:"property,omitempty"`
-	Concept           []CodeSystemConcept         `json:"concept,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                     `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier                `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                     `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                     `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                     `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus           `bson:"status" json:"status"`
+	Experimental      *bool                       `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                     `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                     `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail             `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                     `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext              `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept           `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                     `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                     `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	CaseSensitive     *bool                       `bson:"caseSensitive,omitempty" json:"caseSensitive,omitempty"`
+	ValueSet          *string                     `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
+	HierarchyMeaning  *CodeSystemHierarchyMeaning `bson:"hierarchyMeaning,omitempty" json:"hierarchyMeaning,omitempty"`
+	Compositional     *bool                       `bson:"compositional,omitempty" json:"compositional,omitempty"`
+	VersionNeeded     *bool                       `bson:"versionNeeded,omitempty" json:"versionNeeded,omitempty"`
+	Content           CodeSystemContentMode       `bson:"content" json:"content"`
+	Supplements       *string                     `bson:"supplements,omitempty" json:"supplements,omitempty"`
+	Count             *int                        `bson:"count,omitempty" json:"count,omitempty"`
+	Filter            []CodeSystemFilter          `bson:"filter,omitempty" json:"filter,omitempty"`
+	Property          []CodeSystemProperty        `bson:"property,omitempty" json:"property,omitempty"`
+	Concept           []CodeSystemConcept         `bson:"concept,omitempty" json:"concept,omitempty"`
 }
 type CodeSystemFilter struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              string           `json:"code"`
-	Description       *string          `json:"description,omitempty"`
-	Operator          []FilterOperator `json:"operator"`
-	Value             string           `json:"value"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string           `bson:"code" json:"code"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Operator          []FilterOperator `bson:"operator" json:"operator"`
+	Value             string           `bson:"value" json:"value"`
 }
 type CodeSystemProperty struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Code              string       `json:"code"`
-	Uri               *string      `json:"uri,omitempty"`
-	Description       *string      `json:"description,omitempty"`
-	Type              PropertyType `json:"type"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string       `bson:"code" json:"code"`
+	Uri               *string      `bson:"uri,omitempty" json:"uri,omitempty"`
+	Description       *string      `bson:"description,omitempty" json:"description,omitempty"`
+	Type              PropertyType `bson:"type" json:"type"`
 }
 type CodeSystemConcept struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Code              string                         `json:"code"`
-	Display           *string                        `json:"display,omitempty"`
-	Definition        *string                        `json:"definition,omitempty"`
-	Designation       []CodeSystemConceptDesignation `json:"designation,omitempty"`
-	Property          []CodeSystemConceptProperty    `json:"property,omitempty"`
-	Concept           []CodeSystemConcept            `json:"concept,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string                         `bson:"code" json:"code"`
+	Display           *string                        `bson:"display,omitempty" json:"display,omitempty"`
+	Definition        *string                        `bson:"definition,omitempty" json:"definition,omitempty"`
+	Designation       []CodeSystemConceptDesignation `bson:"designation,omitempty" json:"designation,omitempty"`
+	Property          []CodeSystemConceptProperty    `bson:"property,omitempty" json:"property,omitempty"`
+	Concept           []CodeSystemConcept            `bson:"concept,omitempty" json:"concept,omitempty"`
 }
 type CodeSystemConceptDesignation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Language          *string     `json:"language,omitempty"`
-	Use               *Coding     `json:"use,omitempty"`
-	Value             string      `json:"value"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Language          *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Use               *Coding     `bson:"use,omitempty" json:"use,omitempty"`
+	Value             string      `bson:"value" json:"value"`
 }
 type CodeSystemConceptProperty struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Code              string      `json:"code"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string      `bson:"code" json:"code"`
 }
 type OtherCodeSystem CodeSystem
 

--- a/fhir-models-gen/fhir/codeableConcept.go
+++ b/fhir-models-gen/fhir/codeableConcept.go
@@ -19,8 +19,8 @@ package fhir
 
 // CodeableConcept is documented here http://hl7.org/fhir/StructureDefinition/CodeableConcept
 type CodeableConcept struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Coding    []Coding    `json:"coding,omitempty"`
-	Text      *string     `json:"text,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Coding    []Coding    `bson:"coding,omitempty" json:"coding,omitempty"`
+	Text      *string     `bson:"text,omitempty" json:"text,omitempty"`
 }

--- a/fhir-models-gen/fhir/coding.go
+++ b/fhir-models-gen/fhir/coding.go
@@ -19,11 +19,11 @@ package fhir
 
 // Coding is documented here http://hl7.org/fhir/StructureDefinition/Coding
 type Coding struct {
-	Id           *string     `json:"id,omitempty"`
-	Extension    []Extension `json:"extension,omitempty"`
-	System       *string     `json:"system,omitempty"`
-	Version      *string     `json:"version,omitempty"`
-	Code         *string     `json:"code,omitempty"`
-	Display      *string     `json:"display,omitempty"`
-	UserSelected *bool       `json:"userSelected,omitempty"`
+	Id           *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	System       *string     `bson:"system,omitempty" json:"system,omitempty"`
+	Version      *string     `bson:"version,omitempty" json:"version,omitempty"`
+	Code         *string     `bson:"code,omitempty" json:"code,omitempty"`
+	Display      *string     `bson:"display,omitempty" json:"display,omitempty"`
+	UserSelected *bool       `bson:"userSelected,omitempty" json:"userSelected,omitempty"`
 }

--- a/fhir-models-gen/fhir/contactDetail.go
+++ b/fhir-models-gen/fhir/contactDetail.go
@@ -19,8 +19,8 @@ package fhir
 
 // ContactDetail is documented here http://hl7.org/fhir/StructureDefinition/ContactDetail
 type ContactDetail struct {
-	Id        *string        `json:"id,omitempty"`
-	Extension []Extension    `json:"extension,omitempty"`
-	Name      *string        `json:"name,omitempty"`
-	Telecom   []ContactPoint `json:"telecom,omitempty"`
+	Id        *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	Name      *string        `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom   []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }

--- a/fhir-models-gen/fhir/contactPoint.go
+++ b/fhir-models-gen/fhir/contactPoint.go
@@ -19,11 +19,11 @@ package fhir
 
 // ContactPoint is documented here http://hl7.org/fhir/StructureDefinition/ContactPoint
 type ContactPoint struct {
-	Id        *string             `json:"id,omitempty"`
-	Extension []Extension         `json:"extension,omitempty"`
-	System    *ContactPointSystem `json:"system,omitempty"`
-	Value     *string             `json:"value,omitempty"`
-	Use       *ContactPointUse    `json:"use,omitempty"`
-	Rank      *int                `json:"rank,omitempty"`
-	Period    *Period             `json:"period,omitempty"`
+	Id        *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	System    *ContactPointSystem `bson:"system,omitempty" json:"system,omitempty"`
+	Value     *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Use       *ContactPointUse    `bson:"use,omitempty" json:"use,omitempty"`
+	Rank      *int                `bson:"rank,omitempty" json:"rank,omitempty"`
+	Period    *Period             `bson:"period,omitempty" json:"period,omitempty"`
 }

--- a/fhir-models-gen/fhir/elementDefinition.go
+++ b/fhir-models-gen/fhir/elementDefinition.go
@@ -19,97 +19,97 @@ package fhir
 
 // ElementDefinition is documented here http://hl7.org/fhir/StructureDefinition/ElementDefinition
 type ElementDefinition struct {
-	Id                  *string                       `json:"id,omitempty"`
-	Extension           []Extension                   `json:"extension,omitempty"`
-	ModifierExtension   []Extension                   `json:"modifierExtension,omitempty"`
-	Path                string                        `json:"path"`
-	Representation      []PropertyRepresentation      `json:"representation,omitempty"`
-	SliceName           *string                       `json:"sliceName,omitempty"`
-	SliceIsConstraining *bool                         `json:"sliceIsConstraining,omitempty"`
-	Label               *string                       `json:"label,omitempty"`
-	Code                []Coding                      `json:"code,omitempty"`
-	Slicing             *ElementDefinitionSlicing     `json:"slicing,omitempty"`
-	Short               *string                       `json:"short,omitempty"`
-	Definition          *string                       `json:"definition,omitempty"`
-	Comment             *string                       `json:"comment,omitempty"`
-	Requirements        *string                       `json:"requirements,omitempty"`
-	Alias               []string                      `json:"alias,omitempty"`
-	Min                 *int                          `json:"min,omitempty"`
-	Max                 *string                       `json:"max,omitempty"`
-	Base                *ElementDefinitionBase        `json:"base,omitempty"`
-	ContentReference    *string                       `json:"contentReference,omitempty"`
-	Type                []ElementDefinitionType       `json:"type,omitempty"`
-	MeaningWhenMissing  *string                       `json:"meaningWhenMissing,omitempty"`
-	OrderMeaning        *string                       `json:"orderMeaning,omitempty"`
-	Example             []ElementDefinitionExample    `json:"example,omitempty"`
-	MaxLength           *int                          `json:"maxLength,omitempty"`
-	Condition           []string                      `json:"condition,omitempty"`
-	Constraint          []ElementDefinitionConstraint `json:"constraint,omitempty"`
-	MustSupport         *bool                         `json:"mustSupport,omitempty"`
-	IsModifier          *bool                         `json:"isModifier,omitempty"`
-	IsModifierReason    *string                       `json:"isModifierReason,omitempty"`
-	IsSummary           *bool                         `json:"isSummary,omitempty"`
-	Binding             *ElementDefinitionBinding     `json:"binding,omitempty"`
-	Mapping             []ElementDefinitionMapping    `json:"mapping,omitempty"`
+	Id                  *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Path                string                        `bson:"path" json:"path"`
+	Representation      []PropertyRepresentation      `bson:"representation,omitempty" json:"representation,omitempty"`
+	SliceName           *string                       `bson:"sliceName,omitempty" json:"sliceName,omitempty"`
+	SliceIsConstraining *bool                         `bson:"sliceIsConstraining,omitempty" json:"sliceIsConstraining,omitempty"`
+	Label               *string                       `bson:"label,omitempty" json:"label,omitempty"`
+	Code                []Coding                      `bson:"code,omitempty" json:"code,omitempty"`
+	Slicing             *ElementDefinitionSlicing     `bson:"slicing,omitempty" json:"slicing,omitempty"`
+	Short               *string                       `bson:"short,omitempty" json:"short,omitempty"`
+	Definition          *string                       `bson:"definition,omitempty" json:"definition,omitempty"`
+	Comment             *string                       `bson:"comment,omitempty" json:"comment,omitempty"`
+	Requirements        *string                       `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Alias               []string                      `bson:"alias,omitempty" json:"alias,omitempty"`
+	Min                 *int                          `bson:"min,omitempty" json:"min,omitempty"`
+	Max                 *string                       `bson:"max,omitempty" json:"max,omitempty"`
+	Base                *ElementDefinitionBase        `bson:"base,omitempty" json:"base,omitempty"`
+	ContentReference    *string                       `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
+	Type                []ElementDefinitionType       `bson:"type,omitempty" json:"type,omitempty"`
+	MeaningWhenMissing  *string                       `bson:"meaningWhenMissing,omitempty" json:"meaningWhenMissing,omitempty"`
+	OrderMeaning        *string                       `bson:"orderMeaning,omitempty" json:"orderMeaning,omitempty"`
+	Example             []ElementDefinitionExample    `bson:"example,omitempty" json:"example,omitempty"`
+	MaxLength           *int                          `bson:"maxLength,omitempty" json:"maxLength,omitempty"`
+	Condition           []string                      `bson:"condition,omitempty" json:"condition,omitempty"`
+	Constraint          []ElementDefinitionConstraint `bson:"constraint,omitempty" json:"constraint,omitempty"`
+	MustSupport         *bool                         `bson:"mustSupport,omitempty" json:"mustSupport,omitempty"`
+	IsModifier          *bool                         `bson:"isModifier,omitempty" json:"isModifier,omitempty"`
+	IsModifierReason    *string                       `bson:"isModifierReason,omitempty" json:"isModifierReason,omitempty"`
+	IsSummary           *bool                         `bson:"isSummary,omitempty" json:"isSummary,omitempty"`
+	Binding             *ElementDefinitionBinding     `bson:"binding,omitempty" json:"binding,omitempty"`
+	Mapping             []ElementDefinitionMapping    `bson:"mapping,omitempty" json:"mapping,omitempty"`
 }
 type ElementDefinitionSlicing struct {
-	Id            *string                                 `json:"id,omitempty"`
-	Extension     []Extension                             `json:"extension,omitempty"`
-	Discriminator []ElementDefinitionSlicingDiscriminator `json:"discriminator,omitempty"`
-	Description   *string                                 `json:"description,omitempty"`
-	Ordered       *bool                                   `json:"ordered,omitempty"`
-	Rules         SlicingRules                            `json:"rules"`
+	Id            *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension     []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	Discriminator []ElementDefinitionSlicingDiscriminator `bson:"discriminator,omitempty" json:"discriminator,omitempty"`
+	Description   *string                                 `bson:"description,omitempty" json:"description,omitempty"`
+	Ordered       *bool                                   `bson:"ordered,omitempty" json:"ordered,omitempty"`
+	Rules         SlicingRules                            `bson:"rules" json:"rules"`
 }
 type ElementDefinitionSlicingDiscriminator struct {
-	Id        *string           `json:"id,omitempty"`
-	Extension []Extension       `json:"extension,omitempty"`
-	Type      DiscriminatorType `json:"type"`
-	Path      string            `json:"path"`
+	Id        *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type      DiscriminatorType `bson:"type" json:"type"`
+	Path      string            `bson:"path" json:"path"`
 }
 type ElementDefinitionBase struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Path      string      `json:"path"`
-	Min       int         `json:"min"`
-	Max       string      `json:"max"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Path      string      `bson:"path" json:"path"`
+	Min       int         `bson:"min" json:"min"`
+	Max       string      `bson:"max" json:"max"`
 }
 type ElementDefinitionType struct {
-	Id            *string                `json:"id,omitempty"`
-	Extension     []Extension            `json:"extension,omitempty"`
-	Code          string                 `json:"code"`
-	Profile       []string               `json:"profile,omitempty"`
-	TargetProfile []string               `json:"targetProfile,omitempty"`
-	Aggregation   []AggregationMode      `json:"aggregation,omitempty"`
-	Versioning    *ReferenceVersionRules `json:"versioning,omitempty"`
+	Id            *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension     []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	Code          string                 `bson:"code" json:"code"`
+	Profile       []string               `bson:"profile,omitempty" json:"profile,omitempty"`
+	TargetProfile []string               `bson:"targetProfile,omitempty" json:"targetProfile,omitempty"`
+	Aggregation   []AggregationMode      `bson:"aggregation,omitempty" json:"aggregation,omitempty"`
+	Versioning    *ReferenceVersionRules `bson:"versioning,omitempty" json:"versioning,omitempty"`
 }
 type ElementDefinitionExample struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Label     string      `json:"label"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Label     string      `bson:"label" json:"label"`
 }
 type ElementDefinitionConstraint struct {
-	Id           *string            `json:"id,omitempty"`
-	Extension    []Extension        `json:"extension,omitempty"`
-	Key          string             `json:"key"`
-	Requirements *string            `json:"requirements,omitempty"`
-	Severity     ConstraintSeverity `json:"severity"`
-	Human        string             `json:"human"`
-	Expression   *string            `json:"expression,omitempty"`
-	Xpath        *string            `json:"xpath,omitempty"`
-	Source       *string            `json:"source,omitempty"`
+	Id           *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	Key          string             `bson:"key" json:"key"`
+	Requirements *string            `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Severity     ConstraintSeverity `bson:"severity" json:"severity"`
+	Human        string             `bson:"human" json:"human"`
+	Expression   *string            `bson:"expression,omitempty" json:"expression,omitempty"`
+	Xpath        *string            `bson:"xpath,omitempty" json:"xpath,omitempty"`
+	Source       *string            `bson:"source,omitempty" json:"source,omitempty"`
 }
 type ElementDefinitionBinding struct {
-	Id          *string         `json:"id,omitempty"`
-	Extension   []Extension     `json:"extension,omitempty"`
-	Strength    BindingStrength `json:"strength"`
-	Description *string         `json:"description,omitempty"`
-	ValueSet    *string         `json:"valueSet,omitempty"`
+	Id          *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	Strength    BindingStrength `bson:"strength" json:"strength"`
+	Description *string         `bson:"description,omitempty" json:"description,omitempty"`
+	ValueSet    *string         `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
 }
 type ElementDefinitionMapping struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Identity  string      `json:"identity"`
-	Language  *string     `json:"language,omitempty"`
-	Map       string      `json:"map"`
-	Comment   *string     `json:"comment,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Identity  string      `bson:"identity" json:"identity"`
+	Language  *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Map       string      `bson:"map" json:"map"`
+	Comment   *string     `bson:"comment,omitempty" json:"comment,omitempty"`
 }

--- a/fhir-models-gen/fhir/extension.go
+++ b/fhir-models-gen/fhir/extension.go
@@ -19,7 +19,7 @@ package fhir
 
 // Extension is documented here http://hl7.org/fhir/StructureDefinition/Extension
 type Extension struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Url       string      `json:"url"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Url       string      `bson:"url" json:"url"`
 }

--- a/fhir-models-gen/fhir/identifier.go
+++ b/fhir-models-gen/fhir/identifier.go
@@ -19,12 +19,12 @@ package fhir
 
 // Identifier is documented here http://hl7.org/fhir/StructureDefinition/Identifier
 type Identifier struct {
-	Id        *string          `json:"id,omitempty"`
-	Extension []Extension      `json:"extension,omitempty"`
-	Use       *IdentifierUse   `json:"use,omitempty"`
-	Type      *CodeableConcept `json:"type,omitempty"`
-	System    *string          `json:"system,omitempty"`
-	Value     *string          `json:"value,omitempty"`
-	Period    *Period          `json:"period,omitempty"`
-	Assigner  *Reference       `json:"assigner,omitempty"`
+	Id        *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	Use       *IdentifierUse   `bson:"use,omitempty" json:"use,omitempty"`
+	Type      *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	System    *string          `bson:"system,omitempty" json:"system,omitempty"`
+	Value     *string          `bson:"value,omitempty" json:"value,omitempty"`
+	Period    *Period          `bson:"period,omitempty" json:"period,omitempty"`
+	Assigner  *Reference       `bson:"assigner,omitempty" json:"assigner,omitempty"`
 }

--- a/fhir-models-gen/fhir/meta.go
+++ b/fhir-models-gen/fhir/meta.go
@@ -19,12 +19,12 @@ package fhir
 
 // Meta is documented here http://hl7.org/fhir/StructureDefinition/Meta
 type Meta struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	VersionId   *string     `json:"versionId,omitempty"`
-	LastUpdated *string     `json:"lastUpdated,omitempty"`
-	Source      *string     `json:"source,omitempty"`
-	Profile     []string    `json:"profile,omitempty"`
-	Security    []Coding    `json:"security,omitempty"`
-	Tag         []Coding    `json:"tag,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	VersionId   *string     `bson:"versionId,omitempty" json:"versionId,omitempty"`
+	LastUpdated *string     `bson:"lastUpdated,omitempty" json:"lastUpdated,omitempty"`
+	Source      *string     `bson:"source,omitempty" json:"source,omitempty"`
+	Profile     []string    `bson:"profile,omitempty" json:"profile,omitempty"`
+	Security    []Coding    `bson:"security,omitempty" json:"security,omitempty"`
+	Tag         []Coding    `bson:"tag,omitempty" json:"tag,omitempty"`
 }

--- a/fhir-models-gen/fhir/narrative.go
+++ b/fhir-models-gen/fhir/narrative.go
@@ -19,8 +19,8 @@ package fhir
 
 // Narrative is documented here http://hl7.org/fhir/StructureDefinition/Narrative
 type Narrative struct {
-	Id        *string         `json:"id,omitempty"`
-	Extension []Extension     `json:"extension,omitempty"`
-	Status    NarrativeStatus `json:"status"`
-	Div       string          `json:"div"`
+	Id        *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	Status    NarrativeStatus `bson:"status" json:"status"`
+	Div       string          `bson:"div" json:"div"`
 }

--- a/fhir-models-gen/fhir/period.go
+++ b/fhir-models-gen/fhir/period.go
@@ -19,8 +19,8 @@ package fhir
 
 // Period is documented here http://hl7.org/fhir/StructureDefinition/Period
 type Period struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Start     *string     `json:"start,omitempty"`
-	End       *string     `json:"end,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Start     *string     `bson:"start,omitempty" json:"start,omitempty"`
+	End       *string     `bson:"end,omitempty" json:"end,omitempty"`
 }

--- a/fhir-models-gen/fhir/reference.go
+++ b/fhir-models-gen/fhir/reference.go
@@ -19,10 +19,10 @@ package fhir
 
 // Reference is documented here http://hl7.org/fhir/StructureDefinition/Reference
 type Reference struct {
-	Id         *string     `json:"id,omitempty"`
-	Extension  []Extension `json:"extension,omitempty"`
-	Reference  *string     `json:"reference,omitempty"`
-	Type       *string     `json:"type,omitempty"`
-	Identifier *Identifier `json:"identifier,omitempty"`
-	Display    *string     `json:"display,omitempty"`
+	Id         *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension  []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Reference  *string     `bson:"reference,omitempty" json:"reference,omitempty"`
+	Type       *string     `bson:"type,omitempty" json:"type,omitempty"`
+	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Display    *string     `bson:"display,omitempty" json:"display,omitempty"`
 }

--- a/fhir-models-gen/fhir/signature.go
+++ b/fhir-models-gen/fhir/signature.go
@@ -19,13 +19,13 @@ package fhir
 
 // Signature is documented here http://hl7.org/fhir/StructureDefinition/Signature
 type Signature struct {
-	Id           *string     `json:"id,omitempty"`
-	Extension    []Extension `json:"extension,omitempty"`
-	Type         []Coding    `json:"type"`
-	When         string      `json:"when"`
-	Who          Reference   `json:"who"`
-	OnBehalfOf   *Reference  `json:"onBehalfOf,omitempty"`
-	TargetFormat *string     `json:"targetFormat,omitempty"`
-	SigFormat    *string     `json:"sigFormat,omitempty"`
-	Data         *string     `json:"data,omitempty"`
+	Id           *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type         []Coding    `bson:"type" json:"type"`
+	When         string      `bson:"when" json:"when"`
+	Who          Reference   `bson:"who" json:"who"`
+	OnBehalfOf   *Reference  `bson:"onBehalfOf,omitempty" json:"onBehalfOf,omitempty"`
+	TargetFormat *string     `bson:"targetFormat,omitempty" json:"targetFormat,omitempty"`
+	SigFormat    *string     `bson:"sigFormat,omitempty" json:"sigFormat,omitempty"`
+	Data         *string     `bson:"data,omitempty" json:"data,omitempty"`
 }

--- a/fhir-models-gen/fhir/structureDefinition.go
+++ b/fhir-models-gen/fhir/structureDefinition.go
@@ -21,68 +21,68 @@ import "encoding/json"
 
 // StructureDefinition is documented here http://hl7.org/fhir/StructureDefinition/StructureDefinition
 type StructureDefinition struct {
-	Id                *string                          `json:"id,omitempty"`
-	Meta              *Meta                            `json:"meta,omitempty"`
-	ImplicitRules     *string                          `json:"implicitRules,omitempty"`
-	Language          *string                          `json:"language,omitempty"`
-	Text              *Narrative                       `json:"text,omitempty"`
-	Extension         []Extension                      `json:"extension,omitempty"`
-	ModifierExtension []Extension                      `json:"modifierExtension,omitempty"`
-	Url               string                           `json:"url"`
-	Identifier        []Identifier                     `json:"identifier,omitempty"`
-	Version           *string                          `json:"version,omitempty"`
-	Name              string                           `json:"name"`
-	Title             *string                          `json:"title,omitempty"`
-	Status            PublicationStatus                `json:"status"`
-	Experimental      *bool                            `json:"experimental,omitempty"`
-	Date              *string                          `json:"date,omitempty"`
-	Publisher         *string                          `json:"publisher,omitempty"`
-	Contact           []ContactDetail                  `json:"contact,omitempty"`
-	Description       *string                          `json:"description,omitempty"`
-	UseContext        []UsageContext                   `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                `json:"jurisdiction,omitempty"`
-	Purpose           *string                          `json:"purpose,omitempty"`
-	Copyright         *string                          `json:"copyright,omitempty"`
-	Keyword           []Coding                         `json:"keyword,omitempty"`
-	FhirVersion       *FHIRVersion                     `json:"fhirVersion,omitempty"`
-	Mapping           []StructureDefinitionMapping     `json:"mapping,omitempty"`
-	Kind              StructureDefinitionKind          `json:"kind"`
-	Abstract          bool                             `json:"abstract"`
-	Context           []StructureDefinitionContext     `json:"context,omitempty"`
-	ContextInvariant  []string                         `json:"contextInvariant,omitempty"`
-	Type              string                           `json:"type"`
-	BaseDefinition    *string                          `json:"baseDefinition,omitempty"`
-	Derivation        *TypeDerivationRule              `json:"derivation,omitempty"`
-	Snapshot          *StructureDefinitionSnapshot     `json:"snapshot,omitempty"`
-	Differential      *StructureDefinitionDifferential `json:"differential,omitempty"`
+	Id                *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                          `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                           `bson:"url" json:"url"`
+	Identifier        []Identifier                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                          `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                           `bson:"name" json:"name"`
+	Title             *string                          `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus                `bson:"status" json:"status"`
+	Experimental      *bool                            `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                          `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                          `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                          `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                   `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                          `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                          `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Keyword           []Coding                         `bson:"keyword,omitempty" json:"keyword,omitempty"`
+	FhirVersion       *FHIRVersion                     `bson:"fhirVersion,omitempty" json:"fhirVersion,omitempty"`
+	Mapping           []StructureDefinitionMapping     `bson:"mapping,omitempty" json:"mapping,omitempty"`
+	Kind              StructureDefinitionKind          `bson:"kind" json:"kind"`
+	Abstract          bool                             `bson:"abstract" json:"abstract"`
+	Context           []StructureDefinitionContext     `bson:"context,omitempty" json:"context,omitempty"`
+	ContextInvariant  []string                         `bson:"contextInvariant,omitempty" json:"contextInvariant,omitempty"`
+	Type              string                           `bson:"type" json:"type"`
+	BaseDefinition    *string                          `bson:"baseDefinition,omitempty" json:"baseDefinition,omitempty"`
+	Derivation        *TypeDerivationRule              `bson:"derivation,omitempty" json:"derivation,omitempty"`
+	Snapshot          *StructureDefinitionSnapshot     `bson:"snapshot,omitempty" json:"snapshot,omitempty"`
+	Differential      *StructureDefinitionDifferential `bson:"differential,omitempty" json:"differential,omitempty"`
 }
 type StructureDefinitionMapping struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Identity          string      `json:"identity"`
-	Uri               *string     `json:"uri,omitempty"`
-	Name              *string     `json:"name,omitempty"`
-	Comment           *string     `json:"comment,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identity          string      `bson:"identity" json:"identity"`
+	Uri               *string     `bson:"uri,omitempty" json:"uri,omitempty"`
+	Name              *string     `bson:"name,omitempty" json:"name,omitempty"`
+	Comment           *string     `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type StructureDefinitionContext struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Type              ExtensionContextType `json:"type"`
-	Expression        string               `json:"expression"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ExtensionContextType `bson:"type" json:"type"`
+	Expression        string               `bson:"expression" json:"expression"`
 }
 type StructureDefinitionSnapshot struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Element           []ElementDefinition `json:"element"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Element           []ElementDefinition `bson:"element" json:"element"`
 }
 type StructureDefinitionDifferential struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Element           []ElementDefinition `json:"element"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Element           []ElementDefinition `bson:"element" json:"element"`
 }
 type OtherStructureDefinition StructureDefinition
 

--- a/fhir-models-gen/fhir/usageContext.go
+++ b/fhir-models-gen/fhir/usageContext.go
@@ -19,7 +19,7 @@ package fhir
 
 // UsageContext is documented here http://hl7.org/fhir/StructureDefinition/UsageContext
 type UsageContext struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Code      Coding      `json:"code"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Code      Coding      `bson:"code" json:"code"`
 }

--- a/fhir-models-gen/fhir/valueSet.go
+++ b/fhir-models-gen/fhir/valueSet.go
@@ -21,104 +21,104 @@ import "encoding/json"
 
 // ValueSet is documented here http://hl7.org/fhir/StructureDefinition/ValueSet
 type ValueSet struct {
-	Id                *string            `json:"id,omitempty"`
-	Meta              *Meta              `json:"meta,omitempty"`
-	ImplicitRules     *string            `json:"implicitRules,omitempty"`
-	Language          *string            `json:"language,omitempty"`
-	Text              *Narrative         `json:"text,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Url               *string            `json:"url,omitempty"`
-	Identifier        []Identifier       `json:"identifier,omitempty"`
-	Version           *string            `json:"version,omitempty"`
-	Name              *string            `json:"name,omitempty"`
-	Title             *string            `json:"title,omitempty"`
-	Status            PublicationStatus  `json:"status"`
-	Experimental      *bool              `json:"experimental,omitempty"`
-	Date              *string            `json:"date,omitempty"`
-	Publisher         *string            `json:"publisher,omitempty"`
-	Contact           []ContactDetail    `json:"contact,omitempty"`
-	Description       *string            `json:"description,omitempty"`
-	UseContext        []UsageContext     `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept  `json:"jurisdiction,omitempty"`
-	Immutable         *bool              `json:"immutable,omitempty"`
-	Purpose           *string            `json:"purpose,omitempty"`
-	Copyright         *string            `json:"copyright,omitempty"`
-	Compose           *ValueSetCompose   `json:"compose,omitempty"`
-	Expansion         *ValueSetExpansion `json:"expansion,omitempty"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string            `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string            `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string            `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string            `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus  `bson:"status" json:"status"`
+	Experimental      *bool              `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string            `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string            `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string            `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext     `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept  `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Immutable         *bool              `bson:"immutable,omitempty" json:"immutable,omitempty"`
+	Purpose           *string            `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string            `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Compose           *ValueSetCompose   `bson:"compose,omitempty" json:"compose,omitempty"`
+	Expansion         *ValueSetExpansion `bson:"expansion,omitempty" json:"expansion,omitempty"`
 }
 type ValueSetCompose struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	LockedDate        *string                  `json:"lockedDate,omitempty"`
-	Inactive          *bool                    `json:"inactive,omitempty"`
-	Include           []ValueSetComposeInclude `json:"include"`
-	Exclude           []ValueSetComposeInclude `json:"exclude,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	LockedDate        *string                  `bson:"lockedDate,omitempty" json:"lockedDate,omitempty"`
+	Inactive          *bool                    `bson:"inactive,omitempty" json:"inactive,omitempty"`
+	Include           []ValueSetComposeInclude `bson:"include" json:"include"`
+	Exclude           []ValueSetComposeInclude `bson:"exclude,omitempty" json:"exclude,omitempty"`
 }
 type ValueSetComposeInclude struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	System            *string                         `json:"system,omitempty"`
-	Version           *string                         `json:"version,omitempty"`
-	Concept           []ValueSetComposeIncludeConcept `json:"concept,omitempty"`
-	Filter            []ValueSetComposeIncludeFilter  `json:"filter,omitempty"`
-	ValueSet          []string                        `json:"valueSet,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	System            *string                         `bson:"system,omitempty" json:"system,omitempty"`
+	Version           *string                         `bson:"version,omitempty" json:"version,omitempty"`
+	Concept           []ValueSetComposeIncludeConcept `bson:"concept,omitempty" json:"concept,omitempty"`
+	Filter            []ValueSetComposeIncludeFilter  `bson:"filter,omitempty" json:"filter,omitempty"`
+	ValueSet          []string                        `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
 }
 type ValueSetComposeIncludeConcept struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Code              string                                     `json:"code"`
-	Display           *string                                    `json:"display,omitempty"`
-	Designation       []ValueSetComposeIncludeConceptDesignation `json:"designation,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string                                     `bson:"code" json:"code"`
+	Display           *string                                    `bson:"display,omitempty" json:"display,omitempty"`
+	Designation       []ValueSetComposeIncludeConceptDesignation `bson:"designation,omitempty" json:"designation,omitempty"`
 }
 type ValueSetComposeIncludeConceptDesignation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Language          *string     `json:"language,omitempty"`
-	Use               *Coding     `json:"use,omitempty"`
-	Value             string      `json:"value"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Language          *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Use               *Coding     `bson:"use,omitempty" json:"use,omitempty"`
+	Value             string      `bson:"value" json:"value"`
 }
 type ValueSetComposeIncludeFilter struct {
-	Id                *string        `json:"id,omitempty"`
-	Extension         []Extension    `json:"extension,omitempty"`
-	ModifierExtension []Extension    `json:"modifierExtension,omitempty"`
-	Property          string         `json:"property"`
-	Op                FilterOperator `json:"op"`
-	Value             string         `json:"value"`
+	Id                *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Property          string         `bson:"property" json:"property"`
+	Op                FilterOperator `bson:"op" json:"op"`
+	Value             string         `bson:"value" json:"value"`
 }
 type ValueSetExpansion struct {
-	Id                *string                      `json:"id,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier        *string                      `json:"identifier,omitempty"`
-	Timestamp         string                       `json:"timestamp"`
-	Total             *int                         `json:"total,omitempty"`
-	Offset            *int                         `json:"offset,omitempty"`
-	Parameter         []ValueSetExpansionParameter `json:"parameter,omitempty"`
-	Contains          []ValueSetExpansionContains  `json:"contains,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *string                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Timestamp         string                       `bson:"timestamp" json:"timestamp"`
+	Total             *int                         `bson:"total,omitempty" json:"total,omitempty"`
+	Offset            *int                         `bson:"offset,omitempty" json:"offset,omitempty"`
+	Parameter         []ValueSetExpansionParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	Contains          []ValueSetExpansionContains  `bson:"contains,omitempty" json:"contains,omitempty"`
 }
 type ValueSetExpansionParameter struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
 }
 type ValueSetExpansionContains struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	System            *string                                    `json:"system,omitempty"`
-	Abstract          *bool                                      `json:"abstract,omitempty"`
-	Inactive          *bool                                      `json:"inactive,omitempty"`
-	Version           *string                                    `json:"version,omitempty"`
-	Code              *string                                    `json:"code,omitempty"`
-	Display           *string                                    `json:"display,omitempty"`
-	Designation       []ValueSetComposeIncludeConceptDesignation `json:"designation,omitempty"`
-	Contains          []ValueSetExpansionContains                `json:"contains,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	System            *string                                    `bson:"system,omitempty" json:"system,omitempty"`
+	Abstract          *bool                                      `bson:"abstract,omitempty" json:"abstract,omitempty"`
+	Inactive          *bool                                      `bson:"inactive,omitempty" json:"inactive,omitempty"`
+	Version           *string                                    `bson:"version,omitempty" json:"version,omitempty"`
+	Code              *string                                    `bson:"code,omitempty" json:"code,omitempty"`
+	Display           *string                                    `bson:"display,omitempty" json:"display,omitempty"`
+	Designation       []ValueSetComposeIncludeConceptDesignation `bson:"designation,omitempty" json:"designation,omitempty"`
+	Contains          []ValueSetExpansionContains                `bson:"contains,omitempty" json:"contains,omitempty"`
 }
 type OtherValueSet ValueSet
 

--- a/fhir-models-gen/go.mod
+++ b/fhir-models-gen/go.mod
@@ -1,8 +1,9 @@
-module github.com/samply/golang-fhir-models/fhir-models-gen
+module fhir-models-gen
 
 go 1.13
 
 require (
 	github.com/dave/jennifer v1.4.0
+	github.com/samply/golang-fhir-models/fhir-models-gen v0.0.0-20191203123544-75dc627aca47
 	github.com/spf13/cobra v0.0.5
 )

--- a/fhir-models-gen/go.mod
+++ b/fhir-models-gen/go.mod
@@ -4,6 +4,5 @@ go 1.13
 
 require (
 	github.com/dave/jennifer v1.4.0
-	github.com/samply/golang-fhir-models/fhir-models-gen v0.0.0-20191203123544-75dc627aca47
 	github.com/spf13/cobra v0.0.5
 )

--- a/fhir-models-gen/go.mod
+++ b/fhir-models-gen/go.mod
@@ -1,4 +1,4 @@
-module github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen/fhir
+module github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen
 
 go 1.13
 

--- a/fhir-models-gen/go.mod
+++ b/fhir-models-gen/go.mod
@@ -1,4 +1,4 @@
-module fhir-models-gen
+module github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen/fhir
 
 go 1.13
 

--- a/fhir-models-gen/go.mod
+++ b/fhir-models-gen/go.mod
@@ -1,4 +1,4 @@
-module github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen
+module github.com/samply/golang-fhir-models/fhir-models-gen
 
 go 1.13
 

--- a/fhir-models-gen/go.sum
+++ b/fhir-models-gen/go.sum
@@ -1,4 +1,5 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Universal-Health-Chain/golang-fhir-models v0.1.2 h1:4uJpm9tq9zCj6ydFpb+6JpG7hJ0AhSix7QxW5eairBM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/fhir-models-gen/go.sum
+++ b/fhir-models-gen/go.sum
@@ -9,7 +9,6 @@ github.com/dave/jennifer v1.4.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhr
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -17,9 +16,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/samply/golang-fhir-models v0.1.0 h1:CsJxjvM2rtxsW3cd1oLOpZub3lkcC8urDaOmsDLmI9s=
-github.com/samply/golang-fhir-models/fhir-models-gen v0.0.0-20191203123544-75dc627aca47 h1:m3PvJikerL2icedl/U3mPyp2eNH/GL1CNQgzut17rzg=
-github.com/samply/golang-fhir-models/fhir-models-gen v0.0.0-20191203123544-75dc627aca47/go.mod h1:KHq1WO+77r9c6SwIFgHGPrf3/4bC9vcXrEih/wjYkTY=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=

--- a/fhir-models-gen/go.sum
+++ b/fhir-models-gen/go.sum
@@ -17,6 +17,9 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/samply/golang-fhir-models v0.1.0 h1:CsJxjvM2rtxsW3cd1oLOpZub3lkcC8urDaOmsDLmI9s=
+github.com/samply/golang-fhir-models/fhir-models-gen v0.0.0-20191203123544-75dc627aca47 h1:m3PvJikerL2icedl/U3mPyp2eNH/GL1CNQgzut17rzg=
+github.com/samply/golang-fhir-models/fhir-models-gen v0.0.0-20191203123544-75dc627aca47/go.mod h1:KHq1WO+77r9c6SwIFgHGPrf3/4bC9vcXrEih/wjYkTY=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=

--- a/fhir-models-gen/main.go
+++ b/fhir-models-gen/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "github.com/Universal-Health-Chain/golang-fhir-models/cmd"
+import "github.com/Universal-Health-Chain/golang-fhir-models/fhir-models-gen/cmd"
 
 func main() {
 	cmd.Execute()

--- a/fhir-models-gen/main.go
+++ b/fhir-models-gen/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "fhir-models-gen/cmd"
+import "github.com/Universal-Health-Chain/golang-fhir-models/cmd"
 
 func main() {
 	cmd.Execute()

--- a/fhir-models-gen/main.go
+++ b/fhir-models-gen/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "github.com/samply/golang-fhir-models/fhir-models-gen/cmd"
+import "fhir-models-gen/cmd"
 
 func main() {
 	cmd.Execute()

--- a/fhir-models/fhir/account.go
+++ b/fhir-models/fhir/account.go
@@ -21,39 +21,39 @@ import "encoding/json"
 
 // Account is documented here http://hl7.org/fhir/StructureDefinition/Account
 type Account struct {
-	Id                *string            `json:"id,omitempty"`
-	Meta              *Meta              `json:"meta,omitempty"`
-	ImplicitRules     *string            `json:"implicitRules,omitempty"`
-	Language          *string            `json:"language,omitempty"`
-	Text              *Narrative         `json:"text,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier       `json:"identifier,omitempty"`
-	Status            AccountStatus      `json:"status"`
-	Type              *CodeableConcept   `json:"type,omitempty"`
-	Name              *string            `json:"name,omitempty"`
-	Subject           []Reference        `json:"subject,omitempty"`
-	ServicePeriod     *Period            `json:"servicePeriod,omitempty"`
-	Coverage          []AccountCoverage  `json:"coverage,omitempty"`
-	Owner             *Reference         `json:"owner,omitempty"`
-	Description       *string            `json:"description,omitempty"`
-	Guarantor         []AccountGuarantor `json:"guarantor,omitempty"`
-	PartOf            *Reference         `json:"partOf,omitempty"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            AccountStatus      `bson:"status" json:"status"`
+	Type              *CodeableConcept   `bson:"type,omitempty" json:"type,omitempty"`
+	Name              *string            `bson:"name,omitempty" json:"name,omitempty"`
+	Subject           []Reference        `bson:"subject,omitempty" json:"subject,omitempty"`
+	ServicePeriod     *Period            `bson:"servicePeriod,omitempty" json:"servicePeriod,omitempty"`
+	Coverage          []AccountCoverage  `bson:"coverage,omitempty" json:"coverage,omitempty"`
+	Owner             *Reference         `bson:"owner,omitempty" json:"owner,omitempty"`
+	Description       *string            `bson:"description,omitempty" json:"description,omitempty"`
+	Guarantor         []AccountGuarantor `bson:"guarantor,omitempty" json:"guarantor,omitempty"`
+	PartOf            *Reference         `bson:"partOf,omitempty" json:"partOf,omitempty"`
 }
 type AccountCoverage struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Coverage          Reference   `json:"coverage"`
-	Priority          *int        `json:"priority,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Coverage          Reference   `bson:"coverage" json:"coverage"`
+	Priority          *int        `bson:"priority,omitempty" json:"priority,omitempty"`
 }
 type AccountGuarantor struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Party             Reference   `json:"party"`
-	OnHold            *bool       `json:"onHold,omitempty"`
-	Period            *Period     `json:"period,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Party             Reference   `bson:"party" json:"party"`
+	OnHold            *bool       `bson:"onHold,omitempty" json:"onHold,omitempty"`
+	Period            *Period     `bson:"period,omitempty" json:"period,omitempty"`
 }
 type OtherAccount Account
 

--- a/fhir-models/fhir/activityDefinition.go
+++ b/fhir-models/fhir/activityDefinition.go
@@ -21,70 +21,70 @@ import "encoding/json"
 
 // ActivityDefinition is documented here http://hl7.org/fhir/StructureDefinition/ActivityDefinition
 type ActivityDefinition struct {
-	Id                           *string                          `json:"id,omitempty"`
-	Meta                         *Meta                            `json:"meta,omitempty"`
-	ImplicitRules                *string                          `json:"implicitRules,omitempty"`
-	Language                     *string                          `json:"language,omitempty"`
-	Text                         *Narrative                       `json:"text,omitempty"`
-	Extension                    []Extension                      `json:"extension,omitempty"`
-	ModifierExtension            []Extension                      `json:"modifierExtension,omitempty"`
-	Url                          *string                          `json:"url,omitempty"`
-	Identifier                   []Identifier                     `json:"identifier,omitempty"`
-	Version                      *string                          `json:"version,omitempty"`
-	Name                         *string                          `json:"name,omitempty"`
-	Title                        *string                          `json:"title,omitempty"`
-	Subtitle                     *string                          `json:"subtitle,omitempty"`
-	Status                       PublicationStatus                `json:"status"`
-	Experimental                 *bool                            `json:"experimental,omitempty"`
-	Date                         *string                          `json:"date,omitempty"`
-	Publisher                    *string                          `json:"publisher,omitempty"`
-	Contact                      []ContactDetail                  `json:"contact,omitempty"`
-	Description                  *string                          `json:"description,omitempty"`
-	UseContext                   []UsageContext                   `json:"useContext,omitempty"`
-	Jurisdiction                 []CodeableConcept                `json:"jurisdiction,omitempty"`
-	Purpose                      *string                          `json:"purpose,omitempty"`
-	Usage                        *string                          `json:"usage,omitempty"`
-	Copyright                    *string                          `json:"copyright,omitempty"`
-	ApprovalDate                 *string                          `json:"approvalDate,omitempty"`
-	LastReviewDate               *string                          `json:"lastReviewDate,omitempty"`
-	EffectivePeriod              *Period                          `json:"effectivePeriod,omitempty"`
-	Topic                        []CodeableConcept                `json:"topic,omitempty"`
-	Author                       []ContactDetail                  `json:"author,omitempty"`
-	Editor                       []ContactDetail                  `json:"editor,omitempty"`
-	Reviewer                     []ContactDetail                  `json:"reviewer,omitempty"`
-	Endorser                     []ContactDetail                  `json:"endorser,omitempty"`
-	RelatedArtifact              []RelatedArtifact                `json:"relatedArtifact,omitempty"`
-	Library                      []string                         `json:"library,omitempty"`
-	Kind                         *RequestResourceType             `json:"kind,omitempty"`
-	Profile                      *string                          `json:"profile,omitempty"`
-	Code                         *CodeableConcept                 `json:"code,omitempty"`
-	Intent                       *RequestIntent                   `json:"intent,omitempty"`
-	Priority                     *RequestPriority                 `json:"priority,omitempty"`
-	DoNotPerform                 *bool                            `json:"doNotPerform,omitempty"`
-	Location                     *Reference                       `json:"location,omitempty"`
-	Participant                  []ActivityDefinitionParticipant  `json:"participant,omitempty"`
-	Quantity                     *Quantity                        `json:"quantity,omitempty"`
-	Dosage                       []Dosage                         `json:"dosage,omitempty"`
-	BodySite                     []CodeableConcept                `json:"bodySite,omitempty"`
-	SpecimenRequirement          []Reference                      `json:"specimenRequirement,omitempty"`
-	ObservationRequirement       []Reference                      `json:"observationRequirement,omitempty"`
-	ObservationResultRequirement []Reference                      `json:"observationResultRequirement,omitempty"`
-	Transform                    *string                          `json:"transform,omitempty"`
-	DynamicValue                 []ActivityDefinitionDynamicValue `json:"dynamicValue,omitempty"`
+	Id                           *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                         *Meta                            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules                *string                          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                     *string                          `bson:"language,omitempty" json:"language,omitempty"`
+	Text                         *Narrative                       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                    []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension            []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url                          *string                          `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier                   []Identifier                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version                      *string                          `bson:"version,omitempty" json:"version,omitempty"`
+	Name                         *string                          `bson:"name,omitempty" json:"name,omitempty"`
+	Title                        *string                          `bson:"title,omitempty" json:"title,omitempty"`
+	Subtitle                     *string                          `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status                       PublicationStatus                `bson:"status" json:"status"`
+	Experimental                 *bool                            `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date                         *string                          `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher                    *string                          `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact                      []ContactDetail                  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description                  *string                          `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext                   []UsageContext                   `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction                 []CodeableConcept                `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose                      *string                          `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage                        *string                          `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright                    *string                          `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate                 *string                          `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate               *string                          `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod              *Period                          `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic                        []CodeableConcept                `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author                       []ContactDetail                  `bson:"author,omitempty" json:"author,omitempty"`
+	Editor                       []ContactDetail                  `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer                     []ContactDetail                  `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser                     []ContactDetail                  `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact              []RelatedArtifact                `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Library                      []string                         `bson:"library,omitempty" json:"library,omitempty"`
+	Kind                         *RequestResourceType             `bson:"kind,omitempty" json:"kind,omitempty"`
+	Profile                      *string                          `bson:"profile,omitempty" json:"profile,omitempty"`
+	Code                         *CodeableConcept                 `bson:"code,omitempty" json:"code,omitempty"`
+	Intent                       *RequestIntent                   `bson:"intent,omitempty" json:"intent,omitempty"`
+	Priority                     *RequestPriority                 `bson:"priority,omitempty" json:"priority,omitempty"`
+	DoNotPerform                 *bool                            `bson:"doNotPerform,omitempty" json:"doNotPerform,omitempty"`
+	Location                     *Reference                       `bson:"location,omitempty" json:"location,omitempty"`
+	Participant                  []ActivityDefinitionParticipant  `bson:"participant,omitempty" json:"participant,omitempty"`
+	Quantity                     *Quantity                        `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Dosage                       []Dosage                         `bson:"dosage,omitempty" json:"dosage,omitempty"`
+	BodySite                     []CodeableConcept                `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	SpecimenRequirement          []Reference                      `bson:"specimenRequirement,omitempty" json:"specimenRequirement,omitempty"`
+	ObservationRequirement       []Reference                      `bson:"observationRequirement,omitempty" json:"observationRequirement,omitempty"`
+	ObservationResultRequirement []Reference                      `bson:"observationResultRequirement,omitempty" json:"observationResultRequirement,omitempty"`
+	Transform                    *string                          `bson:"transform,omitempty" json:"transform,omitempty"`
+	DynamicValue                 []ActivityDefinitionDynamicValue `bson:"dynamicValue,omitempty" json:"dynamicValue,omitempty"`
 }
 type ActivityDefinitionParticipant struct {
-	Id                *string               `json:"id,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Type              ActionParticipantType `json:"type"`
-	Role              *CodeableConcept      `json:"role,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ActionParticipantType `bson:"type" json:"type"`
+	Role              *CodeableConcept      `bson:"role,omitempty" json:"role,omitempty"`
 }
 type ActivityDefinitionDynamicValue struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Path              string      `json:"path"`
-	Expression        Expression  `json:"expression"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Path              string      `bson:"path" json:"path"`
+	Expression        Expression  `bson:"expression" json:"expression"`
 }
 type OtherActivityDefinition ActivityDefinition
 

--- a/fhir-models/fhir/address.go
+++ b/fhir-models/fhir/address.go
@@ -19,16 +19,16 @@ package fhir
 
 // Address is documented here http://hl7.org/fhir/StructureDefinition/Address
 type Address struct {
-	Id         *string      `json:"id,omitempty"`
-	Extension  []Extension  `json:"extension,omitempty"`
-	Use        *AddressUse  `json:"use,omitempty"`
-	Type       *AddressType `json:"type,omitempty"`
-	Text       *string      `json:"text,omitempty"`
-	Line       []string     `json:"line,omitempty"`
-	City       *string      `json:"city,omitempty"`
-	District   *string      `json:"district,omitempty"`
-	State      *string      `json:"state,omitempty"`
-	PostalCode *string      `json:"postalCode,omitempty"`
-	Country    *string      `json:"country,omitempty"`
-	Period     *Period      `json:"period,omitempty"`
+	Id         *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension  []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	Use        *AddressUse  `bson:"use,omitempty" json:"use,omitempty"`
+	Type       *AddressType `bson:"type,omitempty" json:"type,omitempty"`
+	Text       *string      `bson:"text,omitempty" json:"text,omitempty"`
+	Line       []string     `bson:"line,omitempty" json:"line,omitempty"`
+	City       *string      `bson:"city,omitempty" json:"city,omitempty"`
+	District   *string      `bson:"district,omitempty" json:"district,omitempty"`
+	State      *string      `bson:"state,omitempty" json:"state,omitempty"`
+	PostalCode *string      `bson:"postalCode,omitempty" json:"postalCode,omitempty"`
+	Country    *string      `bson:"country,omitempty" json:"country,omitempty"`
+	Period     *Period      `bson:"period,omitempty" json:"period,omitempty"`
 }

--- a/fhir-models/fhir/adverseEvent.go
+++ b/fhir-models/fhir/adverseEvent.go
@@ -21,49 +21,49 @@ import "encoding/json"
 
 // AdverseEvent is documented here http://hl7.org/fhir/StructureDefinition/AdverseEvent
 type AdverseEvent struct {
-	Id                    *string                     `json:"id,omitempty"`
-	Meta                  *Meta                       `json:"meta,omitempty"`
-	ImplicitRules         *string                     `json:"implicitRules,omitempty"`
-	Language              *string                     `json:"language,omitempty"`
-	Text                  *Narrative                  `json:"text,omitempty"`
-	Extension             []Extension                 `json:"extension,omitempty"`
-	ModifierExtension     []Extension                 `json:"modifierExtension,omitempty"`
-	Identifier            *Identifier                 `json:"identifier,omitempty"`
-	Actuality             AdverseEventActuality       `json:"actuality"`
-	Category              []CodeableConcept           `json:"category,omitempty"`
-	Event                 *CodeableConcept            `json:"event,omitempty"`
-	Subject               Reference                   `json:"subject"`
-	Encounter             *Reference                  `json:"encounter,omitempty"`
-	Date                  *string                     `json:"date,omitempty"`
-	Detected              *string                     `json:"detected,omitempty"`
-	RecordedDate          *string                     `json:"recordedDate,omitempty"`
-	ResultingCondition    []Reference                 `json:"resultingCondition,omitempty"`
-	Location              *Reference                  `json:"location,omitempty"`
-	Seriousness           *CodeableConcept            `json:"seriousness,omitempty"`
-	Severity              *CodeableConcept            `json:"severity,omitempty"`
-	Outcome               *CodeableConcept            `json:"outcome,omitempty"`
-	Recorder              *Reference                  `json:"recorder,omitempty"`
-	Contributor           []Reference                 `json:"contributor,omitempty"`
-	SuspectEntity         []AdverseEventSuspectEntity `json:"suspectEntity,omitempty"`
-	SubjectMedicalHistory []Reference                 `json:"subjectMedicalHistory,omitempty"`
-	ReferenceDocument     []Reference                 `json:"referenceDocument,omitempty"`
-	Study                 []Reference                 `json:"study,omitempty"`
+	Id                    *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            *Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Actuality             AdverseEventActuality       `bson:"actuality" json:"actuality"`
+	Category              []CodeableConcept           `bson:"category,omitempty" json:"category,omitempty"`
+	Event                 *CodeableConcept            `bson:"event,omitempty" json:"event,omitempty"`
+	Subject               Reference                   `bson:"subject" json:"subject"`
+	Encounter             *Reference                  `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Date                  *string                     `bson:"date,omitempty" json:"date,omitempty"`
+	Detected              *string                     `bson:"detected,omitempty" json:"detected,omitempty"`
+	RecordedDate          *string                     `bson:"recordedDate,omitempty" json:"recordedDate,omitempty"`
+	ResultingCondition    []Reference                 `bson:"resultingCondition,omitempty" json:"resultingCondition,omitempty"`
+	Location              *Reference                  `bson:"location,omitempty" json:"location,omitempty"`
+	Seriousness           *CodeableConcept            `bson:"seriousness,omitempty" json:"seriousness,omitempty"`
+	Severity              *CodeableConcept            `bson:"severity,omitempty" json:"severity,omitempty"`
+	Outcome               *CodeableConcept            `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	Recorder              *Reference                  `bson:"recorder,omitempty" json:"recorder,omitempty"`
+	Contributor           []Reference                 `bson:"contributor,omitempty" json:"contributor,omitempty"`
+	SuspectEntity         []AdverseEventSuspectEntity `bson:"suspectEntity,omitempty" json:"suspectEntity,omitempty"`
+	SubjectMedicalHistory []Reference                 `bson:"subjectMedicalHistory,omitempty" json:"subjectMedicalHistory,omitempty"`
+	ReferenceDocument     []Reference                 `bson:"referenceDocument,omitempty" json:"referenceDocument,omitempty"`
+	Study                 []Reference                 `bson:"study,omitempty" json:"study,omitempty"`
 }
 type AdverseEventSuspectEntity struct {
-	Id                *string                              `json:"id,omitempty"`
-	Extension         []Extension                          `json:"extension,omitempty"`
-	ModifierExtension []Extension                          `json:"modifierExtension,omitempty"`
-	Instance          Reference                            `json:"instance"`
-	Causality         []AdverseEventSuspectEntityCausality `json:"causality,omitempty"`
+	Id                *string                              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Instance          Reference                            `bson:"instance" json:"instance"`
+	Causality         []AdverseEventSuspectEntityCausality `bson:"causality,omitempty" json:"causality,omitempty"`
 }
 type AdverseEventSuspectEntityCausality struct {
-	Id                 *string          `json:"id,omitempty"`
-	Extension          []Extension      `json:"extension,omitempty"`
-	ModifierExtension  []Extension      `json:"modifierExtension,omitempty"`
-	Assessment         *CodeableConcept `json:"assessment,omitempty"`
-	ProductRelatedness *string          `json:"productRelatedness,omitempty"`
-	Author             *Reference       `json:"author,omitempty"`
-	Method             *CodeableConcept `json:"method,omitempty"`
+	Id                 *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Assessment         *CodeableConcept `bson:"assessment,omitempty" json:"assessment,omitempty"`
+	ProductRelatedness *string          `bson:"productRelatedness,omitempty" json:"productRelatedness,omitempty"`
+	Author             *Reference       `bson:"author,omitempty" json:"author,omitempty"`
+	Method             *CodeableConcept `bson:"method,omitempty" json:"method,omitempty"`
 }
 type OtherAdverseEvent AdverseEvent
 

--- a/fhir-models/fhir/allergyIntolerance.go
+++ b/fhir-models/fhir/allergyIntolerance.go
@@ -21,40 +21,40 @@ import "encoding/json"
 
 // AllergyIntolerance is documented here http://hl7.org/fhir/StructureDefinition/AllergyIntolerance
 type AllergyIntolerance struct {
-	Id                 *string                        `json:"id,omitempty"`
-	Meta               *Meta                          `json:"meta,omitempty"`
-	ImplicitRules      *string                        `json:"implicitRules,omitempty"`
-	Language           *string                        `json:"language,omitempty"`
-	Text               *Narrative                     `json:"text,omitempty"`
-	Extension          []Extension                    `json:"extension,omitempty"`
-	ModifierExtension  []Extension                    `json:"modifierExtension,omitempty"`
-	Identifier         []Identifier                   `json:"identifier,omitempty"`
-	ClinicalStatus     *CodeableConcept               `json:"clinicalStatus,omitempty"`
-	VerificationStatus *CodeableConcept               `json:"verificationStatus,omitempty"`
-	Type               *AllergyIntoleranceType        `json:"type,omitempty"`
-	Category           []AllergyIntoleranceCategory   `json:"category,omitempty"`
-	Criticality        *AllergyIntoleranceCriticality `json:"criticality,omitempty"`
-	Code               *CodeableConcept               `json:"code,omitempty"`
-	Patient            Reference                      `json:"patient"`
-	Encounter          *Reference                     `json:"encounter,omitempty"`
-	RecordedDate       *string                        `json:"recordedDate,omitempty"`
-	Recorder           *Reference                     `json:"recorder,omitempty"`
-	Asserter           *Reference                     `json:"asserter,omitempty"`
-	LastOccurrence     *string                        `json:"lastOccurrence,omitempty"`
-	Note               []Annotation                   `json:"note,omitempty"`
-	Reaction           []AllergyIntoleranceReaction   `json:"reaction,omitempty"`
+	Id                 *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	ClinicalStatus     *CodeableConcept               `bson:"clinicalStatus,omitempty" json:"clinicalStatus,omitempty"`
+	VerificationStatus *CodeableConcept               `bson:"verificationStatus,omitempty" json:"verificationStatus,omitempty"`
+	Type               *AllergyIntoleranceType        `bson:"type,omitempty" json:"type,omitempty"`
+	Category           []AllergyIntoleranceCategory   `bson:"category,omitempty" json:"category,omitempty"`
+	Criticality        *AllergyIntoleranceCriticality `bson:"criticality,omitempty" json:"criticality,omitempty"`
+	Code               *CodeableConcept               `bson:"code,omitempty" json:"code,omitempty"`
+	Patient            Reference                      `bson:"patient" json:"patient"`
+	Encounter          *Reference                     `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	RecordedDate       *string                        `bson:"recordedDate,omitempty" json:"recordedDate,omitempty"`
+	Recorder           *Reference                     `bson:"recorder,omitempty" json:"recorder,omitempty"`
+	Asserter           *Reference                     `bson:"asserter,omitempty" json:"asserter,omitempty"`
+	LastOccurrence     *string                        `bson:"lastOccurrence,omitempty" json:"lastOccurrence,omitempty"`
+	Note               []Annotation                   `bson:"note,omitempty" json:"note,omitempty"`
+	Reaction           []AllergyIntoleranceReaction   `bson:"reaction,omitempty" json:"reaction,omitempty"`
 }
 type AllergyIntoleranceReaction struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Substance         *CodeableConcept            `json:"substance,omitempty"`
-	Manifestation     []CodeableConcept           `json:"manifestation"`
-	Description       *string                     `json:"description,omitempty"`
-	Onset             *string                     `json:"onset,omitempty"`
-	Severity          *AllergyIntoleranceSeverity `json:"severity,omitempty"`
-	ExposureRoute     *CodeableConcept            `json:"exposureRoute,omitempty"`
-	Note              []Annotation                `json:"note,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Substance         *CodeableConcept            `bson:"substance,omitempty" json:"substance,omitempty"`
+	Manifestation     []CodeableConcept           `bson:"manifestation" json:"manifestation"`
+	Description       *string                     `bson:"description,omitempty" json:"description,omitempty"`
+	Onset             *string                     `bson:"onset,omitempty" json:"onset,omitempty"`
+	Severity          *AllergyIntoleranceSeverity `bson:"severity,omitempty" json:"severity,omitempty"`
+	ExposureRoute     *CodeableConcept            `bson:"exposureRoute,omitempty" json:"exposureRoute,omitempty"`
+	Note              []Annotation                `bson:"note,omitempty" json:"note,omitempty"`
 }
 type OtherAllergyIntolerance AllergyIntolerance
 

--- a/fhir-models/fhir/annotation.go
+++ b/fhir-models/fhir/annotation.go
@@ -19,8 +19,8 @@ package fhir
 
 // Annotation is documented here http://hl7.org/fhir/StructureDefinition/Annotation
 type Annotation struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Time      *string     `json:"time,omitempty"`
-	Text      string      `json:"text"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Time      *string     `bson:"time,omitempty" json:"time,omitempty"`
+	Text      string      `bson:"text" json:"text"`
 }

--- a/fhir-models/fhir/appointment.go
+++ b/fhir-models/fhir/appointment.go
@@ -21,45 +21,45 @@ import "encoding/json"
 
 // Appointment is documented here http://hl7.org/fhir/StructureDefinition/Appointment
 type Appointment struct {
-	Id                    *string                  `json:"id,omitempty"`
-	Meta                  *Meta                    `json:"meta,omitempty"`
-	ImplicitRules         *string                  `json:"implicitRules,omitempty"`
-	Language              *string                  `json:"language,omitempty"`
-	Text                  *Narrative               `json:"text,omitempty"`
-	Extension             []Extension              `json:"extension,omitempty"`
-	ModifierExtension     []Extension              `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier             `json:"identifier,omitempty"`
-	Status                AppointmentStatus        `json:"status"`
-	CancelationReason     *CodeableConcept         `json:"cancelationReason,omitempty"`
-	ServiceCategory       []CodeableConcept        `json:"serviceCategory,omitempty"`
-	ServiceType           []CodeableConcept        `json:"serviceType,omitempty"`
-	Specialty             []CodeableConcept        `json:"specialty,omitempty"`
-	AppointmentType       *CodeableConcept         `json:"appointmentType,omitempty"`
-	ReasonCode            []CodeableConcept        `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference              `json:"reasonReference,omitempty"`
-	Priority              *int                     `json:"priority,omitempty"`
-	Description           *string                  `json:"description,omitempty"`
-	SupportingInformation []Reference              `json:"supportingInformation,omitempty"`
-	Start                 *string                  `json:"start,omitempty"`
-	End                   *string                  `json:"end,omitempty"`
-	MinutesDuration       *int                     `json:"minutesDuration,omitempty"`
-	Slot                  []Reference              `json:"slot,omitempty"`
-	Created               *string                  `json:"created,omitempty"`
-	Comment               *string                  `json:"comment,omitempty"`
-	PatientInstruction    *string                  `json:"patientInstruction,omitempty"`
-	BasedOn               []Reference              `json:"basedOn,omitempty"`
-	Participant           []AppointmentParticipant `json:"participant"`
-	RequestedPeriod       []Period                 `json:"requestedPeriod,omitempty"`
+	Id                    *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status                AppointmentStatus        `bson:"status" json:"status"`
+	CancelationReason     *CodeableConcept         `bson:"cancelationReason,omitempty" json:"cancelationReason,omitempty"`
+	ServiceCategory       []CodeableConcept        `bson:"serviceCategory,omitempty" json:"serviceCategory,omitempty"`
+	ServiceType           []CodeableConcept        `bson:"serviceType,omitempty" json:"serviceType,omitempty"`
+	Specialty             []CodeableConcept        `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	AppointmentType       *CodeableConcept         `bson:"appointmentType,omitempty" json:"appointmentType,omitempty"`
+	ReasonCode            []CodeableConcept        `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference              `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Priority              *int                     `bson:"priority,omitempty" json:"priority,omitempty"`
+	Description           *string                  `bson:"description,omitempty" json:"description,omitempty"`
+	SupportingInformation []Reference              `bson:"supportingInformation,omitempty" json:"supportingInformation,omitempty"`
+	Start                 *string                  `bson:"start,omitempty" json:"start,omitempty"`
+	End                   *string                  `bson:"end,omitempty" json:"end,omitempty"`
+	MinutesDuration       *int                     `bson:"minutesDuration,omitempty" json:"minutesDuration,omitempty"`
+	Slot                  []Reference              `bson:"slot,omitempty" json:"slot,omitempty"`
+	Created               *string                  `bson:"created,omitempty" json:"created,omitempty"`
+	Comment               *string                  `bson:"comment,omitempty" json:"comment,omitempty"`
+	PatientInstruction    *string                  `bson:"patientInstruction,omitempty" json:"patientInstruction,omitempty"`
+	BasedOn               []Reference              `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Participant           []AppointmentParticipant `bson:"participant" json:"participant"`
+	RequestedPeriod       []Period                 `bson:"requestedPeriod,omitempty" json:"requestedPeriod,omitempty"`
 }
 type AppointmentParticipant struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Type              []CodeableConcept    `json:"type,omitempty"`
-	Actor             *Reference           `json:"actor,omitempty"`
-	Required          *ParticipantRequired `json:"required,omitempty"`
-	Status            ParticipationStatus  `json:"status"`
-	Period            *Period              `json:"period,omitempty"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              []CodeableConcept    `bson:"type,omitempty" json:"type,omitempty"`
+	Actor             *Reference           `bson:"actor,omitempty" json:"actor,omitempty"`
+	Required          *ParticipantRequired `bson:"required,omitempty" json:"required,omitempty"`
+	Status            ParticipationStatus  `bson:"status" json:"status"`
+	Period            *Period              `bson:"period,omitempty" json:"period,omitempty"`
 }
 type OtherAppointment Appointment
 

--- a/fhir-models/fhir/appointmentResponse.go
+++ b/fhir-models/fhir/appointmentResponse.go
@@ -21,21 +21,21 @@ import "encoding/json"
 
 // AppointmentResponse is documented here http://hl7.org/fhir/StructureDefinition/AppointmentResponse
 type AppointmentResponse struct {
-	Id                *string             `json:"id,omitempty"`
-	Meta              *Meta               `json:"meta,omitempty"`
-	ImplicitRules     *string             `json:"implicitRules,omitempty"`
-	Language          *string             `json:"language,omitempty"`
-	Text              *Narrative          `json:"text,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier        `json:"identifier,omitempty"`
-	Appointment       Reference           `json:"appointment"`
-	Start             *string             `json:"start,omitempty"`
-	End               *string             `json:"end,omitempty"`
-	ParticipantType   []CodeableConcept   `json:"participantType,omitempty"`
-	Actor             *Reference          `json:"actor,omitempty"`
-	ParticipantStatus ParticipationStatus `json:"participantStatus"`
-	Comment           *string             `json:"comment,omitempty"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Appointment       Reference           `bson:"appointment" json:"appointment"`
+	Start             *string             `bson:"start,omitempty" json:"start,omitempty"`
+	End               *string             `bson:"end,omitempty" json:"end,omitempty"`
+	ParticipantType   []CodeableConcept   `bson:"participantType,omitempty" json:"participantType,omitempty"`
+	Actor             *Reference          `bson:"actor,omitempty" json:"actor,omitempty"`
+	ParticipantStatus ParticipationStatus `bson:"participantStatus" json:"participantStatus"`
+	Comment           *string             `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type OtherAppointmentResponse AppointmentResponse
 

--- a/fhir-models/fhir/attachment.go
+++ b/fhir-models/fhir/attachment.go
@@ -19,14 +19,14 @@ package fhir
 
 // Attachment is documented here http://hl7.org/fhir/StructureDefinition/Attachment
 type Attachment struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	ContentType *string     `json:"contentType,omitempty"`
-	Language    *string     `json:"language,omitempty"`
-	Data        *string     `json:"data,omitempty"`
-	Url         *string     `json:"url,omitempty"`
-	Size        *int        `json:"size,omitempty"`
-	Hash        *string     `json:"hash,omitempty"`
-	Title       *string     `json:"title,omitempty"`
-	Creation    *string     `json:"creation,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ContentType *string     `bson:"contentType,omitempty" json:"contentType,omitempty"`
+	Language    *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Data        *string     `bson:"data,omitempty" json:"data,omitempty"`
+	Url         *string     `bson:"url,omitempty" json:"url,omitempty"`
+	Size        *int        `bson:"size,omitempty" json:"size,omitempty"`
+	Hash        *string     `bson:"hash,omitempty" json:"hash,omitempty"`
+	Title       *string     `bson:"title,omitempty" json:"title,omitempty"`
+	Creation    *string     `bson:"creation,omitempty" json:"creation,omitempty"`
 }

--- a/fhir-models/fhir/auditEvent.go
+++ b/fhir-models/fhir/auditEvent.go
@@ -21,75 +21,75 @@ import "encoding/json"
 
 // AuditEvent is documented here http://hl7.org/fhir/StructureDefinition/AuditEvent
 type AuditEvent struct {
-	Id                *string            `json:"id,omitempty"`
-	Meta              *Meta              `json:"meta,omitempty"`
-	ImplicitRules     *string            `json:"implicitRules,omitempty"`
-	Language          *string            `json:"language,omitempty"`
-	Text              *Narrative         `json:"text,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Type              Coding             `json:"type"`
-	Subtype           []Coding           `json:"subtype,omitempty"`
-	Action            *AuditEventAction  `json:"action,omitempty"`
-	Period            *Period            `json:"period,omitempty"`
-	Recorded          string             `json:"recorded"`
-	Outcome           *AuditEventOutcome `json:"outcome,omitempty"`
-	OutcomeDesc       *string            `json:"outcomeDesc,omitempty"`
-	PurposeOfEvent    []CodeableConcept  `json:"purposeOfEvent,omitempty"`
-	Agent             []AuditEventAgent  `json:"agent"`
-	Source            AuditEventSource   `json:"source"`
-	Entity            []AuditEventEntity `json:"entity,omitempty"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              Coding             `bson:"type" json:"type"`
+	Subtype           []Coding           `bson:"subtype,omitempty" json:"subtype,omitempty"`
+	Action            *AuditEventAction  `bson:"action,omitempty" json:"action,omitempty"`
+	Period            *Period            `bson:"period,omitempty" json:"period,omitempty"`
+	Recorded          string             `bson:"recorded" json:"recorded"`
+	Outcome           *AuditEventOutcome `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	OutcomeDesc       *string            `bson:"outcomeDesc,omitempty" json:"outcomeDesc,omitempty"`
+	PurposeOfEvent    []CodeableConcept  `bson:"purposeOfEvent,omitempty" json:"purposeOfEvent,omitempty"`
+	Agent             []AuditEventAgent  `bson:"agent" json:"agent"`
+	Source            AuditEventSource   `bson:"source" json:"source"`
+	Entity            []AuditEventEntity `bson:"entity,omitempty" json:"entity,omitempty"`
 }
 type AuditEventAgent struct {
-	Id                *string                 `json:"id,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept        `json:"type,omitempty"`
-	Role              []CodeableConcept       `json:"role,omitempty"`
-	Who               *Reference              `json:"who,omitempty"`
-	AltId             *string                 `json:"altId,omitempty"`
-	Name              *string                 `json:"name,omitempty"`
-	Requestor         bool                    `json:"requestor"`
-	Location          *Reference              `json:"location,omitempty"`
-	Policy            []string                `json:"policy,omitempty"`
-	Media             *Coding                 `json:"media,omitempty"`
-	Network           *AuditEventAgentNetwork `json:"network,omitempty"`
-	PurposeOfUse      []CodeableConcept       `json:"purposeOfUse,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept        `bson:"type,omitempty" json:"type,omitempty"`
+	Role              []CodeableConcept       `bson:"role,omitempty" json:"role,omitempty"`
+	Who               *Reference              `bson:"who,omitempty" json:"who,omitempty"`
+	AltId             *string                 `bson:"altId,omitempty" json:"altId,omitempty"`
+	Name              *string                 `bson:"name,omitempty" json:"name,omitempty"`
+	Requestor         bool                    `bson:"requestor" json:"requestor"`
+	Location          *Reference              `bson:"location,omitempty" json:"location,omitempty"`
+	Policy            []string                `bson:"policy,omitempty" json:"policy,omitempty"`
+	Media             *Coding                 `bson:"media,omitempty" json:"media,omitempty"`
+	Network           *AuditEventAgentNetwork `bson:"network,omitempty" json:"network,omitempty"`
+	PurposeOfUse      []CodeableConcept       `bson:"purposeOfUse,omitempty" json:"purposeOfUse,omitempty"`
 }
 type AuditEventAgentNetwork struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Address           *string                     `json:"address,omitempty"`
-	Type              *AuditEventAgentNetworkType `json:"type,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Address           *string                     `bson:"address,omitempty" json:"address,omitempty"`
+	Type              *AuditEventAgentNetworkType `bson:"type,omitempty" json:"type,omitempty"`
 }
 type AuditEventSource struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Site              *string     `json:"site,omitempty"`
-	Observer          Reference   `json:"observer"`
-	Type              []Coding    `json:"type,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Site              *string     `bson:"site,omitempty" json:"site,omitempty"`
+	Observer          Reference   `bson:"observer" json:"observer"`
+	Type              []Coding    `bson:"type,omitempty" json:"type,omitempty"`
 }
 type AuditEventEntity struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	What              *Reference               `json:"what,omitempty"`
-	Type              *Coding                  `json:"type,omitempty"`
-	Role              *Coding                  `json:"role,omitempty"`
-	Lifecycle         *Coding                  `json:"lifecycle,omitempty"`
-	SecurityLabel     []Coding                 `json:"securityLabel,omitempty"`
-	Name              *string                  `json:"name,omitempty"`
-	Description       *string                  `json:"description,omitempty"`
-	Query             *string                  `json:"query,omitempty"`
-	Detail            []AuditEventEntityDetail `json:"detail,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	What              *Reference               `bson:"what,omitempty" json:"what,omitempty"`
+	Type              *Coding                  `bson:"type,omitempty" json:"type,omitempty"`
+	Role              *Coding                  `bson:"role,omitempty" json:"role,omitempty"`
+	Lifecycle         *Coding                  `bson:"lifecycle,omitempty" json:"lifecycle,omitempty"`
+	SecurityLabel     []Coding                 `bson:"securityLabel,omitempty" json:"securityLabel,omitempty"`
+	Name              *string                  `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string                  `bson:"description,omitempty" json:"description,omitempty"`
+	Query             *string                  `bson:"query,omitempty" json:"query,omitempty"`
+	Detail            []AuditEventEntityDetail `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type AuditEventEntityDetail struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Type              string      `json:"type"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              string      `bson:"type" json:"type"`
 }
 type OtherAuditEvent AuditEvent
 

--- a/fhir-models/fhir/basic.go
+++ b/fhir-models/fhir/basic.go
@@ -21,18 +21,18 @@ import "encoding/json"
 
 // Basic is documented here http://hl7.org/fhir/StructureDefinition/Basic
 type Basic struct {
-	Id                *string         `json:"id,omitempty"`
-	Meta              *Meta           `json:"meta,omitempty"`
-	ImplicitRules     *string         `json:"implicitRules,omitempty"`
-	Language          *string         `json:"language,omitempty"`
-	Text              *Narrative      `json:"text,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier    `json:"identifier,omitempty"`
-	Code              CodeableConcept `json:"code"`
-	Subject           *Reference      `json:"subject,omitempty"`
-	Created           *string         `json:"created,omitempty"`
-	Author            *Reference      `json:"author,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string         `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
+	Subject           *Reference      `bson:"subject,omitempty" json:"subject,omitempty"`
+	Created           *string         `bson:"created,omitempty" json:"created,omitempty"`
+	Author            *Reference      `bson:"author,omitempty" json:"author,omitempty"`
 }
 type OtherBasic Basic
 

--- a/fhir-models/fhir/binary.go
+++ b/fhir-models/fhir/binary.go
@@ -21,13 +21,13 @@ import "encoding/json"
 
 // Binary is documented here http://hl7.org/fhir/StructureDefinition/Binary
 type Binary struct {
-	Id              *string    `json:"id,omitempty"`
-	Meta            *Meta      `json:"meta,omitempty"`
-	ImplicitRules   *string    `json:"implicitRules,omitempty"`
-	Language        *string    `json:"language,omitempty"`
-	ContentType     string     `json:"contentType"`
-	SecurityContext *Reference `json:"securityContext,omitempty"`
-	Data            *string    `json:"data,omitempty"`
+	Id              *string    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta            *Meta      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules   *string    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language        *string    `bson:"language,omitempty" json:"language,omitempty"`
+	ContentType     string     `bson:"contentType" json:"contentType"`
+	SecurityContext *Reference `bson:"securityContext,omitempty" json:"securityContext,omitempty"`
+	Data            *string    `bson:"data,omitempty" json:"data,omitempty"`
 }
 type OtherBinary Binary
 

--- a/fhir-models/fhir/biologicallyDerivedProduct.go
+++ b/fhir-models/fhir/biologicallyDerivedProduct.go
@@ -21,54 +21,54 @@ import "encoding/json"
 
 // BiologicallyDerivedProduct is documented here http://hl7.org/fhir/StructureDefinition/BiologicallyDerivedProduct
 type BiologicallyDerivedProduct struct {
-	Id                *string                                 `json:"id,omitempty"`
-	Meta              *Meta                                   `json:"meta,omitempty"`
-	ImplicitRules     *string                                 `json:"implicitRules,omitempty"`
-	Language          *string                                 `json:"language,omitempty"`
-	Text              *Narrative                              `json:"text,omitempty"`
-	Extension         []Extension                             `json:"extension,omitempty"`
-	ModifierExtension []Extension                             `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                            `json:"identifier,omitempty"`
-	ProductCategory   *BiologicallyDerivedProductCategory     `json:"productCategory,omitempty"`
-	ProductCode       *CodeableConcept                        `json:"productCode,omitempty"`
-	Status            *BiologicallyDerivedProductStatus       `json:"status,omitempty"`
-	Request           []Reference                             `json:"request,omitempty"`
-	Quantity          *int                                    `json:"quantity,omitempty"`
-	Parent            []Reference                             `json:"parent,omitempty"`
-	Collection        *BiologicallyDerivedProductCollection   `json:"collection,omitempty"`
-	Processing        []BiologicallyDerivedProductProcessing  `json:"processing,omitempty"`
-	Manipulation      *BiologicallyDerivedProductManipulation `json:"manipulation,omitempty"`
-	Storage           []BiologicallyDerivedProductStorage     `json:"storage,omitempty"`
+	Id                *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                            `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	ProductCategory   *BiologicallyDerivedProductCategory     `bson:"productCategory,omitempty" json:"productCategory,omitempty"`
+	ProductCode       *CodeableConcept                        `bson:"productCode,omitempty" json:"productCode,omitempty"`
+	Status            *BiologicallyDerivedProductStatus       `bson:"status,omitempty" json:"status,omitempty"`
+	Request           []Reference                             `bson:"request,omitempty" json:"request,omitempty"`
+	Quantity          *int                                    `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Parent            []Reference                             `bson:"parent,omitempty" json:"parent,omitempty"`
+	Collection        *BiologicallyDerivedProductCollection   `bson:"collection,omitempty" json:"collection,omitempty"`
+	Processing        []BiologicallyDerivedProductProcessing  `bson:"processing,omitempty" json:"processing,omitempty"`
+	Manipulation      *BiologicallyDerivedProductManipulation `bson:"manipulation,omitempty" json:"manipulation,omitempty"`
+	Storage           []BiologicallyDerivedProductStorage     `bson:"storage,omitempty" json:"storage,omitempty"`
 }
 type BiologicallyDerivedProductCollection struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Collector         *Reference  `json:"collector,omitempty"`
-	Source            *Reference  `json:"source,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Collector         *Reference  `bson:"collector,omitempty" json:"collector,omitempty"`
+	Source            *Reference  `bson:"source,omitempty" json:"source,omitempty"`
 }
 type BiologicallyDerivedProductProcessing struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Description       *string          `json:"description,omitempty"`
-	Procedure         *CodeableConcept `json:"procedure,omitempty"`
-	Additive          *Reference       `json:"additive,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Procedure         *CodeableConcept `bson:"procedure,omitempty" json:"procedure,omitempty"`
+	Additive          *Reference       `bson:"additive,omitempty" json:"additive,omitempty"`
 }
 type BiologicallyDerivedProductManipulation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Description       *string     `json:"description,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string     `bson:"description,omitempty" json:"description,omitempty"`
 }
 type BiologicallyDerivedProductStorage struct {
-	Id                *string                                 `json:"id,omitempty"`
-	Extension         []Extension                             `json:"extension,omitempty"`
-	ModifierExtension []Extension                             `json:"modifierExtension,omitempty"`
-	Description       *string                                 `json:"description,omitempty"`
-	Temperature       *string                                 `json:"temperature,omitempty"`
-	Scale             *BiologicallyDerivedProductStorageScale `json:"scale,omitempty"`
-	Duration          *Period                                 `json:"duration,omitempty"`
+	Id                *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string                                 `bson:"description,omitempty" json:"description,omitempty"`
+	Temperature       *string                                 `bson:"temperature,omitempty" json:"temperature,omitempty"`
+	Scale             *BiologicallyDerivedProductStorageScale `bson:"scale,omitempty" json:"scale,omitempty"`
+	Duration          *Period                                 `bson:"duration,omitempty" json:"duration,omitempty"`
 }
 type OtherBiologicallyDerivedProduct BiologicallyDerivedProduct
 

--- a/fhir-models/fhir/bodyStructure.go
+++ b/fhir-models/fhir/bodyStructure.go
@@ -21,21 +21,21 @@ import "encoding/json"
 
 // BodyStructure is documented here http://hl7.org/fhir/StructureDefinition/BodyStructure
 type BodyStructure struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier      `json:"identifier,omitempty"`
-	Active            *bool             `json:"active,omitempty"`
-	Morphology        *CodeableConcept  `json:"morphology,omitempty"`
-	Location          *CodeableConcept  `json:"location,omitempty"`
-	LocationQualifier []CodeableConcept `json:"locationQualifier,omitempty"`
-	Description       *string           `json:"description,omitempty"`
-	Image             []Attachment      `json:"image,omitempty"`
-	Patient           Reference         `json:"patient"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active            *bool             `bson:"active,omitempty" json:"active,omitempty"`
+	Morphology        *CodeableConcept  `bson:"morphology,omitempty" json:"morphology,omitempty"`
+	Location          *CodeableConcept  `bson:"location,omitempty" json:"location,omitempty"`
+	LocationQualifier []CodeableConcept `bson:"locationQualifier,omitempty" json:"locationQualifier,omitempty"`
+	Description       *string           `bson:"description,omitempty" json:"description,omitempty"`
+	Image             []Attachment      `bson:"image,omitempty" json:"image,omitempty"`
+	Patient           Reference         `bson:"patient" json:"patient"`
 }
 type OtherBodyStructure BodyStructure
 

--- a/fhir-models/fhir/bundle.go
+++ b/fhir-models/fhir/bundle.go
@@ -21,63 +21,63 @@ import "encoding/json"
 
 // Bundle is documented here http://hl7.org/fhir/StructureDefinition/Bundle
 type Bundle struct {
-	Id            *string       `json:"id,omitempty"`
-	Meta          *Meta         `json:"meta,omitempty"`
-	ImplicitRules *string       `json:"implicitRules,omitempty"`
-	Language      *string       `json:"language,omitempty"`
-	Identifier    *Identifier   `json:"identifier,omitempty"`
-	Type          BundleType    `json:"type"`
-	Timestamp     *string       `json:"timestamp,omitempty"`
-	Total         *int          `json:"total,omitempty"`
-	Link          []BundleLink  `json:"link,omitempty"`
-	Entry         []BundleEntry `json:"entry,omitempty"`
-	Signature     *Signature    `json:"signature,omitempty"`
+	Id            *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta          *Meta         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules *string       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language      *string       `bson:"language,omitempty" json:"language,omitempty"`
+	Identifier    *Identifier   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type          BundleType    `bson:"type" json:"type"`
+	Timestamp     *string       `bson:"timestamp,omitempty" json:"timestamp,omitempty"`
+	Total         *int          `bson:"total,omitempty" json:"total,omitempty"`
+	Link          []BundleLink  `bson:"link,omitempty" json:"link,omitempty"`
+	Entry         []BundleEntry `bson:"entry,omitempty" json:"entry,omitempty"`
+	Signature     *Signature    `bson:"signature,omitempty" json:"signature,omitempty"`
 }
 type BundleLink struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Relation          string      `json:"relation"`
-	Url               string      `json:"url"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Relation          string      `bson:"relation" json:"relation"`
+	Url               string      `bson:"url" json:"url"`
 }
 type BundleEntry struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Link              []BundleLink         `json:"link,omitempty"`
-	FullUrl           *string              `json:"fullUrl,omitempty"`
-	Resource          json.RawMessage      `json:"resource,omitempty"`
-	Search            *BundleEntrySearch   `json:"search,omitempty"`
-	Request           *BundleEntryRequest  `json:"request,omitempty"`
-	Response          *BundleEntryResponse `json:"response,omitempty"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Link              []BundleLink         `bson:"link,omitempty" json:"link,omitempty"`
+	FullUrl           *string              `bson:"fullUrl,omitempty" json:"fullUrl,omitempty"`
+	Resource          json.RawMessage      `bson:"resource,omitempty" json:"resource,omitempty"`
+	Search            *BundleEntrySearch   `bson:"search,omitempty" json:"search,omitempty"`
+	Request           *BundleEntryRequest  `bson:"request,omitempty" json:"request,omitempty"`
+	Response          *BundleEntryResponse `bson:"response,omitempty" json:"response,omitempty"`
 }
 type BundleEntrySearch struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Mode              *SearchEntryMode `json:"mode,omitempty"`
-	Score             *string          `json:"score,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              *SearchEntryMode `bson:"mode,omitempty" json:"mode,omitempty"`
+	Score             *string          `bson:"score,omitempty" json:"score,omitempty"`
 }
 type BundleEntryRequest struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Method            HTTPVerb    `json:"method"`
-	Url               string      `json:"url"`
-	IfNoneMatch       *string     `json:"ifNoneMatch,omitempty"`
-	IfModifiedSince   *string     `json:"ifModifiedSince,omitempty"`
-	IfMatch           *string     `json:"ifMatch,omitempty"`
-	IfNoneExist       *string     `json:"ifNoneExist,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Method            HTTPVerb    `bson:"method" json:"method"`
+	Url               string      `bson:"url" json:"url"`
+	IfNoneMatch       *string     `bson:"ifNoneMatch,omitempty" json:"ifNoneMatch,omitempty"`
+	IfModifiedSince   *string     `bson:"ifModifiedSince,omitempty" json:"ifModifiedSince,omitempty"`
+	IfMatch           *string     `bson:"ifMatch,omitempty" json:"ifMatch,omitempty"`
+	IfNoneExist       *string     `bson:"ifNoneExist,omitempty" json:"ifNoneExist,omitempty"`
 }
 type BundleEntryResponse struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Status            string          `json:"status"`
-	Location          *string         `json:"location,omitempty"`
-	Etag              *string         `json:"etag,omitempty"`
-	LastModified      *string         `json:"lastModified,omitempty"`
-	Outcome           json.RawMessage `json:"outcome,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Status            string          `bson:"status" json:"status"`
+	Location          *string         `bson:"location,omitempty" json:"location,omitempty"`
+	Etag              *string         `bson:"etag,omitempty" json:"etag,omitempty"`
+	LastModified      *string         `bson:"lastModified,omitempty" json:"lastModified,omitempty"`
+	Outcome           json.RawMessage `bson:"outcome,omitempty" json:"outcome,omitempty"`
 }
 type OtherBundle Bundle
 

--- a/fhir-models/fhir/capabilityStatement.go
+++ b/fhir-models/fhir/capabilityStatement.go
@@ -21,160 +21,160 @@ import "encoding/json"
 
 // CapabilityStatement is documented here http://hl7.org/fhir/StructureDefinition/CapabilityStatement
 type CapabilityStatement struct {
-	Id                  *string                            `json:"id,omitempty"`
-	Meta                *Meta                              `json:"meta,omitempty"`
-	ImplicitRules       *string                            `json:"implicitRules,omitempty"`
-	Language            *string                            `json:"language,omitempty"`
-	Text                *Narrative                         `json:"text,omitempty"`
-	Extension           []Extension                        `json:"extension,omitempty"`
-	ModifierExtension   []Extension                        `json:"modifierExtension,omitempty"`
-	Url                 *string                            `json:"url,omitempty"`
-	Version             *string                            `json:"version,omitempty"`
-	Name                *string                            `json:"name,omitempty"`
-	Title               *string                            `json:"title,omitempty"`
-	Status              PublicationStatus                  `json:"status"`
-	Experimental        *bool                              `json:"experimental,omitempty"`
-	Date                string                             `json:"date"`
-	Publisher           *string                            `json:"publisher,omitempty"`
-	Contact             []ContactDetail                    `json:"contact,omitempty"`
-	Description         *string                            `json:"description,omitempty"`
-	UseContext          []UsageContext                     `json:"useContext,omitempty"`
-	Jurisdiction        []CodeableConcept                  `json:"jurisdiction,omitempty"`
-	Purpose             *string                            `json:"purpose,omitempty"`
-	Copyright           *string                            `json:"copyright,omitempty"`
-	Kind                CapabilityStatementKind            `json:"kind"`
-	Instantiates        []string                           `json:"instantiates,omitempty"`
-	Imports             []string                           `json:"imports,omitempty"`
-	Software            *CapabilityStatementSoftware       `json:"software,omitempty"`
-	Implementation      *CapabilityStatementImplementation `json:"implementation,omitempty"`
-	FhirVersion         FHIRVersion                        `json:"fhirVersion"`
-	Format              []string                           `json:"format"`
-	PatchFormat         []string                           `json:"patchFormat,omitempty"`
-	ImplementationGuide []string                           `json:"implementationGuide,omitempty"`
-	Rest                []CapabilityStatementRest          `json:"rest,omitempty"`
-	Messaging           []CapabilityStatementMessaging     `json:"messaging,omitempty"`
-	Document            []CapabilityStatementDocument      `json:"document,omitempty"`
+	Id                  *string                            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string                            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string                            `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative                         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url                 *string                            `bson:"url,omitempty" json:"url,omitempty"`
+	Version             *string                            `bson:"version,omitempty" json:"version,omitempty"`
+	Name                *string                            `bson:"name,omitempty" json:"name,omitempty"`
+	Title               *string                            `bson:"title,omitempty" json:"title,omitempty"`
+	Status              PublicationStatus                  `bson:"status" json:"status"`
+	Experimental        *bool                              `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date                string                             `bson:"date" json:"date"`
+	Publisher           *string                            `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact             []ContactDetail                    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description         *string                            `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext          []UsageContext                     `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction        []CodeableConcept                  `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose             *string                            `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright           *string                            `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Kind                CapabilityStatementKind            `bson:"kind" json:"kind"`
+	Instantiates        []string                           `bson:"instantiates,omitempty" json:"instantiates,omitempty"`
+	Imports             []string                           `bson:"imports,omitempty" json:"imports,omitempty"`
+	Software            *CapabilityStatementSoftware       `bson:"software,omitempty" json:"software,omitempty"`
+	Implementation      *CapabilityStatementImplementation `bson:"implementation,omitempty" json:"implementation,omitempty"`
+	FhirVersion         FHIRVersion                        `bson:"fhirVersion" json:"fhirVersion"`
+	Format              []string                           `bson:"format" json:"format"`
+	PatchFormat         []string                           `bson:"patchFormat,omitempty" json:"patchFormat,omitempty"`
+	ImplementationGuide []string                           `bson:"implementationGuide,omitempty" json:"implementationGuide,omitempty"`
+	Rest                []CapabilityStatementRest          `bson:"rest,omitempty" json:"rest,omitempty"`
+	Messaging           []CapabilityStatementMessaging     `bson:"messaging,omitempty" json:"messaging,omitempty"`
+	Document            []CapabilityStatementDocument      `bson:"document,omitempty" json:"document,omitempty"`
 }
 type CapabilityStatementSoftware struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Version           *string     `json:"version,omitempty"`
-	ReleaseDate       *string     `json:"releaseDate,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Version           *string     `bson:"version,omitempty" json:"version,omitempty"`
+	ReleaseDate       *string     `bson:"releaseDate,omitempty" json:"releaseDate,omitempty"`
 }
 type CapabilityStatementImplementation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Description       string      `json:"description"`
-	Url               *string     `json:"url,omitempty"`
-	Custodian         *Reference  `json:"custodian,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       string      `bson:"description" json:"description"`
+	Url               *string     `bson:"url,omitempty" json:"url,omitempty"`
+	Custodian         *Reference  `bson:"custodian,omitempty" json:"custodian,omitempty"`
 }
 type CapabilityStatementRest struct {
-	Id                *string                                      `json:"id,omitempty"`
-	Extension         []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                                  `json:"modifierExtension,omitempty"`
-	Mode              RestfulCapabilityMode                        `json:"mode"`
-	Documentation     *string                                      `json:"documentation,omitempty"`
-	Security          *CapabilityStatementRestSecurity             `json:"security,omitempty"`
-	Resource          []CapabilityStatementRestResource            `json:"resource,omitempty"`
-	Interaction       []CapabilityStatementRestInteraction         `json:"interaction,omitempty"`
-	SearchParam       []CapabilityStatementRestResourceSearchParam `json:"searchParam,omitempty"`
-	Operation         []CapabilityStatementRestResourceOperation   `json:"operation,omitempty"`
-	Compartment       []string                                     `json:"compartment,omitempty"`
+	Id                *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              RestfulCapabilityMode                        `bson:"mode" json:"mode"`
+	Documentation     *string                                      `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Security          *CapabilityStatementRestSecurity             `bson:"security,omitempty" json:"security,omitempty"`
+	Resource          []CapabilityStatementRestResource            `bson:"resource,omitempty" json:"resource,omitempty"`
+	Interaction       []CapabilityStatementRestInteraction         `bson:"interaction,omitempty" json:"interaction,omitempty"`
+	SearchParam       []CapabilityStatementRestResourceSearchParam `bson:"searchParam,omitempty" json:"searchParam,omitempty"`
+	Operation         []CapabilityStatementRestResourceOperation   `bson:"operation,omitempty" json:"operation,omitempty"`
+	Compartment       []string                                     `bson:"compartment,omitempty" json:"compartment,omitempty"`
 }
 type CapabilityStatementRestSecurity struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Cors              *bool             `json:"cors,omitempty"`
-	Service           []CodeableConcept `json:"service,omitempty"`
-	Description       *string           `json:"description,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Cors              *bool             `bson:"cors,omitempty" json:"cors,omitempty"`
+	Service           []CodeableConcept `bson:"service,omitempty" json:"service,omitempty"`
+	Description       *string           `bson:"description,omitempty" json:"description,omitempty"`
 }
 type CapabilityStatementRestResource struct {
-	Id                *string                                      `json:"id,omitempty"`
-	Extension         []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                                  `json:"modifierExtension,omitempty"`
-	Type              ResourceType                                 `json:"type"`
-	Profile           *string                                      `json:"profile,omitempty"`
-	SupportedProfile  []string                                     `json:"supportedProfile,omitempty"`
-	Documentation     *string                                      `json:"documentation,omitempty"`
-	Interaction       []CapabilityStatementRestResourceInteraction `json:"interaction,omitempty"`
-	Versioning        *ResourceVersionPolicy                       `json:"versioning,omitempty"`
-	ReadHistory       *bool                                        `json:"readHistory,omitempty"`
-	UpdateCreate      *bool                                        `json:"updateCreate,omitempty"`
-	ConditionalCreate *bool                                        `json:"conditionalCreate,omitempty"`
-	ConditionalRead   *ConditionalReadStatus                       `json:"conditionalRead,omitempty"`
-	ConditionalUpdate *bool                                        `json:"conditionalUpdate,omitempty"`
-	ConditionalDelete *ConditionalDeleteStatus                     `json:"conditionalDelete,omitempty"`
-	ReferencePolicy   []ReferenceHandlingPolicy                    `json:"referencePolicy,omitempty"`
-	SearchInclude     []string                                     `json:"searchInclude,omitempty"`
-	SearchRevInclude  []string                                     `json:"searchRevInclude,omitempty"`
-	SearchParam       []CapabilityStatementRestResourceSearchParam `json:"searchParam,omitempty"`
-	Operation         []CapabilityStatementRestResourceOperation   `json:"operation,omitempty"`
+	Id                *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ResourceType                                 `bson:"type" json:"type"`
+	Profile           *string                                      `bson:"profile,omitempty" json:"profile,omitempty"`
+	SupportedProfile  []string                                     `bson:"supportedProfile,omitempty" json:"supportedProfile,omitempty"`
+	Documentation     *string                                      `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Interaction       []CapabilityStatementRestResourceInteraction `bson:"interaction,omitempty" json:"interaction,omitempty"`
+	Versioning        *ResourceVersionPolicy                       `bson:"versioning,omitempty" json:"versioning,omitempty"`
+	ReadHistory       *bool                                        `bson:"readHistory,omitempty" json:"readHistory,omitempty"`
+	UpdateCreate      *bool                                        `bson:"updateCreate,omitempty" json:"updateCreate,omitempty"`
+	ConditionalCreate *bool                                        `bson:"conditionalCreate,omitempty" json:"conditionalCreate,omitempty"`
+	ConditionalRead   *ConditionalReadStatus                       `bson:"conditionalRead,omitempty" json:"conditionalRead,omitempty"`
+	ConditionalUpdate *bool                                        `bson:"conditionalUpdate,omitempty" json:"conditionalUpdate,omitempty"`
+	ConditionalDelete *ConditionalDeleteStatus                     `bson:"conditionalDelete,omitempty" json:"conditionalDelete,omitempty"`
+	ReferencePolicy   []ReferenceHandlingPolicy                    `bson:"referencePolicy,omitempty" json:"referencePolicy,omitempty"`
+	SearchInclude     []string                                     `bson:"searchInclude,omitempty" json:"searchInclude,omitempty"`
+	SearchRevInclude  []string                                     `bson:"searchRevInclude,omitempty" json:"searchRevInclude,omitempty"`
+	SearchParam       []CapabilityStatementRestResourceSearchParam `bson:"searchParam,omitempty" json:"searchParam,omitempty"`
+	Operation         []CapabilityStatementRestResourceOperation   `bson:"operation,omitempty" json:"operation,omitempty"`
 }
 type CapabilityStatementRestResourceInteraction struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Code              TypeRestfulInteraction `json:"code"`
-	Documentation     *string                `json:"documentation,omitempty"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              TypeRestfulInteraction `bson:"code" json:"code"`
+	Documentation     *string                `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type CapabilityStatementRestResourceSearchParam struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Name              string          `json:"name"`
-	Definition        *string         `json:"definition,omitempty"`
-	Type              SearchParamType `json:"type"`
-	Documentation     *string         `json:"documentation,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string          `bson:"name" json:"name"`
+	Definition        *string         `bson:"definition,omitempty" json:"definition,omitempty"`
+	Type              SearchParamType `bson:"type" json:"type"`
+	Documentation     *string         `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type CapabilityStatementRestResourceOperation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Definition        string      `json:"definition"`
-	Documentation     *string     `json:"documentation,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Definition        string      `bson:"definition" json:"definition"`
+	Documentation     *string     `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type CapabilityStatementRestInteraction struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Code              SystemRestfulInteraction `json:"code"`
-	Documentation     *string                  `json:"documentation,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              SystemRestfulInteraction `bson:"code" json:"code"`
+	Documentation     *string                  `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type CapabilityStatementMessaging struct {
-	Id                *string                                        `json:"id,omitempty"`
-	Extension         []Extension                                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                                    `json:"modifierExtension,omitempty"`
-	Endpoint          []CapabilityStatementMessagingEndpoint         `json:"endpoint,omitempty"`
-	ReliableCache     *int                                           `json:"reliableCache,omitempty"`
-	Documentation     *string                                        `json:"documentation,omitempty"`
-	SupportedMessage  []CapabilityStatementMessagingSupportedMessage `json:"supportedMessage,omitempty"`
+	Id                *string                                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Endpoint          []CapabilityStatementMessagingEndpoint         `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	ReliableCache     *int                                           `bson:"reliableCache,omitempty" json:"reliableCache,omitempty"`
+	Documentation     *string                                        `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	SupportedMessage  []CapabilityStatementMessagingSupportedMessage `bson:"supportedMessage,omitempty" json:"supportedMessage,omitempty"`
 }
 type CapabilityStatementMessagingEndpoint struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Protocol          Coding      `json:"protocol"`
-	Address           string      `json:"address"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Protocol          Coding      `bson:"protocol" json:"protocol"`
+	Address           string      `bson:"address" json:"address"`
 }
 type CapabilityStatementMessagingSupportedMessage struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Mode              EventCapabilityMode `json:"mode"`
-	Definition        string              `json:"definition"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              EventCapabilityMode `bson:"mode" json:"mode"`
+	Definition        string              `bson:"definition" json:"definition"`
 }
 type CapabilityStatementDocument struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Mode              DocumentMode `json:"mode"`
-	Documentation     *string      `json:"documentation,omitempty"`
-	Profile           string       `json:"profile"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              DocumentMode `bson:"mode" json:"mode"`
+	Documentation     *string      `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Profile           string       `bson:"profile" json:"profile"`
 }
 type OtherCapabilityStatement CapabilityStatement
 

--- a/fhir-models/fhir/carePlan.go
+++ b/fhir-models/fhir/carePlan.go
@@ -21,66 +21,66 @@ import "encoding/json"
 
 // CarePlan is documented here http://hl7.org/fhir/StructureDefinition/CarePlan
 type CarePlan struct {
-	Id                    *string            `json:"id,omitempty"`
-	Meta                  *Meta              `json:"meta,omitempty"`
-	ImplicitRules         *string            `json:"implicitRules,omitempty"`
-	Language              *string            `json:"language,omitempty"`
-	Text                  *Narrative         `json:"text,omitempty"`
-	Extension             []Extension        `json:"extension,omitempty"`
-	ModifierExtension     []Extension        `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier       `json:"identifier,omitempty"`
-	InstantiatesCanonical []string           `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string           `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference        `json:"basedOn,omitempty"`
-	Replaces              []Reference        `json:"replaces,omitempty"`
-	PartOf                []Reference        `json:"partOf,omitempty"`
-	Status                RequestStatus      `json:"status"`
-	Intent                CarePlanIntent     `json:"intent"`
-	Category              []CodeableConcept  `json:"category,omitempty"`
-	Title                 *string            `json:"title,omitempty"`
-	Description           *string            `json:"description,omitempty"`
-	Subject               Reference          `json:"subject"`
-	Encounter             *Reference         `json:"encounter,omitempty"`
-	Period                *Period            `json:"period,omitempty"`
-	Created               *string            `json:"created,omitempty"`
-	Author                *Reference         `json:"author,omitempty"`
-	Contributor           []Reference        `json:"contributor,omitempty"`
-	CareTeam              []Reference        `json:"careTeam,omitempty"`
-	Addresses             []Reference        `json:"addresses,omitempty"`
-	SupportingInfo        []Reference        `json:"supportingInfo,omitempty"`
-	Goal                  []Reference        `json:"goal,omitempty"`
-	Activity              []CarePlanActivity `json:"activity,omitempty"`
-	Note                  []Annotation       `json:"note,omitempty"`
+	Id                    *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string            `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string           `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string           `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference        `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Replaces              []Reference        `bson:"replaces,omitempty" json:"replaces,omitempty"`
+	PartOf                []Reference        `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status                RequestStatus      `bson:"status" json:"status"`
+	Intent                CarePlanIntent     `bson:"intent" json:"intent"`
+	Category              []CodeableConcept  `bson:"category,omitempty" json:"category,omitempty"`
+	Title                 *string            `bson:"title,omitempty" json:"title,omitempty"`
+	Description           *string            `bson:"description,omitempty" json:"description,omitempty"`
+	Subject               Reference          `bson:"subject" json:"subject"`
+	Encounter             *Reference         `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Period                *Period            `bson:"period,omitempty" json:"period,omitempty"`
+	Created               *string            `bson:"created,omitempty" json:"created,omitempty"`
+	Author                *Reference         `bson:"author,omitempty" json:"author,omitempty"`
+	Contributor           []Reference        `bson:"contributor,omitempty" json:"contributor,omitempty"`
+	CareTeam              []Reference        `bson:"careTeam,omitempty" json:"careTeam,omitempty"`
+	Addresses             []Reference        `bson:"addresses,omitempty" json:"addresses,omitempty"`
+	SupportingInfo        []Reference        `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Goal                  []Reference        `bson:"goal,omitempty" json:"goal,omitempty"`
+	Activity              []CarePlanActivity `bson:"activity,omitempty" json:"activity,omitempty"`
+	Note                  []Annotation       `bson:"note,omitempty" json:"note,omitempty"`
 }
 type CarePlanActivity struct {
-	Id                     *string                 `json:"id,omitempty"`
-	Extension              []Extension             `json:"extension,omitempty"`
-	ModifierExtension      []Extension             `json:"modifierExtension,omitempty"`
-	OutcomeCodeableConcept []CodeableConcept       `json:"outcomeCodeableConcept,omitempty"`
-	OutcomeReference       []Reference             `json:"outcomeReference,omitempty"`
-	Progress               []Annotation            `json:"progress,omitempty"`
-	Reference              *Reference              `json:"reference,omitempty"`
-	Detail                 *CarePlanActivityDetail `json:"detail,omitempty"`
+	Id                     *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension              []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	OutcomeCodeableConcept []CodeableConcept       `bson:"outcomeCodeableConcept,omitempty" json:"outcomeCodeableConcept,omitempty"`
+	OutcomeReference       []Reference             `bson:"outcomeReference,omitempty" json:"outcomeReference,omitempty"`
+	Progress               []Annotation            `bson:"progress,omitempty" json:"progress,omitempty"`
+	Reference              *Reference              `bson:"reference,omitempty" json:"reference,omitempty"`
+	Detail                 *CarePlanActivityDetail `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type CarePlanActivityDetail struct {
-	Id                    *string                `json:"id,omitempty"`
-	Extension             []Extension            `json:"extension,omitempty"`
-	ModifierExtension     []Extension            `json:"modifierExtension,omitempty"`
-	Kind                  *CarePlanActivityKind  `json:"kind,omitempty"`
-	InstantiatesCanonical []string               `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string               `json:"instantiatesUri,omitempty"`
-	Code                  *CodeableConcept       `json:"code,omitempty"`
-	ReasonCode            []CodeableConcept      `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference            `json:"reasonReference,omitempty"`
-	Goal                  []Reference            `json:"goal,omitempty"`
-	Status                CarePlanActivityStatus `json:"status"`
-	StatusReason          *CodeableConcept       `json:"statusReason,omitempty"`
-	DoNotPerform          *bool                  `json:"doNotPerform,omitempty"`
-	Location              *Reference             `json:"location,omitempty"`
-	Performer             []Reference            `json:"performer,omitempty"`
-	DailyAmount           *Quantity              `json:"dailyAmount,omitempty"`
-	Quantity              *Quantity              `json:"quantity,omitempty"`
-	Description           *string                `json:"description,omitempty"`
+	Id                    *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension             []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Kind                  *CarePlanActivityKind  `bson:"kind,omitempty" json:"kind,omitempty"`
+	InstantiatesCanonical []string               `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string               `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	Code                  *CodeableConcept       `bson:"code,omitempty" json:"code,omitempty"`
+	ReasonCode            []CodeableConcept      `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference            `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Goal                  []Reference            `bson:"goal,omitempty" json:"goal,omitempty"`
+	Status                CarePlanActivityStatus `bson:"status" json:"status"`
+	StatusReason          *CodeableConcept       `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	DoNotPerform          *bool                  `bson:"doNotPerform,omitempty" json:"doNotPerform,omitempty"`
+	Location              *Reference             `bson:"location,omitempty" json:"location,omitempty"`
+	Performer             []Reference            `bson:"performer,omitempty" json:"performer,omitempty"`
+	DailyAmount           *Quantity              `bson:"dailyAmount,omitempty" json:"dailyAmount,omitempty"`
+	Quantity              *Quantity              `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Description           *string                `bson:"description,omitempty" json:"description,omitempty"`
 }
 type OtherCarePlan CarePlan
 

--- a/fhir-models/fhir/careTeam.go
+++ b/fhir-models/fhir/careTeam.go
@@ -21,35 +21,35 @@ import "encoding/json"
 
 // CareTeam is documented here http://hl7.org/fhir/StructureDefinition/CareTeam
 type CareTeam struct {
-	Id                   *string               `json:"id,omitempty"`
-	Meta                 *Meta                 `json:"meta,omitempty"`
-	ImplicitRules        *string               `json:"implicitRules,omitempty"`
-	Language             *string               `json:"language,omitempty"`
-	Text                 *Narrative            `json:"text,omitempty"`
-	Extension            []Extension           `json:"extension,omitempty"`
-	ModifierExtension    []Extension           `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier          `json:"identifier,omitempty"`
-	Status               *CareTeamStatus       `json:"status,omitempty"`
-	Category             []CodeableConcept     `json:"category,omitempty"`
-	Name                 *string               `json:"name,omitempty"`
-	Subject              *Reference            `json:"subject,omitempty"`
-	Encounter            *Reference            `json:"encounter,omitempty"`
-	Period               *Period               `json:"period,omitempty"`
-	Participant          []CareTeamParticipant `json:"participant,omitempty"`
-	ReasonCode           []CodeableConcept     `json:"reasonCode,omitempty"`
-	ReasonReference      []Reference           `json:"reasonReference,omitempty"`
-	ManagingOrganization []Reference           `json:"managingOrganization,omitempty"`
-	Telecom              []ContactPoint        `json:"telecom,omitempty"`
-	Note                 []Annotation          `json:"note,omitempty"`
+	Id                   *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status               *CareTeamStatus       `bson:"status,omitempty" json:"status,omitempty"`
+	Category             []CodeableConcept     `bson:"category,omitempty" json:"category,omitempty"`
+	Name                 *string               `bson:"name,omitempty" json:"name,omitempty"`
+	Subject              *Reference            `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter            *Reference            `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Period               *Period               `bson:"period,omitempty" json:"period,omitempty"`
+	Participant          []CareTeamParticipant `bson:"participant,omitempty" json:"participant,omitempty"`
+	ReasonCode           []CodeableConcept     `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference      []Reference           `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	ManagingOrganization []Reference           `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
+	Telecom              []ContactPoint        `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Note                 []Annotation          `bson:"note,omitempty" json:"note,omitempty"`
 }
 type CareTeamParticipant struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Role              []CodeableConcept `json:"role,omitempty"`
-	Member            *Reference        `json:"member,omitempty"`
-	OnBehalfOf        *Reference        `json:"onBehalfOf,omitempty"`
-	Period            *Period           `json:"period,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Role              []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Member            *Reference        `bson:"member,omitempty" json:"member,omitempty"`
+	OnBehalfOf        *Reference        `bson:"onBehalfOf,omitempty" json:"onBehalfOf,omitempty"`
+	Period            *Period           `bson:"period,omitempty" json:"period,omitempty"`
 }
 type OtherCareTeam CareTeam
 

--- a/fhir-models/fhir/catalogEntry.go
+++ b/fhir-models/fhir/catalogEntry.go
@@ -21,33 +21,33 @@ import "encoding/json"
 
 // CatalogEntry is documented here http://hl7.org/fhir/StructureDefinition/CatalogEntry
 type CatalogEntry struct {
-	Id                       *string                    `json:"id,omitempty"`
-	Meta                     *Meta                      `json:"meta,omitempty"`
-	ImplicitRules            *string                    `json:"implicitRules,omitempty"`
-	Language                 *string                    `json:"language,omitempty"`
-	Text                     *Narrative                 `json:"text,omitempty"`
-	Extension                []Extension                `json:"extension,omitempty"`
-	ModifierExtension        []Extension                `json:"modifierExtension,omitempty"`
-	Identifier               []Identifier               `json:"identifier,omitempty"`
-	Type                     *CodeableConcept           `json:"type,omitempty"`
-	Orderable                bool                       `json:"orderable"`
-	ReferencedItem           Reference                  `json:"referencedItem"`
-	AdditionalIdentifier     []Identifier               `json:"additionalIdentifier,omitempty"`
-	Classification           []CodeableConcept          `json:"classification,omitempty"`
-	Status                   *PublicationStatus         `json:"status,omitempty"`
-	ValidityPeriod           *Period                    `json:"validityPeriod,omitempty"`
-	ValidTo                  *string                    `json:"validTo,omitempty"`
-	LastUpdated              *string                    `json:"lastUpdated,omitempty"`
-	AdditionalCharacteristic []CodeableConcept          `json:"additionalCharacteristic,omitempty"`
-	AdditionalClassification []CodeableConcept          `json:"additionalClassification,omitempty"`
-	RelatedEntry             []CatalogEntryRelatedEntry `json:"relatedEntry,omitempty"`
+	Id                       *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                     *Meta                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules            *string                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                 *string                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text                     *Narrative                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension        []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier               []Identifier               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type                     *CodeableConcept           `bson:"type,omitempty" json:"type,omitempty"`
+	Orderable                bool                       `bson:"orderable" json:"orderable"`
+	ReferencedItem           Reference                  `bson:"referencedItem" json:"referencedItem"`
+	AdditionalIdentifier     []Identifier               `bson:"additionalIdentifier,omitempty" json:"additionalIdentifier,omitempty"`
+	Classification           []CodeableConcept          `bson:"classification,omitempty" json:"classification,omitempty"`
+	Status                   *PublicationStatus         `bson:"status,omitempty" json:"status,omitempty"`
+	ValidityPeriod           *Period                    `bson:"validityPeriod,omitempty" json:"validityPeriod,omitempty"`
+	ValidTo                  *string                    `bson:"validTo,omitempty" json:"validTo,omitempty"`
+	LastUpdated              *string                    `bson:"lastUpdated,omitempty" json:"lastUpdated,omitempty"`
+	AdditionalCharacteristic []CodeableConcept          `bson:"additionalCharacteristic,omitempty" json:"additionalCharacteristic,omitempty"`
+	AdditionalClassification []CodeableConcept          `bson:"additionalClassification,omitempty" json:"additionalClassification,omitempty"`
+	RelatedEntry             []CatalogEntryRelatedEntry `bson:"relatedEntry,omitempty" json:"relatedEntry,omitempty"`
 }
 type CatalogEntryRelatedEntry struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Relationtype      CatalogEntryRelationType `json:"relationtype"`
-	Item              Reference                `json:"item"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Relationtype      CatalogEntryRelationType `bson:"relationtype" json:"relationtype"`
+	Item              Reference                `bson:"item" json:"item"`
 }
 type OtherCatalogEntry CatalogEntry
 

--- a/fhir-models/fhir/chargeItem.go
+++ b/fhir-models/fhir/chargeItem.go
@@ -21,44 +21,44 @@ import "encoding/json"
 
 // ChargeItem is documented here http://hl7.org/fhir/StructureDefinition/ChargeItem
 type ChargeItem struct {
-	Id                     *string               `json:"id,omitempty"`
-	Meta                   *Meta                 `json:"meta,omitempty"`
-	ImplicitRules          *string               `json:"implicitRules,omitempty"`
-	Language               *string               `json:"language,omitempty"`
-	Text                   *Narrative            `json:"text,omitempty"`
-	Extension              []Extension           `json:"extension,omitempty"`
-	ModifierExtension      []Extension           `json:"modifierExtension,omitempty"`
-	Identifier             []Identifier          `json:"identifier,omitempty"`
-	DefinitionUri          []string              `json:"definitionUri,omitempty"`
-	DefinitionCanonical    []string              `json:"definitionCanonical,omitempty"`
-	Status                 ChargeItemStatus      `json:"status"`
-	PartOf                 []Reference           `json:"partOf,omitempty"`
-	Code                   CodeableConcept       `json:"code"`
-	Subject                Reference             `json:"subject"`
-	Context                *Reference            `json:"context,omitempty"`
-	Performer              []ChargeItemPerformer `json:"performer,omitempty"`
-	PerformingOrganization *Reference            `json:"performingOrganization,omitempty"`
-	RequestingOrganization *Reference            `json:"requestingOrganization,omitempty"`
-	CostCenter             *Reference            `json:"costCenter,omitempty"`
-	Quantity               *Quantity             `json:"quantity,omitempty"`
-	Bodysite               []CodeableConcept     `json:"bodysite,omitempty"`
-	FactorOverride         *string               `json:"factorOverride,omitempty"`
-	PriceOverride          *Money                `json:"priceOverride,omitempty"`
-	OverrideReason         *string               `json:"overrideReason,omitempty"`
-	Enterer                *Reference            `json:"enterer,omitempty"`
-	EnteredDate            *string               `json:"enteredDate,omitempty"`
-	Reason                 []CodeableConcept     `json:"reason,omitempty"`
-	Service                []Reference           `json:"service,omitempty"`
-	Account                []Reference           `json:"account,omitempty"`
-	Note                   []Annotation          `json:"note,omitempty"`
-	SupportingInformation  []Reference           `json:"supportingInformation,omitempty"`
+	Id                     *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier             []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	DefinitionUri          []string              `bson:"definitionUri,omitempty" json:"definitionUri,omitempty"`
+	DefinitionCanonical    []string              `bson:"definitionCanonical,omitempty" json:"definitionCanonical,omitempty"`
+	Status                 ChargeItemStatus      `bson:"status" json:"status"`
+	PartOf                 []Reference           `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Code                   CodeableConcept       `bson:"code" json:"code"`
+	Subject                Reference             `bson:"subject" json:"subject"`
+	Context                *Reference            `bson:"context,omitempty" json:"context,omitempty"`
+	Performer              []ChargeItemPerformer `bson:"performer,omitempty" json:"performer,omitempty"`
+	PerformingOrganization *Reference            `bson:"performingOrganization,omitempty" json:"performingOrganization,omitempty"`
+	RequestingOrganization *Reference            `bson:"requestingOrganization,omitempty" json:"requestingOrganization,omitempty"`
+	CostCenter             *Reference            `bson:"costCenter,omitempty" json:"costCenter,omitempty"`
+	Quantity               *Quantity             `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Bodysite               []CodeableConcept     `bson:"bodysite,omitempty" json:"bodysite,omitempty"`
+	FactorOverride         *string               `bson:"factorOverride,omitempty" json:"factorOverride,omitempty"`
+	PriceOverride          *Money                `bson:"priceOverride,omitempty" json:"priceOverride,omitempty"`
+	OverrideReason         *string               `bson:"overrideReason,omitempty" json:"overrideReason,omitempty"`
+	Enterer                *Reference            `bson:"enterer,omitempty" json:"enterer,omitempty"`
+	EnteredDate            *string               `bson:"enteredDate,omitempty" json:"enteredDate,omitempty"`
+	Reason                 []CodeableConcept     `bson:"reason,omitempty" json:"reason,omitempty"`
+	Service                []Reference           `bson:"service,omitempty" json:"service,omitempty"`
+	Account                []Reference           `bson:"account,omitempty" json:"account,omitempty"`
+	Note                   []Annotation          `bson:"note,omitempty" json:"note,omitempty"`
+	SupportingInformation  []Reference           `bson:"supportingInformation,omitempty" json:"supportingInformation,omitempty"`
 }
 type ChargeItemPerformer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Function          *CodeableConcept `json:"function,omitempty"`
-	Actor             Reference        `json:"actor"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Function          *CodeableConcept `bson:"function,omitempty" json:"function,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
 }
 type OtherChargeItem ChargeItem
 

--- a/fhir-models/fhir/chargeItemDefinition.go
+++ b/fhir-models/fhir/chargeItemDefinition.go
@@ -21,60 +21,60 @@ import "encoding/json"
 
 // ChargeItemDefinition is documented here http://hl7.org/fhir/StructureDefinition/ChargeItemDefinition
 type ChargeItemDefinition struct {
-	Id                *string                             `json:"id,omitempty"`
-	Meta              *Meta                               `json:"meta,omitempty"`
-	ImplicitRules     *string                             `json:"implicitRules,omitempty"`
-	Language          *string                             `json:"language,omitempty"`
-	Text              *Narrative                          `json:"text,omitempty"`
-	Extension         []Extension                         `json:"extension,omitempty"`
-	ModifierExtension []Extension                         `json:"modifierExtension,omitempty"`
-	Url               string                              `json:"url"`
-	Identifier        []Identifier                        `json:"identifier,omitempty"`
-	Version           *string                             `json:"version,omitempty"`
-	Title             *string                             `json:"title,omitempty"`
-	DerivedFromUri    []string                            `json:"derivedFromUri,omitempty"`
-	PartOf            []string                            `json:"partOf,omitempty"`
-	Replaces          []string                            `json:"replaces,omitempty"`
-	Status            PublicationStatus                   `json:"status"`
-	Experimental      *bool                               `json:"experimental,omitempty"`
-	Date              *string                             `json:"date,omitempty"`
-	Publisher         *string                             `json:"publisher,omitempty"`
-	Contact           []ContactDetail                     `json:"contact,omitempty"`
-	Description       *string                             `json:"description,omitempty"`
-	UseContext        []UsageContext                      `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                   `json:"jurisdiction,omitempty"`
-	Copyright         *string                             `json:"copyright,omitempty"`
-	ApprovalDate      *string                             `json:"approvalDate,omitempty"`
-	LastReviewDate    *string                             `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period                             `json:"effectivePeriod,omitempty"`
-	Code              *CodeableConcept                    `json:"code,omitempty"`
-	Instance          []Reference                         `json:"instance,omitempty"`
-	Applicability     []ChargeItemDefinitionApplicability `json:"applicability,omitempty"`
-	PropertyGroup     []ChargeItemDefinitionPropertyGroup `json:"propertyGroup,omitempty"`
+	Id                *string                             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                              `bson:"url" json:"url"`
+	Identifier        []Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                             `bson:"version,omitempty" json:"version,omitempty"`
+	Title             *string                             `bson:"title,omitempty" json:"title,omitempty"`
+	DerivedFromUri    []string                            `bson:"derivedFromUri,omitempty" json:"derivedFromUri,omitempty"`
+	PartOf            []string                            `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Replaces          []string                            `bson:"replaces,omitempty" json:"replaces,omitempty"`
+	Status            PublicationStatus                   `bson:"status" json:"status"`
+	Experimental      *bool                               `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                             `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                             `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                     `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                             `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                      `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                   `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright         *string                             `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string                             `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string                             `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period                             `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Code              *CodeableConcept                    `bson:"code,omitempty" json:"code,omitempty"`
+	Instance          []Reference                         `bson:"instance,omitempty" json:"instance,omitempty"`
+	Applicability     []ChargeItemDefinitionApplicability `bson:"applicability,omitempty" json:"applicability,omitempty"`
+	PropertyGroup     []ChargeItemDefinitionPropertyGroup `bson:"propertyGroup,omitempty" json:"propertyGroup,omitempty"`
 }
 type ChargeItemDefinitionApplicability struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Description       *string     `json:"description,omitempty"`
-	Language          *string     `json:"language,omitempty"`
-	Expression        *string     `json:"expression,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string     `bson:"description,omitempty" json:"description,omitempty"`
+	Language          *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Expression        *string     `bson:"expression,omitempty" json:"expression,omitempty"`
 }
 type ChargeItemDefinitionPropertyGroup struct {
-	Id                *string                                           `json:"id,omitempty"`
-	Extension         []Extension                                       `json:"extension,omitempty"`
-	ModifierExtension []Extension                                       `json:"modifierExtension,omitempty"`
-	Applicability     []ChargeItemDefinitionApplicability               `json:"applicability,omitempty"`
-	PriceComponent    []ChargeItemDefinitionPropertyGroupPriceComponent `json:"priceComponent,omitempty"`
+	Id                *string                                           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Applicability     []ChargeItemDefinitionApplicability               `bson:"applicability,omitempty" json:"applicability,omitempty"`
+	PriceComponent    []ChargeItemDefinitionPropertyGroupPriceComponent `bson:"priceComponent,omitempty" json:"priceComponent,omitempty"`
 }
 type ChargeItemDefinitionPropertyGroupPriceComponent struct {
-	Id                *string                   `json:"id,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Type              InvoicePriceComponentType `json:"type"`
-	Code              *CodeableConcept          `json:"code,omitempty"`
-	Factor            *string                   `json:"factor,omitempty"`
-	Amount            *Money                    `json:"amount,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              InvoicePriceComponentType `bson:"type" json:"type"`
+	Code              *CodeableConcept          `bson:"code,omitempty" json:"code,omitempty"`
+	Factor            *string                   `bson:"factor,omitempty" json:"factor,omitempty"`
+	Amount            *Money                    `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type OtherChargeItemDefinition ChargeItemDefinition
 

--- a/fhir-models/fhir/claim.go
+++ b/fhir-models/fhir/claim.go
@@ -21,168 +21,168 @@ import "encoding/json"
 
 // Claim is documented here http://hl7.org/fhir/StructureDefinition/Claim
 type Claim struct {
-	Id                   *string                      `json:"id,omitempty"`
-	Meta                 *Meta                        `json:"meta,omitempty"`
-	ImplicitRules        *string                      `json:"implicitRules,omitempty"`
-	Language             *string                      `json:"language,omitempty"`
-	Text                 *Narrative                   `json:"text,omitempty"`
-	Extension            []Extension                  `json:"extension,omitempty"`
-	ModifierExtension    []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier                 `json:"identifier,omitempty"`
-	Status               FinancialResourceStatusCodes `json:"status"`
-	Type                 CodeableConcept              `json:"type"`
-	SubType              *CodeableConcept             `json:"subType,omitempty"`
-	Use                  Use                          `json:"use"`
-	Patient              Reference                    `json:"patient"`
-	BillablePeriod       *Period                      `json:"billablePeriod,omitempty"`
-	Created              string                       `json:"created"`
-	Enterer              *Reference                   `json:"enterer,omitempty"`
-	Insurer              *Reference                   `json:"insurer,omitempty"`
-	Provider             Reference                    `json:"provider"`
-	Priority             CodeableConcept              `json:"priority"`
-	FundsReserve         *CodeableConcept             `json:"fundsReserve,omitempty"`
-	Related              []ClaimRelated               `json:"related,omitempty"`
-	Prescription         *Reference                   `json:"prescription,omitempty"`
-	OriginalPrescription *Reference                   `json:"originalPrescription,omitempty"`
-	Payee                *ClaimPayee                  `json:"payee,omitempty"`
-	Referral             *Reference                   `json:"referral,omitempty"`
-	Facility             *Reference                   `json:"facility,omitempty"`
-	CareTeam             []ClaimCareTeam              `json:"careTeam,omitempty"`
-	SupportingInfo       []ClaimSupportingInfo        `json:"supportingInfo,omitempty"`
-	Diagnosis            []ClaimDiagnosis             `json:"diagnosis,omitempty"`
-	Procedure            []ClaimProcedure             `json:"procedure,omitempty"`
-	Insurance            []ClaimInsurance             `json:"insurance"`
-	Accident             *ClaimAccident               `json:"accident,omitempty"`
-	Item                 []ClaimItem                  `json:"item,omitempty"`
-	Total                *Money                       `json:"total,omitempty"`
+	Id                   *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status               FinancialResourceStatusCodes `bson:"status" json:"status"`
+	Type                 CodeableConcept              `bson:"type" json:"type"`
+	SubType              *CodeableConcept             `bson:"subType,omitempty" json:"subType,omitempty"`
+	Use                  Use                          `bson:"use" json:"use"`
+	Patient              Reference                    `bson:"patient" json:"patient"`
+	BillablePeriod       *Period                      `bson:"billablePeriod,omitempty" json:"billablePeriod,omitempty"`
+	Created              string                       `bson:"created" json:"created"`
+	Enterer              *Reference                   `bson:"enterer,omitempty" json:"enterer,omitempty"`
+	Insurer              *Reference                   `bson:"insurer,omitempty" json:"insurer,omitempty"`
+	Provider             Reference                    `bson:"provider" json:"provider"`
+	Priority             CodeableConcept              `bson:"priority" json:"priority"`
+	FundsReserve         *CodeableConcept             `bson:"fundsReserve,omitempty" json:"fundsReserve,omitempty"`
+	Related              []ClaimRelated               `bson:"related,omitempty" json:"related,omitempty"`
+	Prescription         *Reference                   `bson:"prescription,omitempty" json:"prescription,omitempty"`
+	OriginalPrescription *Reference                   `bson:"originalPrescription,omitempty" json:"originalPrescription,omitempty"`
+	Payee                *ClaimPayee                  `bson:"payee,omitempty" json:"payee,omitempty"`
+	Referral             *Reference                   `bson:"referral,omitempty" json:"referral,omitempty"`
+	Facility             *Reference                   `bson:"facility,omitempty" json:"facility,omitempty"`
+	CareTeam             []ClaimCareTeam              `bson:"careTeam,omitempty" json:"careTeam,omitempty"`
+	SupportingInfo       []ClaimSupportingInfo        `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Diagnosis            []ClaimDiagnosis             `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
+	Procedure            []ClaimProcedure             `bson:"procedure,omitempty" json:"procedure,omitempty"`
+	Insurance            []ClaimInsurance             `bson:"insurance" json:"insurance"`
+	Accident             *ClaimAccident               `bson:"accident,omitempty" json:"accident,omitempty"`
+	Item                 []ClaimItem                  `bson:"item,omitempty" json:"item,omitempty"`
+	Total                *Money                       `bson:"total,omitempty" json:"total,omitempty"`
 }
 type ClaimRelated struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Claim             *Reference       `json:"claim,omitempty"`
-	Relationship      *CodeableConcept `json:"relationship,omitempty"`
-	Reference         *Identifier      `json:"reference,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Claim             *Reference       `bson:"claim,omitempty" json:"claim,omitempty"`
+	Relationship      *CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Reference         *Identifier      `bson:"reference,omitempty" json:"reference,omitempty"`
 }
 type ClaimPayee struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Party             *Reference      `json:"party,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Party             *Reference      `bson:"party,omitempty" json:"party,omitempty"`
 }
 type ClaimCareTeam struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Sequence          int              `json:"sequence"`
-	Provider          Reference        `json:"provider"`
-	Responsible       *bool            `json:"responsible,omitempty"`
-	Role              *CodeableConcept `json:"role,omitempty"`
-	Qualification     *CodeableConcept `json:"qualification,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int              `bson:"sequence" json:"sequence"`
+	Provider          Reference        `bson:"provider" json:"provider"`
+	Responsible       *bool            `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Role              *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Qualification     *CodeableConcept `bson:"qualification,omitempty" json:"qualification,omitempty"`
 }
 type ClaimSupportingInfo struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Sequence          int              `json:"sequence"`
-	Category          CodeableConcept  `json:"category"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Reason            *CodeableConcept `json:"reason,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int              `bson:"sequence" json:"sequence"`
+	Category          CodeableConcept  `bson:"category" json:"category"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Reason            *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 }
 type ClaimDiagnosis struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Sequence          int               `json:"sequence"`
-	Type              []CodeableConcept `json:"type,omitempty"`
-	OnAdmission       *CodeableConcept  `json:"onAdmission,omitempty"`
-	PackageCode       *CodeableConcept  `json:"packageCode,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int               `bson:"sequence" json:"sequence"`
+	Type              []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	OnAdmission       *CodeableConcept  `bson:"onAdmission,omitempty" json:"onAdmission,omitempty"`
+	PackageCode       *CodeableConcept  `bson:"packageCode,omitempty" json:"packageCode,omitempty"`
 }
 type ClaimProcedure struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Sequence          int               `json:"sequence"`
-	Type              []CodeableConcept `json:"type,omitempty"`
-	Date              *string           `json:"date,omitempty"`
-	Udi               []Reference       `json:"udi,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int               `bson:"sequence" json:"sequence"`
+	Type              []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Date              *string           `bson:"date,omitempty" json:"date,omitempty"`
+	Udi               []Reference       `bson:"udi,omitempty" json:"udi,omitempty"`
 }
 type ClaimInsurance struct {
-	Id                  *string     `json:"id,omitempty"`
-	Extension           []Extension `json:"extension,omitempty"`
-	ModifierExtension   []Extension `json:"modifierExtension,omitempty"`
-	Sequence            int         `json:"sequence"`
-	Focal               bool        `json:"focal"`
-	Identifier          *Identifier `json:"identifier,omitempty"`
-	Coverage            Reference   `json:"coverage"`
-	BusinessArrangement *string     `json:"businessArrangement,omitempty"`
-	PreAuthRef          []string    `json:"preAuthRef,omitempty"`
-	ClaimResponse       *Reference  `json:"claimResponse,omitempty"`
+	Id                  *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence            int         `bson:"sequence" json:"sequence"`
+	Focal               bool        `bson:"focal" json:"focal"`
+	Identifier          *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Coverage            Reference   `bson:"coverage" json:"coverage"`
+	BusinessArrangement *string     `bson:"businessArrangement,omitempty" json:"businessArrangement,omitempty"`
+	PreAuthRef          []string    `bson:"preAuthRef,omitempty" json:"preAuthRef,omitempty"`
+	ClaimResponse       *Reference  `bson:"claimResponse,omitempty" json:"claimResponse,omitempty"`
 }
 type ClaimAccident struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Date              string           `json:"date"`
-	Type              *CodeableConcept `json:"type,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Date              string           `bson:"date" json:"date"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 }
 type ClaimItem struct {
-	Id                  *string           `json:"id,omitempty"`
-	Extension           []Extension       `json:"extension,omitempty"`
-	ModifierExtension   []Extension       `json:"modifierExtension,omitempty"`
-	Sequence            int               `json:"sequence"`
-	CareTeamSequence    []int             `json:"careTeamSequence,omitempty"`
-	DiagnosisSequence   []int             `json:"diagnosisSequence,omitempty"`
-	ProcedureSequence   []int             `json:"procedureSequence,omitempty"`
-	InformationSequence []int             `json:"informationSequence,omitempty"`
-	Revenue             *CodeableConcept  `json:"revenue,omitempty"`
-	Category            *CodeableConcept  `json:"category,omitempty"`
-	ProductOrService    CodeableConcept   `json:"productOrService"`
-	Modifier            []CodeableConcept `json:"modifier,omitempty"`
-	ProgramCode         []CodeableConcept `json:"programCode,omitempty"`
-	Quantity            *Quantity         `json:"quantity,omitempty"`
-	UnitPrice           *Money            `json:"unitPrice,omitempty"`
-	Factor              *string           `json:"factor,omitempty"`
-	Net                 *Money            `json:"net,omitempty"`
-	Udi                 []Reference       `json:"udi,omitempty"`
-	BodySite            *CodeableConcept  `json:"bodySite,omitempty"`
-	SubSite             []CodeableConcept `json:"subSite,omitempty"`
-	Encounter           []Reference       `json:"encounter,omitempty"`
-	Detail              []ClaimItemDetail `json:"detail,omitempty"`
+	Id                  *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence            int               `bson:"sequence" json:"sequence"`
+	CareTeamSequence    []int             `bson:"careTeamSequence,omitempty" json:"careTeamSequence,omitempty"`
+	DiagnosisSequence   []int             `bson:"diagnosisSequence,omitempty" json:"diagnosisSequence,omitempty"`
+	ProcedureSequence   []int             `bson:"procedureSequence,omitempty" json:"procedureSequence,omitempty"`
+	InformationSequence []int             `bson:"informationSequence,omitempty" json:"informationSequence,omitempty"`
+	Revenue             *CodeableConcept  `bson:"revenue,omitempty" json:"revenue,omitempty"`
+	Category            *CodeableConcept  `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService    CodeableConcept   `bson:"productOrService" json:"productOrService"`
+	Modifier            []CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode         []CodeableConcept `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity            *Quantity         `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice           *Money            `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor              *string           `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net                 *Money            `bson:"net,omitempty" json:"net,omitempty"`
+	Udi                 []Reference       `bson:"udi,omitempty" json:"udi,omitempty"`
+	BodySite            *CodeableConcept  `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	SubSite             []CodeableConcept `bson:"subSite,omitempty" json:"subSite,omitempty"`
+	Encounter           []Reference       `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Detail              []ClaimItemDetail `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type ClaimItemDetail struct {
-	Id                *string                    `json:"id,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Sequence          int                        `json:"sequence"`
-	Revenue           *CodeableConcept           `json:"revenue,omitempty"`
-	Category          *CodeableConcept           `json:"category,omitempty"`
-	ProductOrService  CodeableConcept            `json:"productOrService"`
-	Modifier          []CodeableConcept          `json:"modifier,omitempty"`
-	ProgramCode       []CodeableConcept          `json:"programCode,omitempty"`
-	Quantity          *Quantity                  `json:"quantity,omitempty"`
-	UnitPrice         *Money                     `json:"unitPrice,omitempty"`
-	Factor            *string                    `json:"factor,omitempty"`
-	Net               *Money                     `json:"net,omitempty"`
-	Udi               []Reference                `json:"udi,omitempty"`
-	SubDetail         []ClaimItemDetailSubDetail `json:"subDetail,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int                        `bson:"sequence" json:"sequence"`
+	Revenue           *CodeableConcept           `bson:"revenue,omitempty" json:"revenue,omitempty"`
+	Category          *CodeableConcept           `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService  CodeableConcept            `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept          `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode       []CodeableConcept          `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity          *Quantity                  `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                     `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                    `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                     `bson:"net,omitempty" json:"net,omitempty"`
+	Udi               []Reference                `bson:"udi,omitempty" json:"udi,omitempty"`
+	SubDetail         []ClaimItemDetailSubDetail `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 type ClaimItemDetailSubDetail struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Sequence          int               `json:"sequence"`
-	Revenue           *CodeableConcept  `json:"revenue,omitempty"`
-	Category          *CodeableConcept  `json:"category,omitempty"`
-	ProductOrService  CodeableConcept   `json:"productOrService"`
-	Modifier          []CodeableConcept `json:"modifier,omitempty"`
-	ProgramCode       []CodeableConcept `json:"programCode,omitempty"`
-	Quantity          *Quantity         `json:"quantity,omitempty"`
-	UnitPrice         *Money            `json:"unitPrice,omitempty"`
-	Factor            *string           `json:"factor,omitempty"`
-	Net               *Money            `json:"net,omitempty"`
-	Udi               []Reference       `json:"udi,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int               `bson:"sequence" json:"sequence"`
+	Revenue           *CodeableConcept  `bson:"revenue,omitempty" json:"revenue,omitempty"`
+	Category          *CodeableConcept  `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService  CodeableConcept   `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode       []CodeableConcept `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity          *Quantity         `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money            `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string           `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money            `bson:"net,omitempty" json:"net,omitempty"`
+	Udi               []Reference       `bson:"udi,omitempty" json:"udi,omitempty"`
 }
 type OtherClaim Claim
 

--- a/fhir-models/fhir/claimResponse.go
+++ b/fhir-models/fhir/claimResponse.go
@@ -21,169 +21,169 @@ import "encoding/json"
 
 // ClaimResponse is documented here http://hl7.org/fhir/StructureDefinition/ClaimResponse
 type ClaimResponse struct {
-	Id                   *string                         `json:"id,omitempty"`
-	Meta                 *Meta                           `json:"meta,omitempty"`
-	ImplicitRules        *string                         `json:"implicitRules,omitempty"`
-	Language             *string                         `json:"language,omitempty"`
-	Text                 *Narrative                      `json:"text,omitempty"`
-	Extension            []Extension                     `json:"extension,omitempty"`
-	ModifierExtension    []Extension                     `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier                    `json:"identifier,omitempty"`
-	Status               FinancialResourceStatusCodes    `json:"status"`
-	Type                 CodeableConcept                 `json:"type"`
-	SubType              *CodeableConcept                `json:"subType,omitempty"`
-	Use                  Use                             `json:"use"`
-	Patient              Reference                       `json:"patient"`
-	Created              string                          `json:"created"`
-	Insurer              Reference                       `json:"insurer"`
-	Requestor            *Reference                      `json:"requestor,omitempty"`
-	Request              *Reference                      `json:"request,omitempty"`
-	Outcome              ClaimProcessingCodes            `json:"outcome"`
-	Disposition          *string                         `json:"disposition,omitempty"`
-	PreAuthRef           *string                         `json:"preAuthRef,omitempty"`
-	PreAuthPeriod        *Period                         `json:"preAuthPeriod,omitempty"`
-	PayeeType            *CodeableConcept                `json:"payeeType,omitempty"`
-	Item                 []ClaimResponseItem             `json:"item,omitempty"`
-	AddItem              []ClaimResponseAddItem          `json:"addItem,omitempty"`
-	Adjudication         []ClaimResponseItemAdjudication `json:"adjudication,omitempty"`
-	Total                []ClaimResponseTotal            `json:"total,omitempty"`
-	Payment              *ClaimResponsePayment           `json:"payment,omitempty"`
-	FundsReserve         *CodeableConcept                `json:"fundsReserve,omitempty"`
-	FormCode             *CodeableConcept                `json:"formCode,omitempty"`
-	Form                 *Attachment                     `json:"form,omitempty"`
-	ProcessNote          []ClaimResponseProcessNote      `json:"processNote,omitempty"`
-	CommunicationRequest []Reference                     `json:"communicationRequest,omitempty"`
-	Insurance            []ClaimResponseInsurance        `json:"insurance,omitempty"`
-	Error                []ClaimResponseError            `json:"error,omitempty"`
+	Id                   *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string                         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string                         `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative                      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status               FinancialResourceStatusCodes    `bson:"status" json:"status"`
+	Type                 CodeableConcept                 `bson:"type" json:"type"`
+	SubType              *CodeableConcept                `bson:"subType,omitempty" json:"subType,omitempty"`
+	Use                  Use                             `bson:"use" json:"use"`
+	Patient              Reference                       `bson:"patient" json:"patient"`
+	Created              string                          `bson:"created" json:"created"`
+	Insurer              Reference                       `bson:"insurer" json:"insurer"`
+	Requestor            *Reference                      `bson:"requestor,omitempty" json:"requestor,omitempty"`
+	Request              *Reference                      `bson:"request,omitempty" json:"request,omitempty"`
+	Outcome              ClaimProcessingCodes            `bson:"outcome" json:"outcome"`
+	Disposition          *string                         `bson:"disposition,omitempty" json:"disposition,omitempty"`
+	PreAuthRef           *string                         `bson:"preAuthRef,omitempty" json:"preAuthRef,omitempty"`
+	PreAuthPeriod        *Period                         `bson:"preAuthPeriod,omitempty" json:"preAuthPeriod,omitempty"`
+	PayeeType            *CodeableConcept                `bson:"payeeType,omitempty" json:"payeeType,omitempty"`
+	Item                 []ClaimResponseItem             `bson:"item,omitempty" json:"item,omitempty"`
+	AddItem              []ClaimResponseAddItem          `bson:"addItem,omitempty" json:"addItem,omitempty"`
+	Adjudication         []ClaimResponseItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	Total                []ClaimResponseTotal            `bson:"total,omitempty" json:"total,omitempty"`
+	Payment              *ClaimResponsePayment           `bson:"payment,omitempty" json:"payment,omitempty"`
+	FundsReserve         *CodeableConcept                `bson:"fundsReserve,omitempty" json:"fundsReserve,omitempty"`
+	FormCode             *CodeableConcept                `bson:"formCode,omitempty" json:"formCode,omitempty"`
+	Form                 *Attachment                     `bson:"form,omitempty" json:"form,omitempty"`
+	ProcessNote          []ClaimResponseProcessNote      `bson:"processNote,omitempty" json:"processNote,omitempty"`
+	CommunicationRequest []Reference                     `bson:"communicationRequest,omitempty" json:"communicationRequest,omitempty"`
+	Insurance            []ClaimResponseInsurance        `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	Error                []ClaimResponseError            `bson:"error,omitempty" json:"error,omitempty"`
 }
 type ClaimResponseItem struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	ItemSequence      int                             `json:"itemSequence"`
-	NoteNumber        []int                           `json:"noteNumber,omitempty"`
-	Adjudication      []ClaimResponseItemAdjudication `json:"adjudication"`
-	Detail            []ClaimResponseItemDetail       `json:"detail,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ItemSequence      int                             `bson:"itemSequence" json:"itemSequence"`
+	NoteNumber        []int                           `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ClaimResponseItemAdjudication `bson:"adjudication" json:"adjudication"`
+	Detail            []ClaimResponseItemDetail       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type ClaimResponseItemAdjudication struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Category          CodeableConcept  `json:"category"`
-	Reason            *CodeableConcept `json:"reason,omitempty"`
-	Amount            *Money           `json:"amount,omitempty"`
-	Value             *string          `json:"value,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          CodeableConcept  `bson:"category" json:"category"`
+	Reason            *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
+	Amount            *Money           `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value             *string          `bson:"value,omitempty" json:"value,omitempty"`
 }
 type ClaimResponseItemDetail struct {
-	Id                *string                            `json:"id,omitempty"`
-	Extension         []Extension                        `json:"extension,omitempty"`
-	ModifierExtension []Extension                        `json:"modifierExtension,omitempty"`
-	DetailSequence    int                                `json:"detailSequence"`
-	NoteNumber        []int                              `json:"noteNumber,omitempty"`
-	Adjudication      []ClaimResponseItemAdjudication    `json:"adjudication,omitempty"`
-	SubDetail         []ClaimResponseItemDetailSubDetail `json:"subDetail,omitempty"`
+	Id                *string                            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DetailSequence    int                                `bson:"detailSequence" json:"detailSequence"`
+	NoteNumber        []int                              `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ClaimResponseItemAdjudication    `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	SubDetail         []ClaimResponseItemDetailSubDetail `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 type ClaimResponseItemDetailSubDetail struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	SubDetailSequence int                             `json:"subDetailSequence"`
-	NoteNumber        []int                           `json:"noteNumber,omitempty"`
-	Adjudication      []ClaimResponseItemAdjudication `json:"adjudication,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SubDetailSequence int                             `bson:"subDetailSequence" json:"subDetailSequence"`
+	NoteNumber        []int                           `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ClaimResponseItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
 }
 type ClaimResponseAddItem struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	ItemSequence      []int                           `json:"itemSequence,omitempty"`
-	DetailSequence    []int                           `json:"detailSequence,omitempty"`
-	SubdetailSequence []int                           `json:"subdetailSequence,omitempty"`
-	Provider          []Reference                     `json:"provider,omitempty"`
-	ProductOrService  CodeableConcept                 `json:"productOrService"`
-	Modifier          []CodeableConcept               `json:"modifier,omitempty"`
-	ProgramCode       []CodeableConcept               `json:"programCode,omitempty"`
-	Quantity          *Quantity                       `json:"quantity,omitempty"`
-	UnitPrice         *Money                          `json:"unitPrice,omitempty"`
-	Factor            *string                         `json:"factor,omitempty"`
-	Net               *Money                          `json:"net,omitempty"`
-	BodySite          *CodeableConcept                `json:"bodySite,omitempty"`
-	SubSite           []CodeableConcept               `json:"subSite,omitempty"`
-	NoteNumber        []int                           `json:"noteNumber,omitempty"`
-	Adjudication      []ClaimResponseItemAdjudication `json:"adjudication,omitempty"`
-	Detail            []ClaimResponseAddItemDetail    `json:"detail,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ItemSequence      []int                           `bson:"itemSequence,omitempty" json:"itemSequence,omitempty"`
+	DetailSequence    []int                           `bson:"detailSequence,omitempty" json:"detailSequence,omitempty"`
+	SubdetailSequence []int                           `bson:"subdetailSequence,omitempty" json:"subdetailSequence,omitempty"`
+	Provider          []Reference                     `bson:"provider,omitempty" json:"provider,omitempty"`
+	ProductOrService  CodeableConcept                 `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept               `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode       []CodeableConcept               `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity          *Quantity                       `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                          `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                         `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                          `bson:"net,omitempty" json:"net,omitempty"`
+	BodySite          *CodeableConcept                `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	SubSite           []CodeableConcept               `bson:"subSite,omitempty" json:"subSite,omitempty"`
+	NoteNumber        []int                           `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ClaimResponseItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	Detail            []ClaimResponseAddItemDetail    `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type ClaimResponseAddItemDetail struct {
-	Id                *string                               `json:"id,omitempty"`
-	Extension         []Extension                           `json:"extension,omitempty"`
-	ModifierExtension []Extension                           `json:"modifierExtension,omitempty"`
-	ProductOrService  CodeableConcept                       `json:"productOrService"`
-	Modifier          []CodeableConcept                     `json:"modifier,omitempty"`
-	Quantity          *Quantity                             `json:"quantity,omitempty"`
-	UnitPrice         *Money                                `json:"unitPrice,omitempty"`
-	Factor            *string                               `json:"factor,omitempty"`
-	Net               *Money                                `json:"net,omitempty"`
-	NoteNumber        []int                                 `json:"noteNumber,omitempty"`
-	Adjudication      []ClaimResponseItemAdjudication       `json:"adjudication,omitempty"`
-	SubDetail         []ClaimResponseAddItemDetailSubDetail `json:"subDetail,omitempty"`
+	Id                *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ProductOrService  CodeableConcept                       `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept                     `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Quantity          *Quantity                             `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                                `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                               `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                                `bson:"net,omitempty" json:"net,omitempty"`
+	NoteNumber        []int                                 `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ClaimResponseItemAdjudication       `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	SubDetail         []ClaimResponseAddItemDetailSubDetail `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 type ClaimResponseAddItemDetailSubDetail struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	ProductOrService  CodeableConcept                 `json:"productOrService"`
-	Modifier          []CodeableConcept               `json:"modifier,omitempty"`
-	Quantity          *Quantity                       `json:"quantity,omitempty"`
-	UnitPrice         *Money                          `json:"unitPrice,omitempty"`
-	Factor            *string                         `json:"factor,omitempty"`
-	Net               *Money                          `json:"net,omitempty"`
-	NoteNumber        []int                           `json:"noteNumber,omitempty"`
-	Adjudication      []ClaimResponseItemAdjudication `json:"adjudication,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ProductOrService  CodeableConcept                 `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept               `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Quantity          *Quantity                       `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                          `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                         `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                          `bson:"net,omitempty" json:"net,omitempty"`
+	NoteNumber        []int                           `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ClaimResponseItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
 }
 type ClaimResponseTotal struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Category          CodeableConcept `json:"category"`
-	Amount            Money           `json:"amount"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          CodeableConcept `bson:"category" json:"category"`
+	Amount            Money           `bson:"amount" json:"amount"`
 }
 type ClaimResponsePayment struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept  `json:"type"`
-	Adjustment        *Money           `json:"adjustment,omitempty"`
-	AdjustmentReason  *CodeableConcept `json:"adjustmentReason,omitempty"`
-	Date              *string          `json:"date,omitempty"`
-	Amount            Money            `json:"amount"`
-	Identifier        *Identifier      `json:"identifier,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept  `bson:"type" json:"type"`
+	Adjustment        *Money           `bson:"adjustment,omitempty" json:"adjustment,omitempty"`
+	AdjustmentReason  *CodeableConcept `bson:"adjustmentReason,omitempty" json:"adjustmentReason,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
+	Amount            Money            `bson:"amount" json:"amount"`
+	Identifier        *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 }
 type ClaimResponseProcessNote struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Number            *int             `json:"number,omitempty"`
-	Type              *NoteType        `json:"type,omitempty"`
-	Text              string           `json:"text"`
-	Language          *CodeableConcept `json:"language,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Number            *int             `bson:"number,omitempty" json:"number,omitempty"`
+	Type              *NoteType        `bson:"type,omitempty" json:"type,omitempty"`
+	Text              string           `bson:"text" json:"text"`
+	Language          *CodeableConcept `bson:"language,omitempty" json:"language,omitempty"`
 }
 type ClaimResponseInsurance struct {
-	Id                  *string     `json:"id,omitempty"`
-	Extension           []Extension `json:"extension,omitempty"`
-	ModifierExtension   []Extension `json:"modifierExtension,omitempty"`
-	Sequence            int         `json:"sequence"`
-	Focal               bool        `json:"focal"`
-	Coverage            Reference   `json:"coverage"`
-	BusinessArrangement *string     `json:"businessArrangement,omitempty"`
-	ClaimResponse       *Reference  `json:"claimResponse,omitempty"`
+	Id                  *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence            int         `bson:"sequence" json:"sequence"`
+	Focal               bool        `bson:"focal" json:"focal"`
+	Coverage            Reference   `bson:"coverage" json:"coverage"`
+	BusinessArrangement *string     `bson:"businessArrangement,omitempty" json:"businessArrangement,omitempty"`
+	ClaimResponse       *Reference  `bson:"claimResponse,omitempty" json:"claimResponse,omitempty"`
 }
 type ClaimResponseError struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	ItemSequence      *int            `json:"itemSequence,omitempty"`
-	DetailSequence    *int            `json:"detailSequence,omitempty"`
-	SubDetailSequence *int            `json:"subDetailSequence,omitempty"`
-	Code              CodeableConcept `json:"code"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ItemSequence      *int            `bson:"itemSequence,omitempty" json:"itemSequence,omitempty"`
+	DetailSequence    *int            `bson:"detailSequence,omitempty" json:"detailSequence,omitempty"`
+	SubDetailSequence *int            `bson:"subDetailSequence,omitempty" json:"subDetailSequence,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
 }
 type OtherClaimResponse ClaimResponse
 

--- a/fhir-models/fhir/clinicalImpression.go
+++ b/fhir-models/fhir/clinicalImpression.go
@@ -21,47 +21,47 @@ import "encoding/json"
 
 // ClinicalImpression is documented here http://hl7.org/fhir/StructureDefinition/ClinicalImpression
 type ClinicalImpression struct {
-	Id                       *string                           `json:"id,omitempty"`
-	Meta                     *Meta                             `json:"meta,omitempty"`
-	ImplicitRules            *string                           `json:"implicitRules,omitempty"`
-	Language                 *string                           `json:"language,omitempty"`
-	Text                     *Narrative                        `json:"text,omitempty"`
-	Extension                []Extension                       `json:"extension,omitempty"`
-	ModifierExtension        []Extension                       `json:"modifierExtension,omitempty"`
-	Identifier               []Identifier                      `json:"identifier,omitempty"`
-	Status                   ClinicalImpressionStatus          `json:"status"`
-	StatusReason             *CodeableConcept                  `json:"statusReason,omitempty"`
-	Code                     *CodeableConcept                  `json:"code,omitempty"`
-	Description              *string                           `json:"description,omitempty"`
-	Subject                  Reference                         `json:"subject"`
-	Encounter                *Reference                        `json:"encounter,omitempty"`
-	Date                     *string                           `json:"date,omitempty"`
-	Assessor                 *Reference                        `json:"assessor,omitempty"`
-	Previous                 *Reference                        `json:"previous,omitempty"`
-	Problem                  []Reference                       `json:"problem,omitempty"`
-	Investigation            []ClinicalImpressionInvestigation `json:"investigation,omitempty"`
-	Protocol                 []string                          `json:"protocol,omitempty"`
-	Summary                  *string                           `json:"summary,omitempty"`
-	Finding                  []ClinicalImpressionFinding       `json:"finding,omitempty"`
-	PrognosisCodeableConcept []CodeableConcept                 `json:"prognosisCodeableConcept,omitempty"`
-	PrognosisReference       []Reference                       `json:"prognosisReference,omitempty"`
-	SupportingInfo           []Reference                       `json:"supportingInfo,omitempty"`
-	Note                     []Annotation                      `json:"note,omitempty"`
+	Id                       *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                     *Meta                             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules            *string                           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                 *string                           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                     *Narrative                        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension        []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier               []Identifier                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status                   ClinicalImpressionStatus          `bson:"status" json:"status"`
+	StatusReason             *CodeableConcept                  `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Code                     *CodeableConcept                  `bson:"code,omitempty" json:"code,omitempty"`
+	Description              *string                           `bson:"description,omitempty" json:"description,omitempty"`
+	Subject                  Reference                         `bson:"subject" json:"subject"`
+	Encounter                *Reference                        `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Date                     *string                           `bson:"date,omitempty" json:"date,omitempty"`
+	Assessor                 *Reference                        `bson:"assessor,omitempty" json:"assessor,omitempty"`
+	Previous                 *Reference                        `bson:"previous,omitempty" json:"previous,omitempty"`
+	Problem                  []Reference                       `bson:"problem,omitempty" json:"problem,omitempty"`
+	Investigation            []ClinicalImpressionInvestigation `bson:"investigation,omitempty" json:"investigation,omitempty"`
+	Protocol                 []string                          `bson:"protocol,omitempty" json:"protocol,omitempty"`
+	Summary                  *string                           `bson:"summary,omitempty" json:"summary,omitempty"`
+	Finding                  []ClinicalImpressionFinding       `bson:"finding,omitempty" json:"finding,omitempty"`
+	PrognosisCodeableConcept []CodeableConcept                 `bson:"prognosisCodeableConcept,omitempty" json:"prognosisCodeableConcept,omitempty"`
+	PrognosisReference       []Reference                       `bson:"prognosisReference,omitempty" json:"prognosisReference,omitempty"`
+	SupportingInfo           []Reference                       `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Note                     []Annotation                      `bson:"note,omitempty" json:"note,omitempty"`
 }
 type ClinicalImpressionInvestigation struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept `json:"code"`
-	Item              []Reference     `json:"item,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
+	Item              []Reference     `bson:"item,omitempty" json:"item,omitempty"`
 }
 type ClinicalImpressionFinding struct {
-	Id                  *string          `json:"id,omitempty"`
-	Extension           []Extension      `json:"extension,omitempty"`
-	ModifierExtension   []Extension      `json:"modifierExtension,omitempty"`
-	ItemCodeableConcept *CodeableConcept `json:"itemCodeableConcept,omitempty"`
-	ItemReference       *Reference       `json:"itemReference,omitempty"`
-	Basis               *string          `json:"basis,omitempty"`
+	Id                  *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ItemCodeableConcept *CodeableConcept `bson:"itemCodeableConcept,omitempty" json:"itemCodeableConcept,omitempty"`
+	ItemReference       *Reference       `bson:"itemReference,omitempty" json:"itemReference,omitempty"`
+	Basis               *string          `bson:"basis,omitempty" json:"basis,omitempty"`
 }
 type OtherClinicalImpression ClinicalImpression
 

--- a/fhir-models/fhir/codeSystem.go
+++ b/fhir-models/fhir/codeSystem.go
@@ -21,82 +21,82 @@ import "encoding/json"
 
 // CodeSystem is documented here http://hl7.org/fhir/StructureDefinition/CodeSystem
 type CodeSystem struct {
-	Id                *string                     `json:"id,omitempty"`
-	Meta              *Meta                       `json:"meta,omitempty"`
-	ImplicitRules     *string                     `json:"implicitRules,omitempty"`
-	Language          *string                     `json:"language,omitempty"`
-	Text              *Narrative                  `json:"text,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Url               *string                     `json:"url,omitempty"`
-	Identifier        []Identifier                `json:"identifier,omitempty"`
-	Version           *string                     `json:"version,omitempty"`
-	Name              *string                     `json:"name,omitempty"`
-	Title             *string                     `json:"title,omitempty"`
-	Status            PublicationStatus           `json:"status"`
-	Experimental      *bool                       `json:"experimental,omitempty"`
-	Date              *string                     `json:"date,omitempty"`
-	Publisher         *string                     `json:"publisher,omitempty"`
-	Contact           []ContactDetail             `json:"contact,omitempty"`
-	Description       *string                     `json:"description,omitempty"`
-	UseContext        []UsageContext              `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept           `json:"jurisdiction,omitempty"`
-	Purpose           *string                     `json:"purpose,omitempty"`
-	Copyright         *string                     `json:"copyright,omitempty"`
-	CaseSensitive     *bool                       `json:"caseSensitive,omitempty"`
-	ValueSet          *string                     `json:"valueSet,omitempty"`
-	HierarchyMeaning  *CodeSystemHierarchyMeaning `json:"hierarchyMeaning,omitempty"`
-	Compositional     *bool                       `json:"compositional,omitempty"`
-	VersionNeeded     *bool                       `json:"versionNeeded,omitempty"`
-	Content           CodeSystemContentMode       `json:"content"`
-	Supplements       *string                     `json:"supplements,omitempty"`
-	Count             *int                        `json:"count,omitempty"`
-	Filter            []CodeSystemFilter          `json:"filter,omitempty"`
-	Property          []CodeSystemProperty        `json:"property,omitempty"`
-	Concept           []CodeSystemConcept         `json:"concept,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                     `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier                `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                     `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                     `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                     `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus           `bson:"status" json:"status"`
+	Experimental      *bool                       `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                     `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                     `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail             `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                     `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext              `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept           `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                     `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                     `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	CaseSensitive     *bool                       `bson:"caseSensitive,omitempty" json:"caseSensitive,omitempty"`
+	ValueSet          *string                     `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
+	HierarchyMeaning  *CodeSystemHierarchyMeaning `bson:"hierarchyMeaning,omitempty" json:"hierarchyMeaning,omitempty"`
+	Compositional     *bool                       `bson:"compositional,omitempty" json:"compositional,omitempty"`
+	VersionNeeded     *bool                       `bson:"versionNeeded,omitempty" json:"versionNeeded,omitempty"`
+	Content           CodeSystemContentMode       `bson:"content" json:"content"`
+	Supplements       *string                     `bson:"supplements,omitempty" json:"supplements,omitempty"`
+	Count             *int                        `bson:"count,omitempty" json:"count,omitempty"`
+	Filter            []CodeSystemFilter          `bson:"filter,omitempty" json:"filter,omitempty"`
+	Property          []CodeSystemProperty        `bson:"property,omitempty" json:"property,omitempty"`
+	Concept           []CodeSystemConcept         `bson:"concept,omitempty" json:"concept,omitempty"`
 }
 type CodeSystemFilter struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              string           `json:"code"`
-	Description       *string          `json:"description,omitempty"`
-	Operator          []FilterOperator `json:"operator"`
-	Value             string           `json:"value"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string           `bson:"code" json:"code"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Operator          []FilterOperator `bson:"operator" json:"operator"`
+	Value             string           `bson:"value" json:"value"`
 }
 type CodeSystemProperty struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Code              string       `json:"code"`
-	Uri               *string      `json:"uri,omitempty"`
-	Description       *string      `json:"description,omitempty"`
-	Type              PropertyType `json:"type"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string       `bson:"code" json:"code"`
+	Uri               *string      `bson:"uri,omitempty" json:"uri,omitempty"`
+	Description       *string      `bson:"description,omitempty" json:"description,omitempty"`
+	Type              PropertyType `bson:"type" json:"type"`
 }
 type CodeSystemConcept struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Code              string                         `json:"code"`
-	Display           *string                        `json:"display,omitempty"`
-	Definition        *string                        `json:"definition,omitempty"`
-	Designation       []CodeSystemConceptDesignation `json:"designation,omitempty"`
-	Property          []CodeSystemConceptProperty    `json:"property,omitempty"`
-	Concept           []CodeSystemConcept            `json:"concept,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string                         `bson:"code" json:"code"`
+	Display           *string                        `bson:"display,omitempty" json:"display,omitempty"`
+	Definition        *string                        `bson:"definition,omitempty" json:"definition,omitempty"`
+	Designation       []CodeSystemConceptDesignation `bson:"designation,omitempty" json:"designation,omitempty"`
+	Property          []CodeSystemConceptProperty    `bson:"property,omitempty" json:"property,omitempty"`
+	Concept           []CodeSystemConcept            `bson:"concept,omitempty" json:"concept,omitempty"`
 }
 type CodeSystemConceptDesignation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Language          *string     `json:"language,omitempty"`
-	Use               *Coding     `json:"use,omitempty"`
-	Value             string      `json:"value"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Language          *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Use               *Coding     `bson:"use,omitempty" json:"use,omitempty"`
+	Value             string      `bson:"value" json:"value"`
 }
 type CodeSystemConceptProperty struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Code              string      `json:"code"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string      `bson:"code" json:"code"`
 }
 type OtherCodeSystem CodeSystem
 

--- a/fhir-models/fhir/codeableConcept.go
+++ b/fhir-models/fhir/codeableConcept.go
@@ -19,8 +19,8 @@ package fhir
 
 // CodeableConcept is documented here http://hl7.org/fhir/StructureDefinition/CodeableConcept
 type CodeableConcept struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Coding    []Coding    `json:"coding,omitempty"`
-	Text      *string     `json:"text,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Coding    []Coding    `bson:"coding,omitempty" json:"coding,omitempty"`
+	Text      *string     `bson:"text,omitempty" json:"text,omitempty"`
 }

--- a/fhir-models/fhir/coding.go
+++ b/fhir-models/fhir/coding.go
@@ -19,11 +19,11 @@ package fhir
 
 // Coding is documented here http://hl7.org/fhir/StructureDefinition/Coding
 type Coding struct {
-	Id           *string     `json:"id,omitempty"`
-	Extension    []Extension `json:"extension,omitempty"`
-	System       *string     `json:"system,omitempty"`
-	Version      *string     `json:"version,omitempty"`
-	Code         *string     `json:"code,omitempty"`
-	Display      *string     `json:"display,omitempty"`
-	UserSelected *bool       `json:"userSelected,omitempty"`
+	Id           *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	System       *string     `bson:"system,omitempty" json:"system,omitempty"`
+	Version      *string     `bson:"version,omitempty" json:"version,omitempty"`
+	Code         *string     `bson:"code,omitempty" json:"code,omitempty"`
+	Display      *string     `bson:"display,omitempty" json:"display,omitempty"`
+	UserSelected *bool       `bson:"userSelected,omitempty" json:"userSelected,omitempty"`
 }

--- a/fhir-models/fhir/communication.go
+++ b/fhir-models/fhir/communication.go
@@ -21,41 +21,41 @@ import "encoding/json"
 
 // Communication is documented here http://hl7.org/fhir/StructureDefinition/Communication
 type Communication struct {
-	Id                    *string                `json:"id,omitempty"`
-	Meta                  *Meta                  `json:"meta,omitempty"`
-	ImplicitRules         *string                `json:"implicitRules,omitempty"`
-	Language              *string                `json:"language,omitempty"`
-	Text                  *Narrative             `json:"text,omitempty"`
-	Extension             []Extension            `json:"extension,omitempty"`
-	ModifierExtension     []Extension            `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier           `json:"identifier,omitempty"`
-	InstantiatesCanonical []string               `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string               `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference            `json:"basedOn,omitempty"`
-	PartOf                []Reference            `json:"partOf,omitempty"`
-	InResponseTo          []Reference            `json:"inResponseTo,omitempty"`
-	Status                EventStatus            `json:"status"`
-	StatusReason          *CodeableConcept       `json:"statusReason,omitempty"`
-	Category              []CodeableConcept      `json:"category,omitempty"`
-	Priority              *RequestPriority       `json:"priority,omitempty"`
-	Medium                []CodeableConcept      `json:"medium,omitempty"`
-	Subject               *Reference             `json:"subject,omitempty"`
-	Topic                 *CodeableConcept       `json:"topic,omitempty"`
-	About                 []Reference            `json:"about,omitempty"`
-	Encounter             *Reference             `json:"encounter,omitempty"`
-	Sent                  *string                `json:"sent,omitempty"`
-	Received              *string                `json:"received,omitempty"`
-	Recipient             []Reference            `json:"recipient,omitempty"`
-	Sender                *Reference             `json:"sender,omitempty"`
-	ReasonCode            []CodeableConcept      `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference            `json:"reasonReference,omitempty"`
-	Payload               []CommunicationPayload `json:"payload,omitempty"`
-	Note                  []Annotation           `json:"note,omitempty"`
+	Id                    *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string               `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string               `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference            `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf                []Reference            `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	InResponseTo          []Reference            `bson:"inResponseTo,omitempty" json:"inResponseTo,omitempty"`
+	Status                EventStatus            `bson:"status" json:"status"`
+	StatusReason          *CodeableConcept       `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Category              []CodeableConcept      `bson:"category,omitempty" json:"category,omitempty"`
+	Priority              *RequestPriority       `bson:"priority,omitempty" json:"priority,omitempty"`
+	Medium                []CodeableConcept      `bson:"medium,omitempty" json:"medium,omitempty"`
+	Subject               *Reference             `bson:"subject,omitempty" json:"subject,omitempty"`
+	Topic                 *CodeableConcept       `bson:"topic,omitempty" json:"topic,omitempty"`
+	About                 []Reference            `bson:"about,omitempty" json:"about,omitempty"`
+	Encounter             *Reference             `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Sent                  *string                `bson:"sent,omitempty" json:"sent,omitempty"`
+	Received              *string                `bson:"received,omitempty" json:"received,omitempty"`
+	Recipient             []Reference            `bson:"recipient,omitempty" json:"recipient,omitempty"`
+	Sender                *Reference             `bson:"sender,omitempty" json:"sender,omitempty"`
+	ReasonCode            []CodeableConcept      `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference            `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Payload               []CommunicationPayload `bson:"payload,omitempty" json:"payload,omitempty"`
+	Note                  []Annotation           `bson:"note,omitempty" json:"note,omitempty"`
 }
 type CommunicationPayload struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherCommunication Communication
 

--- a/fhir-models/fhir/communicationRequest.go
+++ b/fhir-models/fhir/communicationRequest.go
@@ -21,39 +21,39 @@ import "encoding/json"
 
 // CommunicationRequest is documented here http://hl7.org/fhir/StructureDefinition/CommunicationRequest
 type CommunicationRequest struct {
-	Id                *string                       `json:"id,omitempty"`
-	Meta              *Meta                         `json:"meta,omitempty"`
-	ImplicitRules     *string                       `json:"implicitRules,omitempty"`
-	Language          *string                       `json:"language,omitempty"`
-	Text              *Narrative                    `json:"text,omitempty"`
-	Extension         []Extension                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                   `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                  `json:"identifier,omitempty"`
-	BasedOn           []Reference                   `json:"basedOn,omitempty"`
-	Replaces          []Reference                   `json:"replaces,omitempty"`
-	GroupIdentifier   *Identifier                   `json:"groupIdentifier,omitempty"`
-	Status            RequestStatus                 `json:"status"`
-	StatusReason      *CodeableConcept              `json:"statusReason,omitempty"`
-	Category          []CodeableConcept             `json:"category,omitempty"`
-	Priority          *RequestPriority              `json:"priority,omitempty"`
-	DoNotPerform      *bool                         `json:"doNotPerform,omitempty"`
-	Medium            []CodeableConcept             `json:"medium,omitempty"`
-	Subject           *Reference                    `json:"subject,omitempty"`
-	About             []Reference                   `json:"about,omitempty"`
-	Encounter         *Reference                    `json:"encounter,omitempty"`
-	Payload           []CommunicationRequestPayload `json:"payload,omitempty"`
-	AuthoredOn        *string                       `json:"authoredOn,omitempty"`
-	Requester         *Reference                    `json:"requester,omitempty"`
-	Recipient         []Reference                   `json:"recipient,omitempty"`
-	Sender            *Reference                    `json:"sender,omitempty"`
-	ReasonCode        []CodeableConcept             `json:"reasonCode,omitempty"`
-	ReasonReference   []Reference                   `json:"reasonReference,omitempty"`
-	Note              []Annotation                  `json:"note,omitempty"`
+	Id                *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference                   `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Replaces          []Reference                   `bson:"replaces,omitempty" json:"replaces,omitempty"`
+	GroupIdentifier   *Identifier                   `bson:"groupIdentifier,omitempty" json:"groupIdentifier,omitempty"`
+	Status            RequestStatus                 `bson:"status" json:"status"`
+	StatusReason      *CodeableConcept              `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Category          []CodeableConcept             `bson:"category,omitempty" json:"category,omitempty"`
+	Priority          *RequestPriority              `bson:"priority,omitempty" json:"priority,omitempty"`
+	DoNotPerform      *bool                         `bson:"doNotPerform,omitempty" json:"doNotPerform,omitempty"`
+	Medium            []CodeableConcept             `bson:"medium,omitempty" json:"medium,omitempty"`
+	Subject           *Reference                    `bson:"subject,omitempty" json:"subject,omitempty"`
+	About             []Reference                   `bson:"about,omitempty" json:"about,omitempty"`
+	Encounter         *Reference                    `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Payload           []CommunicationRequestPayload `bson:"payload,omitempty" json:"payload,omitempty"`
+	AuthoredOn        *string                       `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	Requester         *Reference                    `bson:"requester,omitempty" json:"requester,omitempty"`
+	Recipient         []Reference                   `bson:"recipient,omitempty" json:"recipient,omitempty"`
+	Sender            *Reference                    `bson:"sender,omitempty" json:"sender,omitempty"`
+	ReasonCode        []CodeableConcept             `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference   []Reference                   `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Note              []Annotation                  `bson:"note,omitempty" json:"note,omitempty"`
 }
 type CommunicationRequestPayload struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherCommunicationRequest CommunicationRequest
 

--- a/fhir-models/fhir/compartmentDefinition.go
+++ b/fhir-models/fhir/compartmentDefinition.go
@@ -21,35 +21,35 @@ import "encoding/json"
 
 // CompartmentDefinition is documented here http://hl7.org/fhir/StructureDefinition/CompartmentDefinition
 type CompartmentDefinition struct {
-	Id                *string                         `json:"id,omitempty"`
-	Meta              *Meta                           `json:"meta,omitempty"`
-	ImplicitRules     *string                         `json:"implicitRules,omitempty"`
-	Language          *string                         `json:"language,omitempty"`
-	Text              *Narrative                      `json:"text,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Url               string                          `json:"url"`
-	Version           *string                         `json:"version,omitempty"`
-	Name              string                          `json:"name"`
-	Status            PublicationStatus               `json:"status"`
-	Experimental      *bool                           `json:"experimental,omitempty"`
-	Date              *string                         `json:"date,omitempty"`
-	Publisher         *string                         `json:"publisher,omitempty"`
-	Contact           []ContactDetail                 `json:"contact,omitempty"`
-	Description       *string                         `json:"description,omitempty"`
-	UseContext        []UsageContext                  `json:"useContext,omitempty"`
-	Purpose           *string                         `json:"purpose,omitempty"`
-	Code              CompartmentType                 `json:"code"`
-	Search            bool                            `json:"search"`
-	Resource          []CompartmentDefinitionResource `json:"resource,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                         `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                          `bson:"url" json:"url"`
+	Version           *string                         `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                          `bson:"name" json:"name"`
+	Status            PublicationStatus               `bson:"status" json:"status"`
+	Experimental      *bool                           `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                         `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                         `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                 `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                         `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                  `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Purpose           *string                         `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Code              CompartmentType                 `bson:"code" json:"code"`
+	Search            bool                            `bson:"search" json:"search"`
+	Resource          []CompartmentDefinitionResource `bson:"resource,omitempty" json:"resource,omitempty"`
 }
 type CompartmentDefinitionResource struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Code              ResourceType `json:"code"`
-	Param             []string     `json:"param,omitempty"`
-	Documentation     *string      `json:"documentation,omitempty"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              ResourceType `bson:"code" json:"code"`
+	Param             []string     `bson:"param,omitempty" json:"param,omitempty"`
+	Documentation     *string      `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type OtherCompartmentDefinition CompartmentDefinition
 

--- a/fhir-models/fhir/composition.go
+++ b/fhir-models/fhir/composition.go
@@ -21,65 +21,65 @@ import "encoding/json"
 
 // Composition is documented here http://hl7.org/fhir/StructureDefinition/Composition
 type Composition struct {
-	Id                *string                `json:"id,omitempty"`
-	Meta              *Meta                  `json:"meta,omitempty"`
-	ImplicitRules     *string                `json:"implicitRules,omitempty"`
-	Language          *string                `json:"language,omitempty"`
-	Text              *Narrative             `json:"text,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier            `json:"identifier,omitempty"`
-	Status            CompositionStatus      `json:"status"`
-	Type              CodeableConcept        `json:"type"`
-	Category          []CodeableConcept      `json:"category,omitempty"`
-	Subject           *Reference             `json:"subject,omitempty"`
-	Encounter         *Reference             `json:"encounter,omitempty"`
-	Date              string                 `json:"date"`
-	Author            []Reference            `json:"author"`
-	Title             string                 `json:"title"`
-	Confidentiality   *string                `json:"confidentiality,omitempty"`
-	Attester          []CompositionAttester  `json:"attester,omitempty"`
-	Custodian         *Reference             `json:"custodian,omitempty"`
-	RelatesTo         []CompositionRelatesTo `json:"relatesTo,omitempty"`
-	Event             []CompositionEvent     `json:"event,omitempty"`
-	Section           []CompositionSection   `json:"section,omitempty"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier            `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            CompositionStatus      `bson:"status" json:"status"`
+	Type              CodeableConcept        `bson:"type" json:"type"`
+	Category          []CodeableConcept      `bson:"category,omitempty" json:"category,omitempty"`
+	Subject           *Reference             `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter         *Reference             `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Date              string                 `bson:"date" json:"date"`
+	Author            []Reference            `bson:"author" json:"author"`
+	Title             string                 `bson:"title" json:"title"`
+	Confidentiality   *string                `bson:"confidentiality,omitempty" json:"confidentiality,omitempty"`
+	Attester          []CompositionAttester  `bson:"attester,omitempty" json:"attester,omitempty"`
+	Custodian         *Reference             `bson:"custodian,omitempty" json:"custodian,omitempty"`
+	RelatesTo         []CompositionRelatesTo `bson:"relatesTo,omitempty" json:"relatesTo,omitempty"`
+	Event             []CompositionEvent     `bson:"event,omitempty" json:"event,omitempty"`
+	Section           []CompositionSection   `bson:"section,omitempty" json:"section,omitempty"`
 }
 type CompositionAttester struct {
-	Id                *string                    `json:"id,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Mode              CompositionAttestationMode `json:"mode"`
-	Time              *string                    `json:"time,omitempty"`
-	Party             *Reference                 `json:"party,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              CompositionAttestationMode `bson:"mode" json:"mode"`
+	Time              *string                    `bson:"time,omitempty" json:"time,omitempty"`
+	Party             *Reference                 `bson:"party,omitempty" json:"party,omitempty"`
 }
 type CompositionRelatesTo struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Code              DocumentRelationshipType `json:"code"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              DocumentRelationshipType `bson:"code" json:"code"`
 }
 type CompositionEvent struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Code              []CodeableConcept `json:"code,omitempty"`
-	Period            *Period           `json:"period,omitempty"`
-	Detail            []Reference       `json:"detail,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Period            *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Detail            []Reference       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type CompositionSection struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Title             *string              `json:"title,omitempty"`
-	Code              *CodeableConcept     `json:"code,omitempty"`
-	Author            []Reference          `json:"author,omitempty"`
-	Focus             *Reference           `json:"focus,omitempty"`
-	Text              *Narrative           `json:"text,omitempty"`
-	Mode              *ListMode            `json:"mode,omitempty"`
-	OrderedBy         *CodeableConcept     `json:"orderedBy,omitempty"`
-	Entry             []Reference          `json:"entry,omitempty"`
-	EmptyReason       *CodeableConcept     `json:"emptyReason,omitempty"`
-	Section           []CompositionSection `json:"section,omitempty"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Title             *string              `bson:"title,omitempty" json:"title,omitempty"`
+	Code              *CodeableConcept     `bson:"code,omitempty" json:"code,omitempty"`
+	Author            []Reference          `bson:"author,omitempty" json:"author,omitempty"`
+	Focus             *Reference           `bson:"focus,omitempty" json:"focus,omitempty"`
+	Text              *Narrative           `bson:"text,omitempty" json:"text,omitempty"`
+	Mode              *ListMode            `bson:"mode,omitempty" json:"mode,omitempty"`
+	OrderedBy         *CodeableConcept     `bson:"orderedBy,omitempty" json:"orderedBy,omitempty"`
+	Entry             []Reference          `bson:"entry,omitempty" json:"entry,omitempty"`
+	EmptyReason       *CodeableConcept     `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
+	Section           []CompositionSection `bson:"section,omitempty" json:"section,omitempty"`
 }
 type OtherComposition Composition
 

--- a/fhir-models/fhir/conceptMap.go
+++ b/fhir-models/fhir/conceptMap.go
@@ -21,77 +21,77 @@ import "encoding/json"
 
 // ConceptMap is documented here http://hl7.org/fhir/StructureDefinition/ConceptMap
 type ConceptMap struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Url               *string           `json:"url,omitempty"`
-	Identifier        *Identifier       `json:"identifier,omitempty"`
-	Version           *string           `json:"version,omitempty"`
-	Name              *string           `json:"name,omitempty"`
-	Title             *string           `json:"title,omitempty"`
-	Status            PublicationStatus `json:"status"`
-	Experimental      *bool             `json:"experimental,omitempty"`
-	Date              *string           `json:"date,omitempty"`
-	Publisher         *string           `json:"publisher,omitempty"`
-	Contact           []ContactDetail   `json:"contact,omitempty"`
-	Description       *string           `json:"description,omitempty"`
-	UseContext        []UsageContext    `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept `json:"jurisdiction,omitempty"`
-	Purpose           *string           `json:"purpose,omitempty"`
-	Copyright         *string           `json:"copyright,omitempty"`
-	Group             []ConceptMapGroup `json:"group,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string           `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        *Identifier       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string           `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string           `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string           `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus `bson:"status" json:"status"`
+	Experimental      *bool             `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string           `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string           `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail   `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string           `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext    `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string           `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string           `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Group             []ConceptMapGroup `bson:"group,omitempty" json:"group,omitempty"`
 }
 type ConceptMapGroup struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Source            *string                  `json:"source,omitempty"`
-	SourceVersion     *string                  `json:"sourceVersion,omitempty"`
-	Target            *string                  `json:"target,omitempty"`
-	TargetVersion     *string                  `json:"targetVersion,omitempty"`
-	Element           []ConceptMapGroupElement `json:"element"`
-	Unmapped          *ConceptMapGroupUnmapped `json:"unmapped,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Source            *string                  `bson:"source,omitempty" json:"source,omitempty"`
+	SourceVersion     *string                  `bson:"sourceVersion,omitempty" json:"sourceVersion,omitempty"`
+	Target            *string                  `bson:"target,omitempty" json:"target,omitempty"`
+	TargetVersion     *string                  `bson:"targetVersion,omitempty" json:"targetVersion,omitempty"`
+	Element           []ConceptMapGroupElement `bson:"element" json:"element"`
+	Unmapped          *ConceptMapGroupUnmapped `bson:"unmapped,omitempty" json:"unmapped,omitempty"`
 }
 type ConceptMapGroupElement struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Code              *string                        `json:"code,omitempty"`
-	Display           *string                        `json:"display,omitempty"`
-	Target            []ConceptMapGroupElementTarget `json:"target,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *string                        `bson:"code,omitempty" json:"code,omitempty"`
+	Display           *string                        `bson:"display,omitempty" json:"display,omitempty"`
+	Target            []ConceptMapGroupElementTarget `bson:"target,omitempty" json:"target,omitempty"`
 }
 type ConceptMapGroupElementTarget struct {
-	Id                *string                                 `json:"id,omitempty"`
-	Extension         []Extension                             `json:"extension,omitempty"`
-	ModifierExtension []Extension                             `json:"modifierExtension,omitempty"`
-	Code              *string                                 `json:"code,omitempty"`
-	Display           *string                                 `json:"display,omitempty"`
-	Equivalence       ConceptMapEquivalence                   `json:"equivalence"`
-	Comment           *string                                 `json:"comment,omitempty"`
-	DependsOn         []ConceptMapGroupElementTargetDependsOn `json:"dependsOn,omitempty"`
-	Product           []ConceptMapGroupElementTargetDependsOn `json:"product,omitempty"`
+	Id                *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *string                                 `bson:"code,omitempty" json:"code,omitempty"`
+	Display           *string                                 `bson:"display,omitempty" json:"display,omitempty"`
+	Equivalence       ConceptMapEquivalence                   `bson:"equivalence" json:"equivalence"`
+	Comment           *string                                 `bson:"comment,omitempty" json:"comment,omitempty"`
+	DependsOn         []ConceptMapGroupElementTargetDependsOn `bson:"dependsOn,omitempty" json:"dependsOn,omitempty"`
+	Product           []ConceptMapGroupElementTargetDependsOn `bson:"product,omitempty" json:"product,omitempty"`
 }
 type ConceptMapGroupElementTargetDependsOn struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Property          string      `json:"property"`
-	System            *string     `json:"system,omitempty"`
-	Value             string      `json:"value"`
-	Display           *string     `json:"display,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Property          string      `bson:"property" json:"property"`
+	System            *string     `bson:"system,omitempty" json:"system,omitempty"`
+	Value             string      `bson:"value" json:"value"`
+	Display           *string     `bson:"display,omitempty" json:"display,omitempty"`
 }
 type ConceptMapGroupUnmapped struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Mode              ConceptMapGroupUnmappedMode `json:"mode"`
-	Code              *string                     `json:"code,omitempty"`
-	Display           *string                     `json:"display,omitempty"`
-	Url               *string                     `json:"url,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Mode              ConceptMapGroupUnmappedMode `bson:"mode" json:"mode"`
+	Code              *string                     `bson:"code,omitempty" json:"code,omitempty"`
+	Display           *string                     `bson:"display,omitempty" json:"display,omitempty"`
+	Url               *string                     `bson:"url,omitempty" json:"url,omitempty"`
 }
 type OtherConceptMap ConceptMap
 

--- a/fhir-models/fhir/condition.go
+++ b/fhir-models/fhir/condition.go
@@ -21,43 +21,43 @@ import "encoding/json"
 
 // Condition is documented here http://hl7.org/fhir/StructureDefinition/Condition
 type Condition struct {
-	Id                 *string             `json:"id,omitempty"`
-	Meta               *Meta               `json:"meta,omitempty"`
-	ImplicitRules      *string             `json:"implicitRules,omitempty"`
-	Language           *string             `json:"language,omitempty"`
-	Text               *Narrative          `json:"text,omitempty"`
-	Extension          []Extension         `json:"extension,omitempty"`
-	ModifierExtension  []Extension         `json:"modifierExtension,omitempty"`
-	Identifier         []Identifier        `json:"identifier,omitempty"`
-	ClinicalStatus     *CodeableConcept    `json:"clinicalStatus,omitempty"`
-	VerificationStatus *CodeableConcept    `json:"verificationStatus,omitempty"`
-	Category           []CodeableConcept   `json:"category,omitempty"`
-	Severity           *CodeableConcept    `json:"severity,omitempty"`
-	Code               *CodeableConcept    `json:"code,omitempty"`
-	BodySite           []CodeableConcept   `json:"bodySite,omitempty"`
-	Subject            Reference           `json:"subject"`
-	Encounter          *Reference          `json:"encounter,omitempty"`
-	RecordedDate       *string             `json:"recordedDate,omitempty"`
-	Recorder           *Reference          `json:"recorder,omitempty"`
-	Asserter           *Reference          `json:"asserter,omitempty"`
-	Stage              []ConditionStage    `json:"stage,omitempty"`
-	Evidence           []ConditionEvidence `json:"evidence,omitempty"`
-	Note               []Annotation        `json:"note,omitempty"`
+	Id                 *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         []Identifier        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	ClinicalStatus     *CodeableConcept    `bson:"clinicalStatus,omitempty" json:"clinicalStatus,omitempty"`
+	VerificationStatus *CodeableConcept    `bson:"verificationStatus,omitempty" json:"verificationStatus,omitempty"`
+	Category           []CodeableConcept   `bson:"category,omitempty" json:"category,omitempty"`
+	Severity           *CodeableConcept    `bson:"severity,omitempty" json:"severity,omitempty"`
+	Code               *CodeableConcept    `bson:"code,omitempty" json:"code,omitempty"`
+	BodySite           []CodeableConcept   `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Subject            Reference           `bson:"subject" json:"subject"`
+	Encounter          *Reference          `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	RecordedDate       *string             `bson:"recordedDate,omitempty" json:"recordedDate,omitempty"`
+	Recorder           *Reference          `bson:"recorder,omitempty" json:"recorder,omitempty"`
+	Asserter           *Reference          `bson:"asserter,omitempty" json:"asserter,omitempty"`
+	Stage              []ConditionStage    `bson:"stage,omitempty" json:"stage,omitempty"`
+	Evidence           []ConditionEvidence `bson:"evidence,omitempty" json:"evidence,omitempty"`
+	Note               []Annotation        `bson:"note,omitempty" json:"note,omitempty"`
 }
 type ConditionStage struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Summary           *CodeableConcept `json:"summary,omitempty"`
-	Assessment        []Reference      `json:"assessment,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Summary           *CodeableConcept `bson:"summary,omitempty" json:"summary,omitempty"`
+	Assessment        []Reference      `bson:"assessment,omitempty" json:"assessment,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 }
 type ConditionEvidence struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Code              []CodeableConcept `json:"code,omitempty"`
-	Detail            []Reference       `json:"detail,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Detail            []Reference       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type OtherCondition Condition
 

--- a/fhir-models/fhir/consent.go
+++ b/fhir-models/fhir/consent.go
@@ -21,70 +21,70 @@ import "encoding/json"
 
 // Consent is documented here http://hl7.org/fhir/StructureDefinition/Consent
 type Consent struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier          `json:"identifier,omitempty"`
-	Status            ConsentState          `json:"status"`
-	Scope             CodeableConcept       `json:"scope"`
-	Category          []CodeableConcept     `json:"category"`
-	Patient           *Reference            `json:"patient,omitempty"`
-	DateTime          *string               `json:"dateTime,omitempty"`
-	Performer         []Reference           `json:"performer,omitempty"`
-	Organization      []Reference           `json:"organization,omitempty"`
-	Policy            []ConsentPolicy       `json:"policy,omitempty"`
-	PolicyRule        *CodeableConcept      `json:"policyRule,omitempty"`
-	Verification      []ConsentVerification `json:"verification,omitempty"`
-	Provision         *ConsentProvision     `json:"provision,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            ConsentState          `bson:"status" json:"status"`
+	Scope             CodeableConcept       `bson:"scope" json:"scope"`
+	Category          []CodeableConcept     `bson:"category" json:"category"`
+	Patient           *Reference            `bson:"patient,omitempty" json:"patient,omitempty"`
+	DateTime          *string               `bson:"dateTime,omitempty" json:"dateTime,omitempty"`
+	Performer         []Reference           `bson:"performer,omitempty" json:"performer,omitempty"`
+	Organization      []Reference           `bson:"organization,omitempty" json:"organization,omitempty"`
+	Policy            []ConsentPolicy       `bson:"policy,omitempty" json:"policy,omitempty"`
+	PolicyRule        *CodeableConcept      `bson:"policyRule,omitempty" json:"policyRule,omitempty"`
+	Verification      []ConsentVerification `bson:"verification,omitempty" json:"verification,omitempty"`
+	Provision         *ConsentProvision     `bson:"provision,omitempty" json:"provision,omitempty"`
 }
 type ConsentPolicy struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Authority         *string     `json:"authority,omitempty"`
-	Uri               *string     `json:"uri,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Authority         *string     `bson:"authority,omitempty" json:"authority,omitempty"`
+	Uri               *string     `bson:"uri,omitempty" json:"uri,omitempty"`
 }
 type ConsentVerification struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Verified          bool        `json:"verified"`
-	VerifiedWith      *Reference  `json:"verifiedWith,omitempty"`
-	VerificationDate  *string     `json:"verificationDate,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Verified          bool        `bson:"verified" json:"verified"`
+	VerifiedWith      *Reference  `bson:"verifiedWith,omitempty" json:"verifiedWith,omitempty"`
+	VerificationDate  *string     `bson:"verificationDate,omitempty" json:"verificationDate,omitempty"`
 }
 type ConsentProvision struct {
-	Id                *string                 `json:"id,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Type              *ConsentProvisionType   `json:"type,omitempty"`
-	Period            *Period                 `json:"period,omitempty"`
-	Actor             []ConsentProvisionActor `json:"actor,omitempty"`
-	Action            []CodeableConcept       `json:"action,omitempty"`
-	SecurityLabel     []Coding                `json:"securityLabel,omitempty"`
-	Purpose           []Coding                `json:"purpose,omitempty"`
-	Class             []Coding                `json:"class,omitempty"`
-	Code              []CodeableConcept       `json:"code,omitempty"`
-	DataPeriod        *Period                 `json:"dataPeriod,omitempty"`
-	Data              []ConsentProvisionData  `json:"data,omitempty"`
-	Provision         []ConsentProvision      `json:"provision,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *ConsentProvisionType   `bson:"type,omitempty" json:"type,omitempty"`
+	Period            *Period                 `bson:"period,omitempty" json:"period,omitempty"`
+	Actor             []ConsentProvisionActor `bson:"actor,omitempty" json:"actor,omitempty"`
+	Action            []CodeableConcept       `bson:"action,omitempty" json:"action,omitempty"`
+	SecurityLabel     []Coding                `bson:"securityLabel,omitempty" json:"securityLabel,omitempty"`
+	Purpose           []Coding                `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Class             []Coding                `bson:"class,omitempty" json:"class,omitempty"`
+	Code              []CodeableConcept       `bson:"code,omitempty" json:"code,omitempty"`
+	DataPeriod        *Period                 `bson:"dataPeriod,omitempty" json:"dataPeriod,omitempty"`
+	Data              []ConsentProvisionData  `bson:"data,omitempty" json:"data,omitempty"`
+	Provision         []ConsentProvision      `bson:"provision,omitempty" json:"provision,omitempty"`
 }
 type ConsentProvisionActor struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Role              CodeableConcept `json:"role"`
-	Reference         Reference       `json:"reference"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Role              CodeableConcept `bson:"role" json:"role"`
+	Reference         Reference       `bson:"reference" json:"reference"`
 }
 type ConsentProvisionData struct {
-	Id                *string            `json:"id,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Meaning           ConsentDataMeaning `json:"meaning"`
-	Reference         Reference          `json:"reference"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Meaning           ConsentDataMeaning `bson:"meaning" json:"meaning"`
+	Reference         Reference          `bson:"reference" json:"reference"`
 }
 type OtherConsent Consent
 

--- a/fhir-models/fhir/contactDetail.go
+++ b/fhir-models/fhir/contactDetail.go
@@ -19,8 +19,8 @@ package fhir
 
 // ContactDetail is documented here http://hl7.org/fhir/StructureDefinition/ContactDetail
 type ContactDetail struct {
-	Id        *string        `json:"id,omitempty"`
-	Extension []Extension    `json:"extension,omitempty"`
-	Name      *string        `json:"name,omitempty"`
-	Telecom   []ContactPoint `json:"telecom,omitempty"`
+	Id        *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	Name      *string        `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom   []ContactPoint `bson:"telecom,omitempty" json:"telecom,omitempty"`
 }

--- a/fhir-models/fhir/contactPoint.go
+++ b/fhir-models/fhir/contactPoint.go
@@ -19,11 +19,11 @@ package fhir
 
 // ContactPoint is documented here http://hl7.org/fhir/StructureDefinition/ContactPoint
 type ContactPoint struct {
-	Id        *string             `json:"id,omitempty"`
-	Extension []Extension         `json:"extension,omitempty"`
-	System    *ContactPointSystem `json:"system,omitempty"`
-	Value     *string             `json:"value,omitempty"`
-	Use       *ContactPointUse    `json:"use,omitempty"`
-	Rank      *int                `json:"rank,omitempty"`
-	Period    *Period             `json:"period,omitempty"`
+	Id        *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	System    *ContactPointSystem `bson:"system,omitempty" json:"system,omitempty"`
+	Value     *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Use       *ContactPointUse    `bson:"use,omitempty" json:"use,omitempty"`
+	Rank      *int                `bson:"rank,omitempty" json:"rank,omitempty"`
+	Period    *Period             `bson:"period,omitempty" json:"period,omitempty"`
 }

--- a/fhir-models/fhir/contract.go
+++ b/fhir-models/fhir/contract.go
@@ -21,208 +21,208 @@ import "encoding/json"
 
 // Contract is documented here http://hl7.org/fhir/StructureDefinition/Contract
 type Contract struct {
-	Id                    *string                      `json:"id,omitempty"`
-	Meta                  *Meta                        `json:"meta,omitempty"`
-	ImplicitRules         *string                      `json:"implicitRules,omitempty"`
-	Language              *string                      `json:"language,omitempty"`
-	Text                  *Narrative                   `json:"text,omitempty"`
-	Extension             []Extension                  `json:"extension,omitempty"`
-	ModifierExtension     []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier                 `json:"identifier,omitempty"`
-	Url                   *string                      `json:"url,omitempty"`
-	Version               *string                      `json:"version,omitempty"`
-	Status                *ContractResourceStatusCodes `json:"status,omitempty"`
-	LegalState            *CodeableConcept             `json:"legalState,omitempty"`
-	InstantiatesCanonical *Reference                   `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       *string                      `json:"instantiatesUri,omitempty"`
-	ContentDerivative     *CodeableConcept             `json:"contentDerivative,omitempty"`
-	Issued                *string                      `json:"issued,omitempty"`
-	Applies               *Period                      `json:"applies,omitempty"`
-	ExpirationType        *CodeableConcept             `json:"expirationType,omitempty"`
-	Subject               []Reference                  `json:"subject,omitempty"`
-	Authority             []Reference                  `json:"authority,omitempty"`
-	Domain                []Reference                  `json:"domain,omitempty"`
-	Site                  []Reference                  `json:"site,omitempty"`
-	Name                  *string                      `json:"name,omitempty"`
-	Title                 *string                      `json:"title,omitempty"`
-	Subtitle              *string                      `json:"subtitle,omitempty"`
-	Alias                 []string                     `json:"alias,omitempty"`
-	Author                *Reference                   `json:"author,omitempty"`
-	Scope                 *CodeableConcept             `json:"scope,omitempty"`
-	Type                  *CodeableConcept             `json:"type,omitempty"`
-	SubType               []CodeableConcept            `json:"subType,omitempty"`
-	ContentDefinition     *ContractContentDefinition   `json:"contentDefinition,omitempty"`
-	Term                  []ContractTerm               `json:"term,omitempty"`
-	SupportingInfo        []Reference                  `json:"supportingInfo,omitempty"`
-	RelevantHistory       []Reference                  `json:"relevantHistory,omitempty"`
-	Signer                []ContractSigner             `json:"signer,omitempty"`
-	Friendly              []ContractFriendly           `json:"friendly,omitempty"`
-	Legal                 []ContractLegal              `json:"legal,omitempty"`
-	Rule                  []ContractRule               `json:"rule,omitempty"`
+	Id                    *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Url                   *string                      `bson:"url,omitempty" json:"url,omitempty"`
+	Version               *string                      `bson:"version,omitempty" json:"version,omitempty"`
+	Status                *ContractResourceStatusCodes `bson:"status,omitempty" json:"status,omitempty"`
+	LegalState            *CodeableConcept             `bson:"legalState,omitempty" json:"legalState,omitempty"`
+	InstantiatesCanonical *Reference                   `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       *string                      `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	ContentDerivative     *CodeableConcept             `bson:"contentDerivative,omitempty" json:"contentDerivative,omitempty"`
+	Issued                *string                      `bson:"issued,omitempty" json:"issued,omitempty"`
+	Applies               *Period                      `bson:"applies,omitempty" json:"applies,omitempty"`
+	ExpirationType        *CodeableConcept             `bson:"expirationType,omitempty" json:"expirationType,omitempty"`
+	Subject               []Reference                  `bson:"subject,omitempty" json:"subject,omitempty"`
+	Authority             []Reference                  `bson:"authority,omitempty" json:"authority,omitempty"`
+	Domain                []Reference                  `bson:"domain,omitempty" json:"domain,omitempty"`
+	Site                  []Reference                  `bson:"site,omitempty" json:"site,omitempty"`
+	Name                  *string                      `bson:"name,omitempty" json:"name,omitempty"`
+	Title                 *string                      `bson:"title,omitempty" json:"title,omitempty"`
+	Subtitle              *string                      `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Alias                 []string                     `bson:"alias,omitempty" json:"alias,omitempty"`
+	Author                *Reference                   `bson:"author,omitempty" json:"author,omitempty"`
+	Scope                 *CodeableConcept             `bson:"scope,omitempty" json:"scope,omitempty"`
+	Type                  *CodeableConcept             `bson:"type,omitempty" json:"type,omitempty"`
+	SubType               []CodeableConcept            `bson:"subType,omitempty" json:"subType,omitempty"`
+	ContentDefinition     *ContractContentDefinition   `bson:"contentDefinition,omitempty" json:"contentDefinition,omitempty"`
+	Term                  []ContractTerm               `bson:"term,omitempty" json:"term,omitempty"`
+	SupportingInfo        []Reference                  `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	RelevantHistory       []Reference                  `bson:"relevantHistory,omitempty" json:"relevantHistory,omitempty"`
+	Signer                []ContractSigner             `bson:"signer,omitempty" json:"signer,omitempty"`
+	Friendly              []ContractFriendly           `bson:"friendly,omitempty" json:"friendly,omitempty"`
+	Legal                 []ContractLegal              `bson:"legal,omitempty" json:"legal,omitempty"`
+	Rule                  []ContractRule               `bson:"rule,omitempty" json:"rule,omitempty"`
 }
 type ContractContentDefinition struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept                        `json:"type"`
-	SubType           *CodeableConcept                       `json:"subType,omitempty"`
-	Publisher         *Reference                             `json:"publisher,omitempty"`
-	PublicationDate   *string                                `json:"publicationDate,omitempty"`
-	PublicationStatus ContractResourcePublicationStatusCodes `json:"publicationStatus"`
-	Copyright         *string                                `json:"copyright,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept                        `bson:"type" json:"type"`
+	SubType           *CodeableConcept                       `bson:"subType,omitempty" json:"subType,omitempty"`
+	Publisher         *Reference                             `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	PublicationDate   *string                                `bson:"publicationDate,omitempty" json:"publicationDate,omitempty"`
+	PublicationStatus ContractResourcePublicationStatusCodes `bson:"publicationStatus" json:"publicationStatus"`
+	Copyright         *string                                `bson:"copyright,omitempty" json:"copyright,omitempty"`
 }
 type ContractTerm struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier                 `json:"identifier,omitempty"`
-	Issued            *string                     `json:"issued,omitempty"`
-	Applies           *Period                     `json:"applies,omitempty"`
-	Type              *CodeableConcept            `json:"type,omitempty"`
-	SubType           *CodeableConcept            `json:"subType,omitempty"`
-	Text              *string                     `json:"text,omitempty"`
-	SecurityLabel     []ContractTermSecurityLabel `json:"securityLabel,omitempty"`
-	Offer             ContractTermOffer           `json:"offer"`
-	Asset             []ContractTermAsset         `json:"asset,omitempty"`
-	Action            []ContractTermAction        `json:"action,omitempty"`
-	Group             []ContractTerm              `json:"group,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Issued            *string                     `bson:"issued,omitempty" json:"issued,omitempty"`
+	Applies           *Period                     `bson:"applies,omitempty" json:"applies,omitempty"`
+	Type              *CodeableConcept            `bson:"type,omitempty" json:"type,omitempty"`
+	SubType           *CodeableConcept            `bson:"subType,omitempty" json:"subType,omitempty"`
+	Text              *string                     `bson:"text,omitempty" json:"text,omitempty"`
+	SecurityLabel     []ContractTermSecurityLabel `bson:"securityLabel,omitempty" json:"securityLabel,omitempty"`
+	Offer             ContractTermOffer           `bson:"offer" json:"offer"`
+	Asset             []ContractTermAsset         `bson:"asset,omitempty" json:"asset,omitempty"`
+	Action            []ContractTermAction        `bson:"action,omitempty" json:"action,omitempty"`
+	Group             []ContractTerm              `bson:"group,omitempty" json:"group,omitempty"`
 }
 type ContractTermSecurityLabel struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Number            []int       `json:"number,omitempty"`
-	Classification    Coding      `json:"classification"`
-	Category          []Coding    `json:"category,omitempty"`
-	Control           []Coding    `json:"control,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Number            []int       `bson:"number,omitempty" json:"number,omitempty"`
+	Classification    Coding      `bson:"classification" json:"classification"`
+	Category          []Coding    `bson:"category,omitempty" json:"category,omitempty"`
+	Control           []Coding    `bson:"control,omitempty" json:"control,omitempty"`
 }
 type ContractTermOffer struct {
-	Id                  *string                   `json:"id,omitempty"`
-	Extension           []Extension               `json:"extension,omitempty"`
-	ModifierExtension   []Extension               `json:"modifierExtension,omitempty"`
-	Identifier          []Identifier              `json:"identifier,omitempty"`
-	Party               []ContractTermOfferParty  `json:"party,omitempty"`
-	Topic               *Reference                `json:"topic,omitempty"`
-	Type                *CodeableConcept          `json:"type,omitempty"`
-	Decision            *CodeableConcept          `json:"decision,omitempty"`
-	DecisionMode        []CodeableConcept         `json:"decisionMode,omitempty"`
-	Answer              []ContractTermOfferAnswer `json:"answer,omitempty"`
-	Text                *string                   `json:"text,omitempty"`
-	LinkId              []string                  `json:"linkId,omitempty"`
-	SecurityLabelNumber []int                     `json:"securityLabelNumber,omitempty"`
+	Id                  *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          []Identifier              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Party               []ContractTermOfferParty  `bson:"party,omitempty" json:"party,omitempty"`
+	Topic               *Reference                `bson:"topic,omitempty" json:"topic,omitempty"`
+	Type                *CodeableConcept          `bson:"type,omitempty" json:"type,omitempty"`
+	Decision            *CodeableConcept          `bson:"decision,omitempty" json:"decision,omitempty"`
+	DecisionMode        []CodeableConcept         `bson:"decisionMode,omitempty" json:"decisionMode,omitempty"`
+	Answer              []ContractTermOfferAnswer `bson:"answer,omitempty" json:"answer,omitempty"`
+	Text                *string                   `bson:"text,omitempty" json:"text,omitempty"`
+	LinkId              []string                  `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	SecurityLabelNumber []int                     `bson:"securityLabelNumber,omitempty" json:"securityLabelNumber,omitempty"`
 }
 type ContractTermOfferParty struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Reference         []Reference     `json:"reference"`
-	Role              CodeableConcept `json:"role"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Reference         []Reference     `bson:"reference" json:"reference"`
+	Role              CodeableConcept `bson:"role" json:"role"`
 }
 type ContractTermOfferAnswer struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type ContractTermAsset struct {
-	Id                  *string                       `json:"id,omitempty"`
-	Extension           []Extension                   `json:"extension,omitempty"`
-	ModifierExtension   []Extension                   `json:"modifierExtension,omitempty"`
-	Scope               *CodeableConcept              `json:"scope,omitempty"`
-	Type                []CodeableConcept             `json:"type,omitempty"`
-	TypeReference       []Reference                   `json:"typeReference,omitempty"`
-	Subtype             []CodeableConcept             `json:"subtype,omitempty"`
-	Relationship        *Coding                       `json:"relationship,omitempty"`
-	Context             []ContractTermAssetContext    `json:"context,omitempty"`
-	Condition           *string                       `json:"condition,omitempty"`
-	PeriodType          []CodeableConcept             `json:"periodType,omitempty"`
-	Period              []Period                      `json:"period,omitempty"`
-	UsePeriod           []Period                      `json:"usePeriod,omitempty"`
-	Text                *string                       `json:"text,omitempty"`
-	LinkId              []string                      `json:"linkId,omitempty"`
-	Answer              []ContractTermOfferAnswer     `json:"answer,omitempty"`
-	SecurityLabelNumber []int                         `json:"securityLabelNumber,omitempty"`
-	ValuedItem          []ContractTermAssetValuedItem `json:"valuedItem,omitempty"`
+	Id                  *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Scope               *CodeableConcept              `bson:"scope,omitempty" json:"scope,omitempty"`
+	Type                []CodeableConcept             `bson:"type,omitempty" json:"type,omitempty"`
+	TypeReference       []Reference                   `bson:"typeReference,omitempty" json:"typeReference,omitempty"`
+	Subtype             []CodeableConcept             `bson:"subtype,omitempty" json:"subtype,omitempty"`
+	Relationship        *Coding                       `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Context             []ContractTermAssetContext    `bson:"context,omitempty" json:"context,omitempty"`
+	Condition           *string                       `bson:"condition,omitempty" json:"condition,omitempty"`
+	PeriodType          []CodeableConcept             `bson:"periodType,omitempty" json:"periodType,omitempty"`
+	Period              []Period                      `bson:"period,omitempty" json:"period,omitempty"`
+	UsePeriod           []Period                      `bson:"usePeriod,omitempty" json:"usePeriod,omitempty"`
+	Text                *string                       `bson:"text,omitempty" json:"text,omitempty"`
+	LinkId              []string                      `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	Answer              []ContractTermOfferAnswer     `bson:"answer,omitempty" json:"answer,omitempty"`
+	SecurityLabelNumber []int                         `bson:"securityLabelNumber,omitempty" json:"securityLabelNumber,omitempty"`
+	ValuedItem          []ContractTermAssetValuedItem `bson:"valuedItem,omitempty" json:"valuedItem,omitempty"`
 }
 type ContractTermAssetContext struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Reference         *Reference        `json:"reference,omitempty"`
-	Code              []CodeableConcept `json:"code,omitempty"`
-	Text              *string           `json:"text,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Reference         *Reference        `bson:"reference,omitempty" json:"reference,omitempty"`
+	Code              []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Text              *string           `bson:"text,omitempty" json:"text,omitempty"`
 }
 type ContractTermAssetValuedItem struct {
-	Id                  *string     `json:"id,omitempty"`
-	Extension           []Extension `json:"extension,omitempty"`
-	ModifierExtension   []Extension `json:"modifierExtension,omitempty"`
-	Identifier          *Identifier `json:"identifier,omitempty"`
-	EffectiveTime       *string     `json:"effectiveTime,omitempty"`
-	Quantity            *Quantity   `json:"quantity,omitempty"`
-	UnitPrice           *Money      `json:"unitPrice,omitempty"`
-	Factor              *string     `json:"factor,omitempty"`
-	Points              *string     `json:"points,omitempty"`
-	Net                 *Money      `json:"net,omitempty"`
-	Payment             *string     `json:"payment,omitempty"`
-	PaymentDate         *string     `json:"paymentDate,omitempty"`
-	Responsible         *Reference  `json:"responsible,omitempty"`
-	Recipient           *Reference  `json:"recipient,omitempty"`
-	LinkId              []string    `json:"linkId,omitempty"`
-	SecurityLabelNumber []int       `json:"securityLabelNumber,omitempty"`
+	Id                  *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	EffectiveTime       *string     `bson:"effectiveTime,omitempty" json:"effectiveTime,omitempty"`
+	Quantity            *Quantity   `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice           *Money      `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor              *string     `bson:"factor,omitempty" json:"factor,omitempty"`
+	Points              *string     `bson:"points,omitempty" json:"points,omitempty"`
+	Net                 *Money      `bson:"net,omitempty" json:"net,omitempty"`
+	Payment             *string     `bson:"payment,omitempty" json:"payment,omitempty"`
+	PaymentDate         *string     `bson:"paymentDate,omitempty" json:"paymentDate,omitempty"`
+	Responsible         *Reference  `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Recipient           *Reference  `bson:"recipient,omitempty" json:"recipient,omitempty"`
+	LinkId              []string    `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	SecurityLabelNumber []int       `bson:"securityLabelNumber,omitempty" json:"securityLabelNumber,omitempty"`
 }
 type ContractTermAction struct {
-	Id                  *string                     `json:"id,omitempty"`
-	Extension           []Extension                 `json:"extension,omitempty"`
-	ModifierExtension   []Extension                 `json:"modifierExtension,omitempty"`
-	DoNotPerform        *bool                       `json:"doNotPerform,omitempty"`
-	Type                CodeableConcept             `json:"type"`
-	Subject             []ContractTermActionSubject `json:"subject,omitempty"`
-	Intent              CodeableConcept             `json:"intent"`
-	LinkId              []string                    `json:"linkId,omitempty"`
-	Status              CodeableConcept             `json:"status"`
-	Context             *Reference                  `json:"context,omitempty"`
-	ContextLinkId       []string                    `json:"contextLinkId,omitempty"`
-	Requester           []Reference                 `json:"requester,omitempty"`
-	RequesterLinkId     []string                    `json:"requesterLinkId,omitempty"`
-	PerformerType       []CodeableConcept           `json:"performerType,omitempty"`
-	PerformerRole       *CodeableConcept            `json:"performerRole,omitempty"`
-	Performer           *Reference                  `json:"performer,omitempty"`
-	PerformerLinkId     []string                    `json:"performerLinkId,omitempty"`
-	ReasonCode          []CodeableConcept           `json:"reasonCode,omitempty"`
-	ReasonReference     []Reference                 `json:"reasonReference,omitempty"`
-	Reason              []string                    `json:"reason,omitempty"`
-	ReasonLinkId        []string                    `json:"reasonLinkId,omitempty"`
-	Note                []Annotation                `json:"note,omitempty"`
-	SecurityLabelNumber []int                       `json:"securityLabelNumber,omitempty"`
+	Id                  *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DoNotPerform        *bool                       `bson:"doNotPerform,omitempty" json:"doNotPerform,omitempty"`
+	Type                CodeableConcept             `bson:"type" json:"type"`
+	Subject             []ContractTermActionSubject `bson:"subject,omitempty" json:"subject,omitempty"`
+	Intent              CodeableConcept             `bson:"intent" json:"intent"`
+	LinkId              []string                    `bson:"linkId,omitempty" json:"linkId,omitempty"`
+	Status              CodeableConcept             `bson:"status" json:"status"`
+	Context             *Reference                  `bson:"context,omitempty" json:"context,omitempty"`
+	ContextLinkId       []string                    `bson:"contextLinkId,omitempty" json:"contextLinkId,omitempty"`
+	Requester           []Reference                 `bson:"requester,omitempty" json:"requester,omitempty"`
+	RequesterLinkId     []string                    `bson:"requesterLinkId,omitempty" json:"requesterLinkId,omitempty"`
+	PerformerType       []CodeableConcept           `bson:"performerType,omitempty" json:"performerType,omitempty"`
+	PerformerRole       *CodeableConcept            `bson:"performerRole,omitempty" json:"performerRole,omitempty"`
+	Performer           *Reference                  `bson:"performer,omitempty" json:"performer,omitempty"`
+	PerformerLinkId     []string                    `bson:"performerLinkId,omitempty" json:"performerLinkId,omitempty"`
+	ReasonCode          []CodeableConcept           `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference     []Reference                 `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Reason              []string                    `bson:"reason,omitempty" json:"reason,omitempty"`
+	ReasonLinkId        []string                    `bson:"reasonLinkId,omitempty" json:"reasonLinkId,omitempty"`
+	Note                []Annotation                `bson:"note,omitempty" json:"note,omitempty"`
+	SecurityLabelNumber []int                       `bson:"securityLabelNumber,omitempty" json:"securityLabelNumber,omitempty"`
 }
 type ContractTermActionSubject struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Reference         []Reference      `json:"reference"`
-	Role              *CodeableConcept `json:"role,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Reference         []Reference      `bson:"reference" json:"reference"`
+	Role              *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
 }
 type ContractSigner struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Type              Coding      `json:"type"`
-	Party             Reference   `json:"party"`
-	Signature         []Signature `json:"signature"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              Coding      `bson:"type" json:"type"`
+	Party             Reference   `bson:"party" json:"party"`
+	Signature         []Signature `bson:"signature" json:"signature"`
 }
 type ContractFriendly struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type ContractLegal struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type ContractRule struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherContract Contract
 

--- a/fhir-models/fhir/coverage.go
+++ b/fhir-models/fhir/coverage.go
@@ -21,52 +21,52 @@ import "encoding/json"
 
 // Coverage is documented here http://hl7.org/fhir/StructureDefinition/Coverage
 type Coverage struct {
-	Id                *string                      `json:"id,omitempty"`
-	Meta              *Meta                        `json:"meta,omitempty"`
-	ImplicitRules     *string                      `json:"implicitRules,omitempty"`
-	Language          *string                      `json:"language,omitempty"`
-	Text              *Narrative                   `json:"text,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                 `json:"identifier,omitempty"`
-	Status            FinancialResourceStatusCodes `json:"status"`
-	Type              *CodeableConcept             `json:"type,omitempty"`
-	PolicyHolder      *Reference                   `json:"policyHolder,omitempty"`
-	Subscriber        *Reference                   `json:"subscriber,omitempty"`
-	SubscriberId      *string                      `json:"subscriberId,omitempty"`
-	Beneficiary       Reference                    `json:"beneficiary"`
-	Dependent         *string                      `json:"dependent,omitempty"`
-	Relationship      *CodeableConcept             `json:"relationship,omitempty"`
-	Period            *Period                      `json:"period,omitempty"`
-	Payor             []Reference                  `json:"payor"`
-	Class             []CoverageClass              `json:"class,omitempty"`
-	Order             *int                         `json:"order,omitempty"`
-	Network           *string                      `json:"network,omitempty"`
-	CostToBeneficiary []CoverageCostToBeneficiary  `json:"costToBeneficiary,omitempty"`
-	Subrogation       *bool                        `json:"subrogation,omitempty"`
-	Contract          []Reference                  `json:"contract,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FinancialResourceStatusCodes `bson:"status" json:"status"`
+	Type              *CodeableConcept             `bson:"type,omitempty" json:"type,omitempty"`
+	PolicyHolder      *Reference                   `bson:"policyHolder,omitempty" json:"policyHolder,omitempty"`
+	Subscriber        *Reference                   `bson:"subscriber,omitempty" json:"subscriber,omitempty"`
+	SubscriberId      *string                      `bson:"subscriberId,omitempty" json:"subscriberId,omitempty"`
+	Beneficiary       Reference                    `bson:"beneficiary" json:"beneficiary"`
+	Dependent         *string                      `bson:"dependent,omitempty" json:"dependent,omitempty"`
+	Relationship      *CodeableConcept             `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Period            *Period                      `bson:"period,omitempty" json:"period,omitempty"`
+	Payor             []Reference                  `bson:"payor" json:"payor"`
+	Class             []CoverageClass              `bson:"class,omitempty" json:"class,omitempty"`
+	Order             *int                         `bson:"order,omitempty" json:"order,omitempty"`
+	Network           *string                      `bson:"network,omitempty" json:"network,omitempty"`
+	CostToBeneficiary []CoverageCostToBeneficiary  `bson:"costToBeneficiary,omitempty" json:"costToBeneficiary,omitempty"`
+	Subrogation       *bool                        `bson:"subrogation,omitempty" json:"subrogation,omitempty"`
+	Contract          []Reference                  `bson:"contract,omitempty" json:"contract,omitempty"`
 }
 type CoverageClass struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Value             string          `json:"value"`
-	Name              *string         `json:"name,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Value             string          `bson:"value" json:"value"`
+	Name              *string         `bson:"name,omitempty" json:"name,omitempty"`
 }
 type CoverageCostToBeneficiary struct {
-	Id                *string                              `json:"id,omitempty"`
-	Extension         []Extension                          `json:"extension,omitempty"`
-	ModifierExtension []Extension                          `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept                     `json:"type,omitempty"`
-	Exception         []CoverageCostToBeneficiaryException `json:"exception,omitempty"`
+	Id                *string                              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept                     `bson:"type,omitempty" json:"type,omitempty"`
+	Exception         []CoverageCostToBeneficiaryException `bson:"exception,omitempty" json:"exception,omitempty"`
 }
 type CoverageCostToBeneficiaryException struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Period            *Period         `json:"period,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Period            *Period         `bson:"period,omitempty" json:"period,omitempty"`
 }
 type OtherCoverage Coverage
 

--- a/fhir-models/fhir/coverageEligibilityRequest.go
+++ b/fhir-models/fhir/coverageEligibilityRequest.go
@@ -21,62 +21,62 @@ import "encoding/json"
 
 // CoverageEligibilityRequest is documented here http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest
 type CoverageEligibilityRequest struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Meta              *Meta                                      `json:"meta,omitempty"`
-	ImplicitRules     *string                                    `json:"implicitRules,omitempty"`
-	Language          *string                                    `json:"language,omitempty"`
-	Text              *Narrative                                 `json:"text,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                               `json:"identifier,omitempty"`
-	Status            FinancialResourceStatusCodes               `json:"status"`
-	Priority          *CodeableConcept                           `json:"priority,omitempty"`
-	Purpose           []EligibilityRequestPurpose                `json:"purpose"`
-	Patient           Reference                                  `json:"patient"`
-	Created           string                                     `json:"created"`
-	Enterer           *Reference                                 `json:"enterer,omitempty"`
-	Provider          *Reference                                 `json:"provider,omitempty"`
-	Insurer           Reference                                  `json:"insurer"`
-	Facility          *Reference                                 `json:"facility,omitempty"`
-	SupportingInfo    []CoverageEligibilityRequestSupportingInfo `json:"supportingInfo,omitempty"`
-	Insurance         []CoverageEligibilityRequestInsurance      `json:"insurance,omitempty"`
-	Item              []CoverageEligibilityRequestItem           `json:"item,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FinancialResourceStatusCodes               `bson:"status" json:"status"`
+	Priority          *CodeableConcept                           `bson:"priority,omitempty" json:"priority,omitempty"`
+	Purpose           []EligibilityRequestPurpose                `bson:"purpose" json:"purpose"`
+	Patient           Reference                                  `bson:"patient" json:"patient"`
+	Created           string                                     `bson:"created" json:"created"`
+	Enterer           *Reference                                 `bson:"enterer,omitempty" json:"enterer,omitempty"`
+	Provider          *Reference                                 `bson:"provider,omitempty" json:"provider,omitempty"`
+	Insurer           Reference                                  `bson:"insurer" json:"insurer"`
+	Facility          *Reference                                 `bson:"facility,omitempty" json:"facility,omitempty"`
+	SupportingInfo    []CoverageEligibilityRequestSupportingInfo `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Insurance         []CoverageEligibilityRequestInsurance      `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	Item              []CoverageEligibilityRequestItem           `bson:"item,omitempty" json:"item,omitempty"`
 }
 type CoverageEligibilityRequestSupportingInfo struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Sequence          int         `json:"sequence"`
-	Information       Reference   `json:"information"`
-	AppliesToAll      *bool       `json:"appliesToAll,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int         `bson:"sequence" json:"sequence"`
+	Information       Reference   `bson:"information" json:"information"`
+	AppliesToAll      *bool       `bson:"appliesToAll,omitempty" json:"appliesToAll,omitempty"`
 }
 type CoverageEligibilityRequestInsurance struct {
-	Id                  *string     `json:"id,omitempty"`
-	Extension           []Extension `json:"extension,omitempty"`
-	ModifierExtension   []Extension `json:"modifierExtension,omitempty"`
-	Focal               *bool       `json:"focal,omitempty"`
-	Coverage            Reference   `json:"coverage"`
-	BusinessArrangement *string     `json:"businessArrangement,omitempty"`
+	Id                  *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Focal               *bool       `bson:"focal,omitempty" json:"focal,omitempty"`
+	Coverage            Reference   `bson:"coverage" json:"coverage"`
+	BusinessArrangement *string     `bson:"businessArrangement,omitempty" json:"businessArrangement,omitempty"`
 }
 type CoverageEligibilityRequestItem struct {
-	Id                     *string                                   `json:"id,omitempty"`
-	Extension              []Extension                               `json:"extension,omitempty"`
-	ModifierExtension      []Extension                               `json:"modifierExtension,omitempty"`
-	SupportingInfoSequence []int                                     `json:"supportingInfoSequence,omitempty"`
-	Category               *CodeableConcept                          `json:"category,omitempty"`
-	ProductOrService       *CodeableConcept                          `json:"productOrService,omitempty"`
-	Modifier               []CodeableConcept                         `json:"modifier,omitempty"`
-	Provider               *Reference                                `json:"provider,omitempty"`
-	Quantity               *Quantity                                 `json:"quantity,omitempty"`
-	UnitPrice              *Money                                    `json:"unitPrice,omitempty"`
-	Facility               *Reference                                `json:"facility,omitempty"`
-	Diagnosis              []CoverageEligibilityRequestItemDiagnosis `json:"diagnosis,omitempty"`
-	Detail                 []Reference                               `json:"detail,omitempty"`
+	Id                     *string                                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension              []Extension                               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SupportingInfoSequence []int                                     `bson:"supportingInfoSequence,omitempty" json:"supportingInfoSequence,omitempty"`
+	Category               *CodeableConcept                          `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService       *CodeableConcept                          `bson:"productOrService,omitempty" json:"productOrService,omitempty"`
+	Modifier               []CodeableConcept                         `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Provider               *Reference                                `bson:"provider,omitempty" json:"provider,omitempty"`
+	Quantity               *Quantity                                 `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice              *Money                                    `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Facility               *Reference                                `bson:"facility,omitempty" json:"facility,omitempty"`
+	Diagnosis              []CoverageEligibilityRequestItemDiagnosis `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
+	Detail                 []Reference                               `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type CoverageEligibilityRequestItemDiagnosis struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherCoverageEligibilityRequest CoverageEligibilityRequest
 

--- a/fhir-models/fhir/coverageEligibilityResponse.go
+++ b/fhir-models/fhir/coverageEligibilityResponse.go
@@ -21,67 +21,67 @@ import "encoding/json"
 
 // CoverageEligibilityResponse is documented here http://hl7.org/fhir/StructureDefinition/CoverageEligibilityResponse
 type CoverageEligibilityResponse struct {
-	Id                *string                                `json:"id,omitempty"`
-	Meta              *Meta                                  `json:"meta,omitempty"`
-	ImplicitRules     *string                                `json:"implicitRules,omitempty"`
-	Language          *string                                `json:"language,omitempty"`
-	Text              *Narrative                             `json:"text,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                           `json:"identifier,omitempty"`
-	Status            FinancialResourceStatusCodes           `json:"status"`
-	Purpose           []EligibilityResponsePurpose           `json:"purpose"`
-	Patient           Reference                              `json:"patient"`
-	Created           string                                 `json:"created"`
-	Requestor         *Reference                             `json:"requestor,omitempty"`
-	Request           Reference                              `json:"request"`
-	Outcome           ClaimProcessingCodes                   `json:"outcome"`
-	Disposition       *string                                `json:"disposition,omitempty"`
-	Insurer           Reference                              `json:"insurer"`
-	Insurance         []CoverageEligibilityResponseInsurance `json:"insurance,omitempty"`
-	PreAuthRef        *string                                `json:"preAuthRef,omitempty"`
-	Form              *CodeableConcept                       `json:"form,omitempty"`
-	Error             []CoverageEligibilityResponseError     `json:"error,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FinancialResourceStatusCodes           `bson:"status" json:"status"`
+	Purpose           []EligibilityResponsePurpose           `bson:"purpose" json:"purpose"`
+	Patient           Reference                              `bson:"patient" json:"patient"`
+	Created           string                                 `bson:"created" json:"created"`
+	Requestor         *Reference                             `bson:"requestor,omitempty" json:"requestor,omitempty"`
+	Request           Reference                              `bson:"request" json:"request"`
+	Outcome           ClaimProcessingCodes                   `bson:"outcome" json:"outcome"`
+	Disposition       *string                                `bson:"disposition,omitempty" json:"disposition,omitempty"`
+	Insurer           Reference                              `bson:"insurer" json:"insurer"`
+	Insurance         []CoverageEligibilityResponseInsurance `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	PreAuthRef        *string                                `bson:"preAuthRef,omitempty" json:"preAuthRef,omitempty"`
+	Form              *CodeableConcept                       `bson:"form,omitempty" json:"form,omitempty"`
+	Error             []CoverageEligibilityResponseError     `bson:"error,omitempty" json:"error,omitempty"`
 }
 type CoverageEligibilityResponseInsurance struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Coverage          Reference                                  `json:"coverage"`
-	Inforce           *bool                                      `json:"inforce,omitempty"`
-	BenefitPeriod     *Period                                    `json:"benefitPeriod,omitempty"`
-	Item              []CoverageEligibilityResponseInsuranceItem `json:"item,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Coverage          Reference                                  `bson:"coverage" json:"coverage"`
+	Inforce           *bool                                      `bson:"inforce,omitempty" json:"inforce,omitempty"`
+	BenefitPeriod     *Period                                    `bson:"benefitPeriod,omitempty" json:"benefitPeriod,omitempty"`
+	Item              []CoverageEligibilityResponseInsuranceItem `bson:"item,omitempty" json:"item,omitempty"`
 }
 type CoverageEligibilityResponseInsuranceItem struct {
-	Id                      *string                                           `json:"id,omitempty"`
-	Extension               []Extension                                       `json:"extension,omitempty"`
-	ModifierExtension       []Extension                                       `json:"modifierExtension,omitempty"`
-	Category                *CodeableConcept                                  `json:"category,omitempty"`
-	ProductOrService        *CodeableConcept                                  `json:"productOrService,omitempty"`
-	Modifier                []CodeableConcept                                 `json:"modifier,omitempty"`
-	Provider                *Reference                                        `json:"provider,omitempty"`
-	Excluded                *bool                                             `json:"excluded,omitempty"`
-	Name                    *string                                           `json:"name,omitempty"`
-	Description             *string                                           `json:"description,omitempty"`
-	Network                 *CodeableConcept                                  `json:"network,omitempty"`
-	Unit                    *CodeableConcept                                  `json:"unit,omitempty"`
-	Term                    *CodeableConcept                                  `json:"term,omitempty"`
-	Benefit                 []CoverageEligibilityResponseInsuranceItemBenefit `json:"benefit,omitempty"`
-	AuthorizationRequired   *bool                                             `json:"authorizationRequired,omitempty"`
-	AuthorizationSupporting []CodeableConcept                                 `json:"authorizationSupporting,omitempty"`
-	AuthorizationUrl        *string                                           `json:"authorizationUrl,omitempty"`
+	Id                      *string                                           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension               []Extension                                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension                                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category                *CodeableConcept                                  `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService        *CodeableConcept                                  `bson:"productOrService,omitempty" json:"productOrService,omitempty"`
+	Modifier                []CodeableConcept                                 `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Provider                *Reference                                        `bson:"provider,omitempty" json:"provider,omitempty"`
+	Excluded                *bool                                             `bson:"excluded,omitempty" json:"excluded,omitempty"`
+	Name                    *string                                           `bson:"name,omitempty" json:"name,omitempty"`
+	Description             *string                                           `bson:"description,omitempty" json:"description,omitempty"`
+	Network                 *CodeableConcept                                  `bson:"network,omitempty" json:"network,omitempty"`
+	Unit                    *CodeableConcept                                  `bson:"unit,omitempty" json:"unit,omitempty"`
+	Term                    *CodeableConcept                                  `bson:"term,omitempty" json:"term,omitempty"`
+	Benefit                 []CoverageEligibilityResponseInsuranceItemBenefit `bson:"benefit,omitempty" json:"benefit,omitempty"`
+	AuthorizationRequired   *bool                                             `bson:"authorizationRequired,omitempty" json:"authorizationRequired,omitempty"`
+	AuthorizationSupporting []CodeableConcept                                 `bson:"authorizationSupporting,omitempty" json:"authorizationSupporting,omitempty"`
+	AuthorizationUrl        *string                                           `bson:"authorizationUrl,omitempty" json:"authorizationUrl,omitempty"`
 }
 type CoverageEligibilityResponseInsuranceItemBenefit struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
 }
 type CoverageEligibilityResponseError struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept `json:"code"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
 }
 type OtherCoverageEligibilityResponse CoverageEligibilityResponse
 

--- a/fhir-models/fhir/dataRequirement.go
+++ b/fhir-models/fhir/dataRequirement.go
@@ -19,33 +19,33 @@ package fhir
 
 // DataRequirement is documented here http://hl7.org/fhir/StructureDefinition/DataRequirement
 type DataRequirement struct {
-	Id          *string                     `json:"id,omitempty"`
-	Extension   []Extension                 `json:"extension,omitempty"`
-	Type        string                      `json:"type"`
-	Profile     []string                    `json:"profile,omitempty"`
-	MustSupport []string                    `json:"mustSupport,omitempty"`
-	CodeFilter  []DataRequirementCodeFilter `json:"codeFilter,omitempty"`
-	DateFilter  []DataRequirementDateFilter `json:"dateFilter,omitempty"`
-	Limit       *int                        `json:"limit,omitempty"`
-	Sort        []DataRequirementSort       `json:"sort,omitempty"`
+	Id          *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type        string                      `bson:"type" json:"type"`
+	Profile     []string                    `bson:"profile,omitempty" json:"profile,omitempty"`
+	MustSupport []string                    `bson:"mustSupport,omitempty" json:"mustSupport,omitempty"`
+	CodeFilter  []DataRequirementCodeFilter `bson:"codeFilter,omitempty" json:"codeFilter,omitempty"`
+	DateFilter  []DataRequirementDateFilter `bson:"dateFilter,omitempty" json:"dateFilter,omitempty"`
+	Limit       *int                        `bson:"limit,omitempty" json:"limit,omitempty"`
+	Sort        []DataRequirementSort       `bson:"sort,omitempty" json:"sort,omitempty"`
 }
 type DataRequirementCodeFilter struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	Path        *string     `json:"path,omitempty"`
-	SearchParam *string     `json:"searchParam,omitempty"`
-	ValueSet    *string     `json:"valueSet,omitempty"`
-	Code        []Coding    `json:"code,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Path        *string     `bson:"path,omitempty" json:"path,omitempty"`
+	SearchParam *string     `bson:"searchParam,omitempty" json:"searchParam,omitempty"`
+	ValueSet    *string     `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
+	Code        []Coding    `bson:"code,omitempty" json:"code,omitempty"`
 }
 type DataRequirementDateFilter struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	Path        *string     `json:"path,omitempty"`
-	SearchParam *string     `json:"searchParam,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Path        *string     `bson:"path,omitempty" json:"path,omitempty"`
+	SearchParam *string     `bson:"searchParam,omitempty" json:"searchParam,omitempty"`
 }
 type DataRequirementSort struct {
-	Id        *string       `json:"id,omitempty"`
-	Extension []Extension   `json:"extension,omitempty"`
-	Path      string        `json:"path"`
-	Direction SortDirection `json:"direction"`
+	Id        *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension   `bson:"extension,omitempty" json:"extension,omitempty"`
+	Path      string        `bson:"path" json:"path"`
+	Direction SortDirection `bson:"direction" json:"direction"`
 }

--- a/fhir-models/fhir/detectedIssue.go
+++ b/fhir-models/fhir/detectedIssue.go
@@ -21,39 +21,39 @@ import "encoding/json"
 
 // DetectedIssue is documented here http://hl7.org/fhir/StructureDefinition/DetectedIssue
 type DetectedIssue struct {
-	Id                *string                   `json:"id,omitempty"`
-	Meta              *Meta                     `json:"meta,omitempty"`
-	ImplicitRules     *string                   `json:"implicitRules,omitempty"`
-	Language          *string                   `json:"language,omitempty"`
-	Text              *Narrative                `json:"text,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier              `json:"identifier,omitempty"`
-	Status            ObservationStatus         `json:"status"`
-	Code              *CodeableConcept          `json:"code,omitempty"`
-	Severity          *DetectedIssueSeverity    `json:"severity,omitempty"`
-	Patient           *Reference                `json:"patient,omitempty"`
-	Author            *Reference                `json:"author,omitempty"`
-	Implicated        []Reference               `json:"implicated,omitempty"`
-	Evidence          []DetectedIssueEvidence   `json:"evidence,omitempty"`
-	Detail            *string                   `json:"detail,omitempty"`
-	Reference         *string                   `json:"reference,omitempty"`
-	Mitigation        []DetectedIssueMitigation `json:"mitigation,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            ObservationStatus         `bson:"status" json:"status"`
+	Code              *CodeableConcept          `bson:"code,omitempty" json:"code,omitempty"`
+	Severity          *DetectedIssueSeverity    `bson:"severity,omitempty" json:"severity,omitempty"`
+	Patient           *Reference                `bson:"patient,omitempty" json:"patient,omitempty"`
+	Author            *Reference                `bson:"author,omitempty" json:"author,omitempty"`
+	Implicated        []Reference               `bson:"implicated,omitempty" json:"implicated,omitempty"`
+	Evidence          []DetectedIssueEvidence   `bson:"evidence,omitempty" json:"evidence,omitempty"`
+	Detail            *string                   `bson:"detail,omitempty" json:"detail,omitempty"`
+	Reference         *string                   `bson:"reference,omitempty" json:"reference,omitempty"`
+	Mitigation        []DetectedIssueMitigation `bson:"mitigation,omitempty" json:"mitigation,omitempty"`
 }
 type DetectedIssueEvidence struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Code              []CodeableConcept `json:"code,omitempty"`
-	Detail            []Reference       `json:"detail,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Detail            []Reference       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type DetectedIssueMitigation struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Action            CodeableConcept `json:"action"`
-	Date              *string         `json:"date,omitempty"`
-	Author            *Reference      `json:"author,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Action            CodeableConcept `bson:"action" json:"action"`
+	Date              *string         `bson:"date,omitempty" json:"date,omitempty"`
+	Author            *Reference      `bson:"author,omitempty" json:"author,omitempty"`
 }
 type OtherDetectedIssue DetectedIssue
 

--- a/fhir-models/fhir/device.go
+++ b/fhir-models/fhir/device.go
@@ -21,80 +21,80 @@ import "encoding/json"
 
 // Device is documented here http://hl7.org/fhir/StructureDefinition/Device
 type Device struct {
-	Id                 *string                `json:"id,omitempty"`
-	Meta               *Meta                  `json:"meta,omitempty"`
-	ImplicitRules      *string                `json:"implicitRules,omitempty"`
-	Language           *string                `json:"language,omitempty"`
-	Text               *Narrative             `json:"text,omitempty"`
-	Extension          []Extension            `json:"extension,omitempty"`
-	ModifierExtension  []Extension            `json:"modifierExtension,omitempty"`
-	Identifier         []Identifier           `json:"identifier,omitempty"`
-	Definition         *Reference             `json:"definition,omitempty"`
-	UdiCarrier         []DeviceUdiCarrier     `json:"udiCarrier,omitempty"`
-	Status             *FHIRDeviceStatus      `json:"status,omitempty"`
-	StatusReason       []CodeableConcept      `json:"statusReason,omitempty"`
-	DistinctIdentifier *string                `json:"distinctIdentifier,omitempty"`
-	Manufacturer       *string                `json:"manufacturer,omitempty"`
-	ManufactureDate    *string                `json:"manufactureDate,omitempty"`
-	ExpirationDate     *string                `json:"expirationDate,omitempty"`
-	LotNumber          *string                `json:"lotNumber,omitempty"`
-	SerialNumber       *string                `json:"serialNumber,omitempty"`
-	DeviceName         []DeviceDeviceName     `json:"deviceName,omitempty"`
-	ModelNumber        *string                `json:"modelNumber,omitempty"`
-	PartNumber         *string                `json:"partNumber,omitempty"`
-	Type               *CodeableConcept       `json:"type,omitempty"`
-	Specialization     []DeviceSpecialization `json:"specialization,omitempty"`
-	Version            []DeviceVersion        `json:"version,omitempty"`
-	Property           []DeviceProperty       `json:"property,omitempty"`
-	Patient            *Reference             `json:"patient,omitempty"`
-	Owner              *Reference             `json:"owner,omitempty"`
-	Contact            []ContactPoint         `json:"contact,omitempty"`
-	Location           *Reference             `json:"location,omitempty"`
-	Url                *string                `json:"url,omitempty"`
-	Note               []Annotation           `json:"note,omitempty"`
-	Safety             []CodeableConcept      `json:"safety,omitempty"`
-	Parent             *Reference             `json:"parent,omitempty"`
+	Id                 *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Definition         *Reference             `bson:"definition,omitempty" json:"definition,omitempty"`
+	UdiCarrier         []DeviceUdiCarrier     `bson:"udiCarrier,omitempty" json:"udiCarrier,omitempty"`
+	Status             *FHIRDeviceStatus      `bson:"status,omitempty" json:"status,omitempty"`
+	StatusReason       []CodeableConcept      `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	DistinctIdentifier *string                `bson:"distinctIdentifier,omitempty" json:"distinctIdentifier,omitempty"`
+	Manufacturer       *string                `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	ManufactureDate    *string                `bson:"manufactureDate,omitempty" json:"manufactureDate,omitempty"`
+	ExpirationDate     *string                `bson:"expirationDate,omitempty" json:"expirationDate,omitempty"`
+	LotNumber          *string                `bson:"lotNumber,omitempty" json:"lotNumber,omitempty"`
+	SerialNumber       *string                `bson:"serialNumber,omitempty" json:"serialNumber,omitempty"`
+	DeviceName         []DeviceDeviceName     `bson:"deviceName,omitempty" json:"deviceName,omitempty"`
+	ModelNumber        *string                `bson:"modelNumber,omitempty" json:"modelNumber,omitempty"`
+	PartNumber         *string                `bson:"partNumber,omitempty" json:"partNumber,omitempty"`
+	Type               *CodeableConcept       `bson:"type,omitempty" json:"type,omitempty"`
+	Specialization     []DeviceSpecialization `bson:"specialization,omitempty" json:"specialization,omitempty"`
+	Version            []DeviceVersion        `bson:"version,omitempty" json:"version,omitempty"`
+	Property           []DeviceProperty       `bson:"property,omitempty" json:"property,omitempty"`
+	Patient            *Reference             `bson:"patient,omitempty" json:"patient,omitempty"`
+	Owner              *Reference             `bson:"owner,omitempty" json:"owner,omitempty"`
+	Contact            []ContactPoint         `bson:"contact,omitempty" json:"contact,omitempty"`
+	Location           *Reference             `bson:"location,omitempty" json:"location,omitempty"`
+	Url                *string                `bson:"url,omitempty" json:"url,omitempty"`
+	Note               []Annotation           `bson:"note,omitempty" json:"note,omitempty"`
+	Safety             []CodeableConcept      `bson:"safety,omitempty" json:"safety,omitempty"`
+	Parent             *Reference             `bson:"parent,omitempty" json:"parent,omitempty"`
 }
 type DeviceUdiCarrier struct {
-	Id                *string       `json:"id,omitempty"`
-	Extension         []Extension   `json:"extension,omitempty"`
-	ModifierExtension []Extension   `json:"modifierExtension,omitempty"`
-	DeviceIdentifier  *string       `json:"deviceIdentifier,omitempty"`
-	Issuer            *string       `json:"issuer,omitempty"`
-	Jurisdiction      *string       `json:"jurisdiction,omitempty"`
-	CarrierAIDC       *string       `json:"carrierAIDC,omitempty"`
-	CarrierHRF        *string       `json:"carrierHRF,omitempty"`
-	EntryType         *UDIEntryType `json:"entryType,omitempty"`
+	Id                *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DeviceIdentifier  *string       `bson:"deviceIdentifier,omitempty" json:"deviceIdentifier,omitempty"`
+	Issuer            *string       `bson:"issuer,omitempty" json:"issuer,omitempty"`
+	Jurisdiction      *string       `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	CarrierAIDC       *string       `bson:"carrierAIDC,omitempty" json:"carrierAIDC,omitempty"`
+	CarrierHRF        *string       `bson:"carrierHRF,omitempty" json:"carrierHRF,omitempty"`
+	EntryType         *UDIEntryType `bson:"entryType,omitempty" json:"entryType,omitempty"`
 }
 type DeviceDeviceName struct {
-	Id                *string        `json:"id,omitempty"`
-	Extension         []Extension    `json:"extension,omitempty"`
-	ModifierExtension []Extension    `json:"modifierExtension,omitempty"`
-	Name              string         `json:"name"`
-	Type              DeviceNameType `json:"type"`
+	Id                *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string         `bson:"name" json:"name"`
+	Type              DeviceNameType `bson:"type" json:"type"`
 }
 type DeviceSpecialization struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	SystemType        CodeableConcept `json:"systemType"`
-	Version           *string         `json:"version,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SystemType        CodeableConcept `bson:"systemType" json:"systemType"`
+	Version           *string         `bson:"version,omitempty" json:"version,omitempty"`
 }
 type DeviceVersion struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Component         *Identifier      `json:"component,omitempty"`
-	Value             string           `json:"value"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Component         *Identifier      `bson:"component,omitempty" json:"component,omitempty"`
+	Value             string           `bson:"value" json:"value"`
 }
 type DeviceProperty struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept   `json:"type"`
-	ValueQuantity     []Quantity        `json:"valueQuantity,omitempty"`
-	ValueCode         []CodeableConcept `json:"valueCode,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept   `bson:"type" json:"type"`
+	ValueQuantity     []Quantity        `bson:"valueQuantity,omitempty" json:"valueQuantity,omitempty"`
+	ValueCode         []CodeableConcept `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 }
 type OtherDevice Device
 

--- a/fhir-models/fhir/deviceDefinition.go
+++ b/fhir-models/fhir/deviceDefinition.go
@@ -21,79 +21,79 @@ import "encoding/json"
 
 // DeviceDefinition is documented here http://hl7.org/fhir/StructureDefinition/DeviceDefinition
 type DeviceDefinition struct {
-	Id                      *string                               `json:"id,omitempty"`
-	Meta                    *Meta                                 `json:"meta,omitempty"`
-	ImplicitRules           *string                               `json:"implicitRules,omitempty"`
-	Language                *string                               `json:"language,omitempty"`
-	Text                    *Narrative                            `json:"text,omitempty"`
-	Extension               []Extension                           `json:"extension,omitempty"`
-	ModifierExtension       []Extension                           `json:"modifierExtension,omitempty"`
-	Identifier              []Identifier                          `json:"identifier,omitempty"`
-	UdiDeviceIdentifier     []DeviceDefinitionUdiDeviceIdentifier `json:"udiDeviceIdentifier,omitempty"`
-	DeviceName              []DeviceDefinitionDeviceName          `json:"deviceName,omitempty"`
-	ModelNumber             *string                               `json:"modelNumber,omitempty"`
-	Type                    *CodeableConcept                      `json:"type,omitempty"`
-	Specialization          []DeviceDefinitionSpecialization      `json:"specialization,omitempty"`
-	Version                 []string                              `json:"version,omitempty"`
-	Safety                  []CodeableConcept                     `json:"safety,omitempty"`
-	ShelfLifeStorage        []ProductShelfLife                    `json:"shelfLifeStorage,omitempty"`
-	PhysicalCharacteristics *ProdCharacteristic                   `json:"physicalCharacteristics,omitempty"`
-	LanguageCode            []CodeableConcept                     `json:"languageCode,omitempty"`
-	Capability              []DeviceDefinitionCapability          `json:"capability,omitempty"`
-	Property                []DeviceDefinitionProperty            `json:"property,omitempty"`
-	Owner                   *Reference                            `json:"owner,omitempty"`
-	Contact                 []ContactPoint                        `json:"contact,omitempty"`
-	Url                     *string                               `json:"url,omitempty"`
-	OnlineInformation       *string                               `json:"onlineInformation,omitempty"`
-	Note                    []Annotation                          `json:"note,omitempty"`
-	Quantity                *Quantity                             `json:"quantity,omitempty"`
-	ParentDevice            *Reference                            `json:"parentDevice,omitempty"`
-	Material                []DeviceDefinitionMaterial            `json:"material,omitempty"`
+	Id                      *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                    *Meta                                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules           *string                               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                *string                               `bson:"language,omitempty" json:"language,omitempty"`
+	Text                    *Narrative                            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension               []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier              []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	UdiDeviceIdentifier     []DeviceDefinitionUdiDeviceIdentifier `bson:"udiDeviceIdentifier,omitempty" json:"udiDeviceIdentifier,omitempty"`
+	DeviceName              []DeviceDefinitionDeviceName          `bson:"deviceName,omitempty" json:"deviceName,omitempty"`
+	ModelNumber             *string                               `bson:"modelNumber,omitempty" json:"modelNumber,omitempty"`
+	Type                    *CodeableConcept                      `bson:"type,omitempty" json:"type,omitempty"`
+	Specialization          []DeviceDefinitionSpecialization      `bson:"specialization,omitempty" json:"specialization,omitempty"`
+	Version                 []string                              `bson:"version,omitempty" json:"version,omitempty"`
+	Safety                  []CodeableConcept                     `bson:"safety,omitempty" json:"safety,omitempty"`
+	ShelfLifeStorage        []ProductShelfLife                    `bson:"shelfLifeStorage,omitempty" json:"shelfLifeStorage,omitempty"`
+	PhysicalCharacteristics *ProdCharacteristic                   `bson:"physicalCharacteristics,omitempty" json:"physicalCharacteristics,omitempty"`
+	LanguageCode            []CodeableConcept                     `bson:"languageCode,omitempty" json:"languageCode,omitempty"`
+	Capability              []DeviceDefinitionCapability          `bson:"capability,omitempty" json:"capability,omitempty"`
+	Property                []DeviceDefinitionProperty            `bson:"property,omitempty" json:"property,omitempty"`
+	Owner                   *Reference                            `bson:"owner,omitempty" json:"owner,omitempty"`
+	Contact                 []ContactPoint                        `bson:"contact,omitempty" json:"contact,omitempty"`
+	Url                     *string                               `bson:"url,omitempty" json:"url,omitempty"`
+	OnlineInformation       *string                               `bson:"onlineInformation,omitempty" json:"onlineInformation,omitempty"`
+	Note                    []Annotation                          `bson:"note,omitempty" json:"note,omitempty"`
+	Quantity                *Quantity                             `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	ParentDevice            *Reference                            `bson:"parentDevice,omitempty" json:"parentDevice,omitempty"`
+	Material                []DeviceDefinitionMaterial            `bson:"material,omitempty" json:"material,omitempty"`
 }
 type DeviceDefinitionUdiDeviceIdentifier struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	DeviceIdentifier  string      `json:"deviceIdentifier"`
-	Issuer            string      `json:"issuer"`
-	Jurisdiction      string      `json:"jurisdiction"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DeviceIdentifier  string      `bson:"deviceIdentifier" json:"deviceIdentifier"`
+	Issuer            string      `bson:"issuer" json:"issuer"`
+	Jurisdiction      string      `bson:"jurisdiction" json:"jurisdiction"`
 }
 type DeviceDefinitionDeviceName struct {
-	Id                *string        `json:"id,omitempty"`
-	Extension         []Extension    `json:"extension,omitempty"`
-	ModifierExtension []Extension    `json:"modifierExtension,omitempty"`
-	Name              string         `json:"name"`
-	Type              DeviceNameType `json:"type"`
+	Id                *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string         `bson:"name" json:"name"`
+	Type              DeviceNameType `bson:"type" json:"type"`
 }
 type DeviceDefinitionSpecialization struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	SystemType        string      `json:"systemType"`
-	Version           *string     `json:"version,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SystemType        string      `bson:"systemType" json:"systemType"`
+	Version           *string     `bson:"version,omitempty" json:"version,omitempty"`
 }
 type DeviceDefinitionCapability struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept   `json:"type"`
-	Description       []CodeableConcept `json:"description,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept   `bson:"type" json:"type"`
+	Description       []CodeableConcept `bson:"description,omitempty" json:"description,omitempty"`
 }
 type DeviceDefinitionProperty struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept   `json:"type"`
-	ValueQuantity     []Quantity        `json:"valueQuantity,omitempty"`
-	ValueCode         []CodeableConcept `json:"valueCode,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept   `bson:"type" json:"type"`
+	ValueQuantity     []Quantity        `bson:"valueQuantity,omitempty" json:"valueQuantity,omitempty"`
+	ValueCode         []CodeableConcept `bson:"valueCode,omitempty" json:"valueCode,omitempty"`
 }
 type DeviceDefinitionMaterial struct {
-	Id                  *string         `json:"id,omitempty"`
-	Extension           []Extension     `json:"extension,omitempty"`
-	ModifierExtension   []Extension     `json:"modifierExtension,omitempty"`
-	Substance           CodeableConcept `json:"substance"`
-	Alternate           *bool           `json:"alternate,omitempty"`
-	AllergenicIndicator *bool           `json:"allergenicIndicator,omitempty"`
+	Id                  *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Substance           CodeableConcept `bson:"substance" json:"substance"`
+	Alternate           *bool           `bson:"alternate,omitempty" json:"alternate,omitempty"`
+	AllergenicIndicator *bool           `bson:"allergenicIndicator,omitempty" json:"allergenicIndicator,omitempty"`
 }
 type OtherDeviceDefinition DeviceDefinition
 

--- a/fhir-models/fhir/deviceMetric.go
+++ b/fhir-models/fhir/deviceMetric.go
@@ -21,31 +21,31 @@ import "encoding/json"
 
 // DeviceMetric is documented here http://hl7.org/fhir/StructureDefinition/DeviceMetric
 type DeviceMetric struct {
-	Id                *string                        `json:"id,omitempty"`
-	Meta              *Meta                          `json:"meta,omitempty"`
-	ImplicitRules     *string                        `json:"implicitRules,omitempty"`
-	Language          *string                        `json:"language,omitempty"`
-	Text              *Narrative                     `json:"text,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                   `json:"identifier,omitempty"`
-	Type              CodeableConcept                `json:"type"`
-	Unit              *CodeableConcept               `json:"unit,omitempty"`
-	Source            *Reference                     `json:"source,omitempty"`
-	Parent            *Reference                     `json:"parent,omitempty"`
-	OperationalStatus *DeviceMetricOperationalStatus `json:"operationalStatus,omitempty"`
-	Color             *DeviceMetricColor             `json:"color,omitempty"`
-	Category          DeviceMetricCategory           `json:"category"`
-	MeasurementPeriod *Timing                        `json:"measurementPeriod,omitempty"`
-	Calibration       []DeviceMetricCalibration      `json:"calibration,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type              CodeableConcept                `bson:"type" json:"type"`
+	Unit              *CodeableConcept               `bson:"unit,omitempty" json:"unit,omitempty"`
+	Source            *Reference                     `bson:"source,omitempty" json:"source,omitempty"`
+	Parent            *Reference                     `bson:"parent,omitempty" json:"parent,omitempty"`
+	OperationalStatus *DeviceMetricOperationalStatus `bson:"operationalStatus,omitempty" json:"operationalStatus,omitempty"`
+	Color             *DeviceMetricColor             `bson:"color,omitempty" json:"color,omitempty"`
+	Category          DeviceMetricCategory           `bson:"category" json:"category"`
+	MeasurementPeriod *Timing                        `bson:"measurementPeriod,omitempty" json:"measurementPeriod,omitempty"`
+	Calibration       []DeviceMetricCalibration      `bson:"calibration,omitempty" json:"calibration,omitempty"`
 }
 type DeviceMetricCalibration struct {
-	Id                *string                       `json:"id,omitempty"`
-	Extension         []Extension                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                   `json:"modifierExtension,omitempty"`
-	Type              *DeviceMetricCalibrationType  `json:"type,omitempty"`
-	State             *DeviceMetricCalibrationState `json:"state,omitempty"`
-	Time              *string                       `json:"time,omitempty"`
+	Id                *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *DeviceMetricCalibrationType  `bson:"type,omitempty" json:"type,omitempty"`
+	State             *DeviceMetricCalibrationState `bson:"state,omitempty" json:"state,omitempty"`
+	Time              *string                       `bson:"time,omitempty" json:"time,omitempty"`
 }
 type OtherDeviceMetric DeviceMetric
 

--- a/fhir-models/fhir/deviceRequest.go
+++ b/fhir-models/fhir/deviceRequest.go
@@ -21,41 +21,41 @@ import "encoding/json"
 
 // DeviceRequest is documented here http://hl7.org/fhir/StructureDefinition/DeviceRequest
 type DeviceRequest struct {
-	Id                    *string                  `json:"id,omitempty"`
-	Meta                  *Meta                    `json:"meta,omitempty"`
-	ImplicitRules         *string                  `json:"implicitRules,omitempty"`
-	Language              *string                  `json:"language,omitempty"`
-	Text                  *Narrative               `json:"text,omitempty"`
-	Extension             []Extension              `json:"extension,omitempty"`
-	ModifierExtension     []Extension              `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier             `json:"identifier,omitempty"`
-	InstantiatesCanonical []string                 `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string                 `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference              `json:"basedOn,omitempty"`
-	PriorRequest          []Reference              `json:"priorRequest,omitempty"`
-	GroupIdentifier       *Identifier              `json:"groupIdentifier,omitempty"`
-	Status                *RequestStatus           `json:"status,omitempty"`
-	Intent                RequestIntent            `json:"intent"`
-	Priority              *RequestPriority         `json:"priority,omitempty"`
-	Parameter             []DeviceRequestParameter `json:"parameter,omitempty"`
-	Subject               Reference                `json:"subject"`
-	Encounter             *Reference               `json:"encounter,omitempty"`
-	AuthoredOn            *string                  `json:"authoredOn,omitempty"`
-	Requester             *Reference               `json:"requester,omitempty"`
-	PerformerType         *CodeableConcept         `json:"performerType,omitempty"`
-	Performer             *Reference               `json:"performer,omitempty"`
-	ReasonCode            []CodeableConcept        `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference              `json:"reasonReference,omitempty"`
-	Insurance             []Reference              `json:"insurance,omitempty"`
-	SupportingInfo        []Reference              `json:"supportingInfo,omitempty"`
-	Note                  []Annotation             `json:"note,omitempty"`
-	RelevantHistory       []Reference              `json:"relevantHistory,omitempty"`
+	Id                    *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string                 `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string                 `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference              `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PriorRequest          []Reference              `bson:"priorRequest,omitempty" json:"priorRequest,omitempty"`
+	GroupIdentifier       *Identifier              `bson:"groupIdentifier,omitempty" json:"groupIdentifier,omitempty"`
+	Status                *RequestStatus           `bson:"status,omitempty" json:"status,omitempty"`
+	Intent                RequestIntent            `bson:"intent" json:"intent"`
+	Priority              *RequestPriority         `bson:"priority,omitempty" json:"priority,omitempty"`
+	Parameter             []DeviceRequestParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	Subject               Reference                `bson:"subject" json:"subject"`
+	Encounter             *Reference               `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	AuthoredOn            *string                  `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	Requester             *Reference               `bson:"requester,omitempty" json:"requester,omitempty"`
+	PerformerType         *CodeableConcept         `bson:"performerType,omitempty" json:"performerType,omitempty"`
+	Performer             *Reference               `bson:"performer,omitempty" json:"performer,omitempty"`
+	ReasonCode            []CodeableConcept        `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference              `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Insurance             []Reference              `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	SupportingInfo        []Reference              `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Note                  []Annotation             `bson:"note,omitempty" json:"note,omitempty"`
+	RelevantHistory       []Reference              `bson:"relevantHistory,omitempty" json:"relevantHistory,omitempty"`
 }
 type DeviceRequestParameter struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 }
 type OtherDeviceRequest DeviceRequest
 

--- a/fhir-models/fhir/deviceUseStatement.go
+++ b/fhir-models/fhir/deviceUseStatement.go
@@ -21,25 +21,25 @@ import "encoding/json"
 
 // DeviceUseStatement is documented here http://hl7.org/fhir/StructureDefinition/DeviceUseStatement
 type DeviceUseStatement struct {
-	Id                *string                  `json:"id,omitempty"`
-	Meta              *Meta                    `json:"meta,omitempty"`
-	ImplicitRules     *string                  `json:"implicitRules,omitempty"`
-	Language          *string                  `json:"language,omitempty"`
-	Text              *Narrative               `json:"text,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier             `json:"identifier,omitempty"`
-	BasedOn           []Reference              `json:"basedOn,omitempty"`
-	Status            DeviceUseStatementStatus `json:"status"`
-	Subject           Reference                `json:"subject"`
-	DerivedFrom       []Reference              `json:"derivedFrom,omitempty"`
-	RecordedOn        *string                  `json:"recordedOn,omitempty"`
-	Source            *Reference               `json:"source,omitempty"`
-	Device            Reference                `json:"device"`
-	ReasonCode        []CodeableConcept        `json:"reasonCode,omitempty"`
-	ReasonReference   []Reference              `json:"reasonReference,omitempty"`
-	BodySite          *CodeableConcept         `json:"bodySite,omitempty"`
-	Note              []Annotation             `json:"note,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference              `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Status            DeviceUseStatementStatus `bson:"status" json:"status"`
+	Subject           Reference                `bson:"subject" json:"subject"`
+	DerivedFrom       []Reference              `bson:"derivedFrom,omitempty" json:"derivedFrom,omitempty"`
+	RecordedOn        *string                  `bson:"recordedOn,omitempty" json:"recordedOn,omitempty"`
+	Source            *Reference               `bson:"source,omitempty" json:"source,omitempty"`
+	Device            Reference                `bson:"device" json:"device"`
+	ReasonCode        []CodeableConcept        `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference   []Reference              `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	BodySite          *CodeableConcept         `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Note              []Annotation             `bson:"note,omitempty" json:"note,omitempty"`
 }
 type OtherDeviceUseStatement DeviceUseStatement
 

--- a/fhir-models/fhir/diagnosticReport.go
+++ b/fhir-models/fhir/diagnosticReport.go
@@ -21,37 +21,37 @@ import "encoding/json"
 
 // DiagnosticReport is documented here http://hl7.org/fhir/StructureDefinition/DiagnosticReport
 type DiagnosticReport struct {
-	Id                 *string                 `json:"id,omitempty"`
-	Meta               *Meta                   `json:"meta,omitempty"`
-	ImplicitRules      *string                 `json:"implicitRules,omitempty"`
-	Language           *string                 `json:"language,omitempty"`
-	Text               *Narrative              `json:"text,omitempty"`
-	Extension          []Extension             `json:"extension,omitempty"`
-	ModifierExtension  []Extension             `json:"modifierExtension,omitempty"`
-	Identifier         []Identifier            `json:"identifier,omitempty"`
-	BasedOn            []Reference             `json:"basedOn,omitempty"`
-	Status             DiagnosticReportStatus  `json:"status"`
-	Category           []CodeableConcept       `json:"category,omitempty"`
-	Code               CodeableConcept         `json:"code"`
-	Subject            *Reference              `json:"subject,omitempty"`
-	Encounter          *Reference              `json:"encounter,omitempty"`
-	Issued             *string                 `json:"issued,omitempty"`
-	Performer          []Reference             `json:"performer,omitempty"`
-	ResultsInterpreter []Reference             `json:"resultsInterpreter,omitempty"`
-	Specimen           []Reference             `json:"specimen,omitempty"`
-	Result             []Reference             `json:"result,omitempty"`
-	ImagingStudy       []Reference             `json:"imagingStudy,omitempty"`
-	Media              []DiagnosticReportMedia `json:"media,omitempty"`
-	Conclusion         *string                 `json:"conclusion,omitempty"`
-	ConclusionCode     []CodeableConcept       `json:"conclusionCode,omitempty"`
-	PresentedForm      []Attachment            `json:"presentedForm,omitempty"`
+	Id                 *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         []Identifier            `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn            []Reference             `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Status             DiagnosticReportStatus  `bson:"status" json:"status"`
+	Category           []CodeableConcept       `bson:"category,omitempty" json:"category,omitempty"`
+	Code               CodeableConcept         `bson:"code" json:"code"`
+	Subject            *Reference              `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter          *Reference              `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Issued             *string                 `bson:"issued,omitempty" json:"issued,omitempty"`
+	Performer          []Reference             `bson:"performer,omitempty" json:"performer,omitempty"`
+	ResultsInterpreter []Reference             `bson:"resultsInterpreter,omitempty" json:"resultsInterpreter,omitempty"`
+	Specimen           []Reference             `bson:"specimen,omitempty" json:"specimen,omitempty"`
+	Result             []Reference             `bson:"result,omitempty" json:"result,omitempty"`
+	ImagingStudy       []Reference             `bson:"imagingStudy,omitempty" json:"imagingStudy,omitempty"`
+	Media              []DiagnosticReportMedia `bson:"media,omitempty" json:"media,omitempty"`
+	Conclusion         *string                 `bson:"conclusion,omitempty" json:"conclusion,omitempty"`
+	ConclusionCode     []CodeableConcept       `bson:"conclusionCode,omitempty" json:"conclusionCode,omitempty"`
+	PresentedForm      []Attachment            `bson:"presentedForm,omitempty" json:"presentedForm,omitempty"`
 }
 type DiagnosticReportMedia struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Comment           *string     `json:"comment,omitempty"`
-	Link              Reference   `json:"link"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Comment           *string     `bson:"comment,omitempty" json:"comment,omitempty"`
+	Link              Reference   `bson:"link" json:"link"`
 }
 type OtherDiagnosticReport DiagnosticReport
 

--- a/fhir-models/fhir/documentManifest.go
+++ b/fhir-models/fhir/documentManifest.go
@@ -21,32 +21,32 @@ import "encoding/json"
 
 // DocumentManifest is documented here http://hl7.org/fhir/StructureDefinition/DocumentManifest
 type DocumentManifest struct {
-	Id                *string                   `json:"id,omitempty"`
-	Meta              *Meta                     `json:"meta,omitempty"`
-	ImplicitRules     *string                   `json:"implicitRules,omitempty"`
-	Language          *string                   `json:"language,omitempty"`
-	Text              *Narrative                `json:"text,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	MasterIdentifier  *Identifier               `json:"masterIdentifier,omitempty"`
-	Identifier        []Identifier              `json:"identifier,omitempty"`
-	Status            DocumentReferenceStatus   `json:"status"`
-	Type              *CodeableConcept          `json:"type,omitempty"`
-	Subject           *Reference                `json:"subject,omitempty"`
-	Created           *string                   `json:"created,omitempty"`
-	Author            []Reference               `json:"author,omitempty"`
-	Recipient         []Reference               `json:"recipient,omitempty"`
-	Source            *string                   `json:"source,omitempty"`
-	Description       *string                   `json:"description,omitempty"`
-	Content           []Reference               `json:"content"`
-	Related           []DocumentManifestRelated `json:"related,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	MasterIdentifier  *Identifier               `bson:"masterIdentifier,omitempty" json:"masterIdentifier,omitempty"`
+	Identifier        []Identifier              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            DocumentReferenceStatus   `bson:"status" json:"status"`
+	Type              *CodeableConcept          `bson:"type,omitempty" json:"type,omitempty"`
+	Subject           *Reference                `bson:"subject,omitempty" json:"subject,omitempty"`
+	Created           *string                   `bson:"created,omitempty" json:"created,omitempty"`
+	Author            []Reference               `bson:"author,omitempty" json:"author,omitempty"`
+	Recipient         []Reference               `bson:"recipient,omitempty" json:"recipient,omitempty"`
+	Source            *string                   `bson:"source,omitempty" json:"source,omitempty"`
+	Description       *string                   `bson:"description,omitempty" json:"description,omitempty"`
+	Content           []Reference               `bson:"content" json:"content"`
+	Related           []DocumentManifestRelated `bson:"related,omitempty" json:"related,omitempty"`
 }
 type DocumentManifestRelated struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier `json:"identifier,omitempty"`
-	Ref               *Reference  `json:"ref,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Ref               *Reference  `bson:"ref,omitempty" json:"ref,omitempty"`
 }
 type OtherDocumentManifest DocumentManifest
 

--- a/fhir-models/fhir/documentReference.go
+++ b/fhir-models/fhir/documentReference.go
@@ -21,55 +21,55 @@ import "encoding/json"
 
 // DocumentReference is documented here http://hl7.org/fhir/StructureDefinition/DocumentReference
 type DocumentReference struct {
-	Id                *string                      `json:"id,omitempty"`
-	Meta              *Meta                        `json:"meta,omitempty"`
-	ImplicitRules     *string                      `json:"implicitRules,omitempty"`
-	Language          *string                      `json:"language,omitempty"`
-	Text              *Narrative                   `json:"text,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	MasterIdentifier  *Identifier                  `json:"masterIdentifier,omitempty"`
-	Identifier        []Identifier                 `json:"identifier,omitempty"`
-	Status            DocumentReferenceStatus      `json:"status"`
-	DocStatus         *CompositionStatus           `json:"docStatus,omitempty"`
-	Type              *CodeableConcept             `json:"type,omitempty"`
-	Category          []CodeableConcept            `json:"category,omitempty"`
-	Subject           *Reference                   `json:"subject,omitempty"`
-	Date              *string                      `json:"date,omitempty"`
-	Author            []Reference                  `json:"author,omitempty"`
-	Authenticator     *Reference                   `json:"authenticator,omitempty"`
-	Custodian         *Reference                   `json:"custodian,omitempty"`
-	RelatesTo         []DocumentReferenceRelatesTo `json:"relatesTo,omitempty"`
-	Description       *string                      `json:"description,omitempty"`
-	SecurityLabel     []CodeableConcept            `json:"securityLabel,omitempty"`
-	Content           []DocumentReferenceContent   `json:"content"`
-	Context           *DocumentReferenceContext    `json:"context,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	MasterIdentifier  *Identifier                  `bson:"masterIdentifier,omitempty" json:"masterIdentifier,omitempty"`
+	Identifier        []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            DocumentReferenceStatus      `bson:"status" json:"status"`
+	DocStatus         *CompositionStatus           `bson:"docStatus,omitempty" json:"docStatus,omitempty"`
+	Type              *CodeableConcept             `bson:"type,omitempty" json:"type,omitempty"`
+	Category          []CodeableConcept            `bson:"category,omitempty" json:"category,omitempty"`
+	Subject           *Reference                   `bson:"subject,omitempty" json:"subject,omitempty"`
+	Date              *string                      `bson:"date,omitempty" json:"date,omitempty"`
+	Author            []Reference                  `bson:"author,omitempty" json:"author,omitempty"`
+	Authenticator     *Reference                   `bson:"authenticator,omitempty" json:"authenticator,omitempty"`
+	Custodian         *Reference                   `bson:"custodian,omitempty" json:"custodian,omitempty"`
+	RelatesTo         []DocumentReferenceRelatesTo `bson:"relatesTo,omitempty" json:"relatesTo,omitempty"`
+	Description       *string                      `bson:"description,omitempty" json:"description,omitempty"`
+	SecurityLabel     []CodeableConcept            `bson:"securityLabel,omitempty" json:"securityLabel,omitempty"`
+	Content           []DocumentReferenceContent   `bson:"content" json:"content"`
+	Context           *DocumentReferenceContext    `bson:"context,omitempty" json:"context,omitempty"`
 }
 type DocumentReferenceRelatesTo struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Code              DocumentRelationshipType `json:"code"`
-	Target            Reference                `json:"target"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              DocumentRelationshipType `bson:"code" json:"code"`
+	Target            Reference                `bson:"target" json:"target"`
 }
 type DocumentReferenceContent struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Attachment        Attachment  `json:"attachment"`
-	Format            *Coding     `json:"format,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Attachment        Attachment  `bson:"attachment" json:"attachment"`
+	Format            *Coding     `bson:"format,omitempty" json:"format,omitempty"`
 }
 type DocumentReferenceContext struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Encounter         []Reference       `json:"encounter,omitempty"`
-	Event             []CodeableConcept `json:"event,omitempty"`
-	Period            *Period           `json:"period,omitempty"`
-	FacilityType      *CodeableConcept  `json:"facilityType,omitempty"`
-	PracticeSetting   *CodeableConcept  `json:"practiceSetting,omitempty"`
-	SourcePatientInfo *Reference        `json:"sourcePatientInfo,omitempty"`
-	Related           []Reference       `json:"related,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Encounter         []Reference       `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Event             []CodeableConcept `bson:"event,omitempty" json:"event,omitempty"`
+	Period            *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	FacilityType      *CodeableConcept  `bson:"facilityType,omitempty" json:"facilityType,omitempty"`
+	PracticeSetting   *CodeableConcept  `bson:"practiceSetting,omitempty" json:"practiceSetting,omitempty"`
+	SourcePatientInfo *Reference        `bson:"sourcePatientInfo,omitempty" json:"sourcePatientInfo,omitempty"`
+	Related           []Reference       `bson:"related,omitempty" json:"related,omitempty"`
 }
 type OtherDocumentReference DocumentReference
 

--- a/fhir-models/fhir/domainResource.go
+++ b/fhir-models/fhir/domainResource.go
@@ -21,13 +21,13 @@ import "encoding/json"
 
 // DomainResource is documented here http://hl7.org/fhir/StructureDefinition/DomainResource
 type DomainResource struct {
-	Id                *string     `json:"id,omitempty"`
-	Meta              *Meta       `json:"meta,omitempty"`
-	ImplicitRules     *string     `json:"implicitRules,omitempty"`
-	Language          *string     `json:"language,omitempty"`
-	Text              *Narrative  `json:"text,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherDomainResource DomainResource
 

--- a/fhir-models/fhir/dosage.go
+++ b/fhir-models/fhir/dosage.go
@@ -19,24 +19,24 @@ package fhir
 
 // Dosage is documented here http://hl7.org/fhir/StructureDefinition/Dosage
 type Dosage struct {
-	Id                       *string             `json:"id,omitempty"`
-	Extension                []Extension         `json:"extension,omitempty"`
-	ModifierExtension        []Extension         `json:"modifierExtension,omitempty"`
-	Sequence                 *int                `json:"sequence,omitempty"`
-	Text                     *string             `json:"text,omitempty"`
-	AdditionalInstruction    []CodeableConcept   `json:"additionalInstruction,omitempty"`
-	PatientInstruction       *string             `json:"patientInstruction,omitempty"`
-	Timing                   *Timing             `json:"timing,omitempty"`
-	Site                     *CodeableConcept    `json:"site,omitempty"`
-	Route                    *CodeableConcept    `json:"route,omitempty"`
-	Method                   *CodeableConcept    `json:"method,omitempty"`
-	DoseAndRate              []DosageDoseAndRate `json:"doseAndRate,omitempty"`
-	MaxDosePerPeriod         *Ratio              `json:"maxDosePerPeriod,omitempty"`
-	MaxDosePerAdministration *Quantity           `json:"maxDosePerAdministration,omitempty"`
-	MaxDosePerLifetime       *Quantity           `json:"maxDosePerLifetime,omitempty"`
+	Id                       *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension        []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence                 *int                `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Text                     *string             `bson:"text,omitempty" json:"text,omitempty"`
+	AdditionalInstruction    []CodeableConcept   `bson:"additionalInstruction,omitempty" json:"additionalInstruction,omitempty"`
+	PatientInstruction       *string             `bson:"patientInstruction,omitempty" json:"patientInstruction,omitempty"`
+	Timing                   *Timing             `bson:"timing,omitempty" json:"timing,omitempty"`
+	Site                     *CodeableConcept    `bson:"site,omitempty" json:"site,omitempty"`
+	Route                    *CodeableConcept    `bson:"route,omitempty" json:"route,omitempty"`
+	Method                   *CodeableConcept    `bson:"method,omitempty" json:"method,omitempty"`
+	DoseAndRate              []DosageDoseAndRate `bson:"doseAndRate,omitempty" json:"doseAndRate,omitempty"`
+	MaxDosePerPeriod         *Ratio              `bson:"maxDosePerPeriod,omitempty" json:"maxDosePerPeriod,omitempty"`
+	MaxDosePerAdministration *Quantity           `bson:"maxDosePerAdministration,omitempty" json:"maxDosePerAdministration,omitempty"`
+	MaxDosePerLifetime       *Quantity           `bson:"maxDosePerLifetime,omitempty" json:"maxDosePerLifetime,omitempty"`
 }
 type DosageDoseAndRate struct {
-	Id        *string          `json:"id,omitempty"`
-	Extension []Extension      `json:"extension,omitempty"`
-	Type      *CodeableConcept `json:"type,omitempty"`
+	Id        *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type      *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 }

--- a/fhir-models/fhir/duration.go
+++ b/fhir-models/fhir/duration.go
@@ -19,11 +19,11 @@ package fhir
 
 // Duration is documented here http://hl7.org/fhir/StructureDefinition/Duration
 type Duration struct {
-	Id         *string             `json:"id,omitempty"`
-	Extension  []Extension         `json:"extension,omitempty"`
-	Value      *string             `json:"value,omitempty"`
-	Comparator *QuantityComparator `json:"comparator,omitempty"`
-	Unit       *string             `json:"unit,omitempty"`
-	System     *string             `json:"system,omitempty"`
-	Code       *string             `json:"code,omitempty"`
+	Id         *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
+	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
+	System     *string             `bson:"system,omitempty" json:"system,omitempty"`
+	Code       *string             `bson:"code,omitempty" json:"code,omitempty"`
 }

--- a/fhir-models/fhir/effectEvidenceSynthesis.go
+++ b/fhir-models/fhir/effectEvidenceSynthesis.go
@@ -21,99 +21,99 @@ import "encoding/json"
 
 // EffectEvidenceSynthesis is documented here http://hl7.org/fhir/StructureDefinition/EffectEvidenceSynthesis
 type EffectEvidenceSynthesis struct {
-	Id                  *string                                    `json:"id,omitempty"`
-	Meta                *Meta                                      `json:"meta,omitempty"`
-	ImplicitRules       *string                                    `json:"implicitRules,omitempty"`
-	Language            *string                                    `json:"language,omitempty"`
-	Text                *Narrative                                 `json:"text,omitempty"`
-	Extension           []Extension                                `json:"extension,omitempty"`
-	ModifierExtension   []Extension                                `json:"modifierExtension,omitempty"`
-	Url                 *string                                    `json:"url,omitempty"`
-	Identifier          []Identifier                               `json:"identifier,omitempty"`
-	Version             *string                                    `json:"version,omitempty"`
-	Name                *string                                    `json:"name,omitempty"`
-	Title               *string                                    `json:"title,omitempty"`
-	Status              PublicationStatus                          `json:"status"`
-	Date                *string                                    `json:"date,omitempty"`
-	Publisher           *string                                    `json:"publisher,omitempty"`
-	Contact             []ContactDetail                            `json:"contact,omitempty"`
-	Description         *string                                    `json:"description,omitempty"`
-	Note                []Annotation                               `json:"note,omitempty"`
-	UseContext          []UsageContext                             `json:"useContext,omitempty"`
-	Jurisdiction        []CodeableConcept                          `json:"jurisdiction,omitempty"`
-	Copyright           *string                                    `json:"copyright,omitempty"`
-	ApprovalDate        *string                                    `json:"approvalDate,omitempty"`
-	LastReviewDate      *string                                    `json:"lastReviewDate,omitempty"`
-	EffectivePeriod     *Period                                    `json:"effectivePeriod,omitempty"`
-	Topic               []CodeableConcept                          `json:"topic,omitempty"`
-	Author              []ContactDetail                            `json:"author,omitempty"`
-	Editor              []ContactDetail                            `json:"editor,omitempty"`
-	Reviewer            []ContactDetail                            `json:"reviewer,omitempty"`
-	Endorser            []ContactDetail                            `json:"endorser,omitempty"`
-	RelatedArtifact     []RelatedArtifact                          `json:"relatedArtifact,omitempty"`
-	SynthesisType       *CodeableConcept                           `json:"synthesisType,omitempty"`
-	StudyType           *CodeableConcept                           `json:"studyType,omitempty"`
-	Population          Reference                                  `json:"population"`
-	Exposure            Reference                                  `json:"exposure"`
-	ExposureAlternative Reference                                  `json:"exposureAlternative"`
-	Outcome             Reference                                  `json:"outcome"`
-	SampleSize          *EffectEvidenceSynthesisSampleSize         `json:"sampleSize,omitempty"`
-	ResultsByExposure   []EffectEvidenceSynthesisResultsByExposure `json:"resultsByExposure,omitempty"`
-	EffectEstimate      []EffectEvidenceSynthesisEffectEstimate    `json:"effectEstimate,omitempty"`
-	Certainty           []EffectEvidenceSynthesisCertainty         `json:"certainty,omitempty"`
+	Id                  *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string                                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string                                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative                                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url                 *string                                    `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier          []Identifier                               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version             *string                                    `bson:"version,omitempty" json:"version,omitempty"`
+	Name                *string                                    `bson:"name,omitempty" json:"name,omitempty"`
+	Title               *string                                    `bson:"title,omitempty" json:"title,omitempty"`
+	Status              PublicationStatus                          `bson:"status" json:"status"`
+	Date                *string                                    `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher           *string                                    `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact             []ContactDetail                            `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description         *string                                    `bson:"description,omitempty" json:"description,omitempty"`
+	Note                []Annotation                               `bson:"note,omitempty" json:"note,omitempty"`
+	UseContext          []UsageContext                             `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction        []CodeableConcept                          `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright           *string                                    `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate        *string                                    `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate      *string                                    `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod     *Period                                    `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic               []CodeableConcept                          `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author              []ContactDetail                            `bson:"author,omitempty" json:"author,omitempty"`
+	Editor              []ContactDetail                            `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer            []ContactDetail                            `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser            []ContactDetail                            `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact     []RelatedArtifact                          `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	SynthesisType       *CodeableConcept                           `bson:"synthesisType,omitempty" json:"synthesisType,omitempty"`
+	StudyType           *CodeableConcept                           `bson:"studyType,omitempty" json:"studyType,omitempty"`
+	Population          Reference                                  `bson:"population" json:"population"`
+	Exposure            Reference                                  `bson:"exposure" json:"exposure"`
+	ExposureAlternative Reference                                  `bson:"exposureAlternative" json:"exposureAlternative"`
+	Outcome             Reference                                  `bson:"outcome" json:"outcome"`
+	SampleSize          *EffectEvidenceSynthesisSampleSize         `bson:"sampleSize,omitempty" json:"sampleSize,omitempty"`
+	ResultsByExposure   []EffectEvidenceSynthesisResultsByExposure `bson:"resultsByExposure,omitempty" json:"resultsByExposure,omitempty"`
+	EffectEstimate      []EffectEvidenceSynthesisEffectEstimate    `bson:"effectEstimate,omitempty" json:"effectEstimate,omitempty"`
+	Certainty           []EffectEvidenceSynthesisCertainty         `bson:"certainty,omitempty" json:"certainty,omitempty"`
 }
 type EffectEvidenceSynthesisSampleSize struct {
-	Id                   *string     `json:"id,omitempty"`
-	Extension            []Extension `json:"extension,omitempty"`
-	ModifierExtension    []Extension `json:"modifierExtension,omitempty"`
-	Description          *string     `json:"description,omitempty"`
-	NumberOfStudies      *int        `json:"numberOfStudies,omitempty"`
-	NumberOfParticipants *int        `json:"numberOfParticipants,omitempty"`
+	Id                   *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension            []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description          *string     `bson:"description,omitempty" json:"description,omitempty"`
+	NumberOfStudies      *int        `bson:"numberOfStudies,omitempty" json:"numberOfStudies,omitempty"`
+	NumberOfParticipants *int        `bson:"numberOfParticipants,omitempty" json:"numberOfParticipants,omitempty"`
 }
 type EffectEvidenceSynthesisResultsByExposure struct {
-	Id                    *string          `json:"id,omitempty"`
-	Extension             []Extension      `json:"extension,omitempty"`
-	ModifierExtension     []Extension      `json:"modifierExtension,omitempty"`
-	Description           *string          `json:"description,omitempty"`
-	ExposureState         *ExposureState   `json:"exposureState,omitempty"`
-	VariantState          *CodeableConcept `json:"variantState,omitempty"`
-	RiskEvidenceSynthesis Reference        `json:"riskEvidenceSynthesis"`
+	Id                    *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension             []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description           *string          `bson:"description,omitempty" json:"description,omitempty"`
+	ExposureState         *ExposureState   `bson:"exposureState,omitempty" json:"exposureState,omitempty"`
+	VariantState          *CodeableConcept `bson:"variantState,omitempty" json:"variantState,omitempty"`
+	RiskEvidenceSynthesis Reference        `bson:"riskEvidenceSynthesis" json:"riskEvidenceSynthesis"`
 }
 type EffectEvidenceSynthesisEffectEstimate struct {
-	Id                *string                                                  `json:"id,omitempty"`
-	Extension         []Extension                                              `json:"extension,omitempty"`
-	ModifierExtension []Extension                                              `json:"modifierExtension,omitempty"`
-	Description       *string                                                  `json:"description,omitempty"`
-	Type              *CodeableConcept                                         `json:"type,omitempty"`
-	VariantState      *CodeableConcept                                         `json:"variantState,omitempty"`
-	Value             *string                                                  `json:"value,omitempty"`
-	UnitOfMeasure     *CodeableConcept                                         `json:"unitOfMeasure,omitempty"`
-	PrecisionEstimate []EffectEvidenceSynthesisEffectEstimatePrecisionEstimate `json:"precisionEstimate,omitempty"`
+	Id                *string                                                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string                                                  `bson:"description,omitempty" json:"description,omitempty"`
+	Type              *CodeableConcept                                         `bson:"type,omitempty" json:"type,omitempty"`
+	VariantState      *CodeableConcept                                         `bson:"variantState,omitempty" json:"variantState,omitempty"`
+	Value             *string                                                  `bson:"value,omitempty" json:"value,omitempty"`
+	UnitOfMeasure     *CodeableConcept                                         `bson:"unitOfMeasure,omitempty" json:"unitOfMeasure,omitempty"`
+	PrecisionEstimate []EffectEvidenceSynthesisEffectEstimatePrecisionEstimate `bson:"precisionEstimate,omitempty" json:"precisionEstimate,omitempty"`
 }
 type EffectEvidenceSynthesisEffectEstimatePrecisionEstimate struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Level             *string          `json:"level,omitempty"`
-	From              *string          `json:"from,omitempty"`
-	To                *string          `json:"to,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Level             *string          `bson:"level,omitempty" json:"level,omitempty"`
+	From              *string          `bson:"from,omitempty" json:"from,omitempty"`
+	To                *string          `bson:"to,omitempty" json:"to,omitempty"`
 }
 type EffectEvidenceSynthesisCertainty struct {
-	Id                    *string                                                 `json:"id,omitempty"`
-	Extension             []Extension                                             `json:"extension,omitempty"`
-	ModifierExtension     []Extension                                             `json:"modifierExtension,omitempty"`
-	Rating                []CodeableConcept                                       `json:"rating,omitempty"`
-	Note                  []Annotation                                            `json:"note,omitempty"`
-	CertaintySubcomponent []EffectEvidenceSynthesisCertaintyCertaintySubcomponent `json:"certaintySubcomponent,omitempty"`
+	Id                    *string                                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension             []Extension                                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Rating                []CodeableConcept                                       `bson:"rating,omitempty" json:"rating,omitempty"`
+	Note                  []Annotation                                            `bson:"note,omitempty" json:"note,omitempty"`
+	CertaintySubcomponent []EffectEvidenceSynthesisCertaintyCertaintySubcomponent `bson:"certaintySubcomponent,omitempty" json:"certaintySubcomponent,omitempty"`
 }
 type EffectEvidenceSynthesisCertaintyCertaintySubcomponent struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept  `json:"type,omitempty"`
-	Rating            []CodeableConcept `json:"rating,omitempty"`
-	Note              []Annotation      `json:"note,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	Rating            []CodeableConcept `bson:"rating,omitempty" json:"rating,omitempty"`
+	Note              []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
 }
 type OtherEffectEvidenceSynthesis EffectEvidenceSynthesis
 

--- a/fhir-models/fhir/elementDefinition.go
+++ b/fhir-models/fhir/elementDefinition.go
@@ -19,97 +19,97 @@ package fhir
 
 // ElementDefinition is documented here http://hl7.org/fhir/StructureDefinition/ElementDefinition
 type ElementDefinition struct {
-	Id                  *string                       `json:"id,omitempty"`
-	Extension           []Extension                   `json:"extension,omitempty"`
-	ModifierExtension   []Extension                   `json:"modifierExtension,omitempty"`
-	Path                string                        `json:"path"`
-	Representation      []PropertyRepresentation      `json:"representation,omitempty"`
-	SliceName           *string                       `json:"sliceName,omitempty"`
-	SliceIsConstraining *bool                         `json:"sliceIsConstraining,omitempty"`
-	Label               *string                       `json:"label,omitempty"`
-	Code                []Coding                      `json:"code,omitempty"`
-	Slicing             *ElementDefinitionSlicing     `json:"slicing,omitempty"`
-	Short               *string                       `json:"short,omitempty"`
-	Definition          *string                       `json:"definition,omitempty"`
-	Comment             *string                       `json:"comment,omitempty"`
-	Requirements        *string                       `json:"requirements,omitempty"`
-	Alias               []string                      `json:"alias,omitempty"`
-	Min                 *int                          `json:"min,omitempty"`
-	Max                 *string                       `json:"max,omitempty"`
-	Base                *ElementDefinitionBase        `json:"base,omitempty"`
-	ContentReference    *string                       `json:"contentReference,omitempty"`
-	Type                []ElementDefinitionType       `json:"type,omitempty"`
-	MeaningWhenMissing  *string                       `json:"meaningWhenMissing,omitempty"`
-	OrderMeaning        *string                       `json:"orderMeaning,omitempty"`
-	Example             []ElementDefinitionExample    `json:"example,omitempty"`
-	MaxLength           *int                          `json:"maxLength,omitempty"`
-	Condition           []string                      `json:"condition,omitempty"`
-	Constraint          []ElementDefinitionConstraint `json:"constraint,omitempty"`
-	MustSupport         *bool                         `json:"mustSupport,omitempty"`
-	IsModifier          *bool                         `json:"isModifier,omitempty"`
-	IsModifierReason    *string                       `json:"isModifierReason,omitempty"`
-	IsSummary           *bool                         `json:"isSummary,omitempty"`
-	Binding             *ElementDefinitionBinding     `json:"binding,omitempty"`
-	Mapping             []ElementDefinitionMapping    `json:"mapping,omitempty"`
+	Id                  *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Path                string                        `bson:"path" json:"path"`
+	Representation      []PropertyRepresentation      `bson:"representation,omitempty" json:"representation,omitempty"`
+	SliceName           *string                       `bson:"sliceName,omitempty" json:"sliceName,omitempty"`
+	SliceIsConstraining *bool                         `bson:"sliceIsConstraining,omitempty" json:"sliceIsConstraining,omitempty"`
+	Label               *string                       `bson:"label,omitempty" json:"label,omitempty"`
+	Code                []Coding                      `bson:"code,omitempty" json:"code,omitempty"`
+	Slicing             *ElementDefinitionSlicing     `bson:"slicing,omitempty" json:"slicing,omitempty"`
+	Short               *string                       `bson:"short,omitempty" json:"short,omitempty"`
+	Definition          *string                       `bson:"definition,omitempty" json:"definition,omitempty"`
+	Comment             *string                       `bson:"comment,omitempty" json:"comment,omitempty"`
+	Requirements        *string                       `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Alias               []string                      `bson:"alias,omitempty" json:"alias,omitempty"`
+	Min                 *int                          `bson:"min,omitempty" json:"min,omitempty"`
+	Max                 *string                       `bson:"max,omitempty" json:"max,omitempty"`
+	Base                *ElementDefinitionBase        `bson:"base,omitempty" json:"base,omitempty"`
+	ContentReference    *string                       `bson:"contentReference,omitempty" json:"contentReference,omitempty"`
+	Type                []ElementDefinitionType       `bson:"type,omitempty" json:"type,omitempty"`
+	MeaningWhenMissing  *string                       `bson:"meaningWhenMissing,omitempty" json:"meaningWhenMissing,omitempty"`
+	OrderMeaning        *string                       `bson:"orderMeaning,omitempty" json:"orderMeaning,omitempty"`
+	Example             []ElementDefinitionExample    `bson:"example,omitempty" json:"example,omitempty"`
+	MaxLength           *int                          `bson:"maxLength,omitempty" json:"maxLength,omitempty"`
+	Condition           []string                      `bson:"condition,omitempty" json:"condition,omitempty"`
+	Constraint          []ElementDefinitionConstraint `bson:"constraint,omitempty" json:"constraint,omitempty"`
+	MustSupport         *bool                         `bson:"mustSupport,omitempty" json:"mustSupport,omitempty"`
+	IsModifier          *bool                         `bson:"isModifier,omitempty" json:"isModifier,omitempty"`
+	IsModifierReason    *string                       `bson:"isModifierReason,omitempty" json:"isModifierReason,omitempty"`
+	IsSummary           *bool                         `bson:"isSummary,omitempty" json:"isSummary,omitempty"`
+	Binding             *ElementDefinitionBinding     `bson:"binding,omitempty" json:"binding,omitempty"`
+	Mapping             []ElementDefinitionMapping    `bson:"mapping,omitempty" json:"mapping,omitempty"`
 }
 type ElementDefinitionSlicing struct {
-	Id            *string                                 `json:"id,omitempty"`
-	Extension     []Extension                             `json:"extension,omitempty"`
-	Discriminator []ElementDefinitionSlicingDiscriminator `json:"discriminator,omitempty"`
-	Description   *string                                 `json:"description,omitempty"`
-	Ordered       *bool                                   `json:"ordered,omitempty"`
-	Rules         SlicingRules                            `json:"rules"`
+	Id            *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension     []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	Discriminator []ElementDefinitionSlicingDiscriminator `bson:"discriminator,omitempty" json:"discriminator,omitempty"`
+	Description   *string                                 `bson:"description,omitempty" json:"description,omitempty"`
+	Ordered       *bool                                   `bson:"ordered,omitempty" json:"ordered,omitempty"`
+	Rules         SlicingRules                            `bson:"rules" json:"rules"`
 }
 type ElementDefinitionSlicingDiscriminator struct {
-	Id        *string           `json:"id,omitempty"`
-	Extension []Extension       `json:"extension,omitempty"`
-	Type      DiscriminatorType `json:"type"`
-	Path      string            `json:"path"`
+	Id        *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type      DiscriminatorType `bson:"type" json:"type"`
+	Path      string            `bson:"path" json:"path"`
 }
 type ElementDefinitionBase struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Path      string      `json:"path"`
-	Min       int         `json:"min"`
-	Max       string      `json:"max"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Path      string      `bson:"path" json:"path"`
+	Min       int         `bson:"min" json:"min"`
+	Max       string      `bson:"max" json:"max"`
 }
 type ElementDefinitionType struct {
-	Id            *string                `json:"id,omitempty"`
-	Extension     []Extension            `json:"extension,omitempty"`
-	Code          string                 `json:"code"`
-	Profile       []string               `json:"profile,omitempty"`
-	TargetProfile []string               `json:"targetProfile,omitempty"`
-	Aggregation   []AggregationMode      `json:"aggregation,omitempty"`
-	Versioning    *ReferenceVersionRules `json:"versioning,omitempty"`
+	Id            *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension     []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	Code          string                 `bson:"code" json:"code"`
+	Profile       []string               `bson:"profile,omitempty" json:"profile,omitempty"`
+	TargetProfile []string               `bson:"targetProfile,omitempty" json:"targetProfile,omitempty"`
+	Aggregation   []AggregationMode      `bson:"aggregation,omitempty" json:"aggregation,omitempty"`
+	Versioning    *ReferenceVersionRules `bson:"versioning,omitempty" json:"versioning,omitempty"`
 }
 type ElementDefinitionExample struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Label     string      `json:"label"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Label     string      `bson:"label" json:"label"`
 }
 type ElementDefinitionConstraint struct {
-	Id           *string            `json:"id,omitempty"`
-	Extension    []Extension        `json:"extension,omitempty"`
-	Key          string             `json:"key"`
-	Requirements *string            `json:"requirements,omitempty"`
-	Severity     ConstraintSeverity `json:"severity"`
-	Human        string             `json:"human"`
-	Expression   *string            `json:"expression,omitempty"`
-	Xpath        *string            `json:"xpath,omitempty"`
-	Source       *string            `json:"source,omitempty"`
+	Id           *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	Key          string             `bson:"key" json:"key"`
+	Requirements *string            `bson:"requirements,omitempty" json:"requirements,omitempty"`
+	Severity     ConstraintSeverity `bson:"severity" json:"severity"`
+	Human        string             `bson:"human" json:"human"`
+	Expression   *string            `bson:"expression,omitempty" json:"expression,omitempty"`
+	Xpath        *string            `bson:"xpath,omitempty" json:"xpath,omitempty"`
+	Source       *string            `bson:"source,omitempty" json:"source,omitempty"`
 }
 type ElementDefinitionBinding struct {
-	Id          *string         `json:"id,omitempty"`
-	Extension   []Extension     `json:"extension,omitempty"`
-	Strength    BindingStrength `json:"strength"`
-	Description *string         `json:"description,omitempty"`
-	ValueSet    *string         `json:"valueSet,omitempty"`
+	Id          *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	Strength    BindingStrength `bson:"strength" json:"strength"`
+	Description *string         `bson:"description,omitempty" json:"description,omitempty"`
+	ValueSet    *string         `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
 }
 type ElementDefinitionMapping struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Identity  string      `json:"identity"`
-	Language  *string     `json:"language,omitempty"`
-	Map       string      `json:"map"`
-	Comment   *string     `json:"comment,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Identity  string      `bson:"identity" json:"identity"`
+	Language  *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Map       string      `bson:"map" json:"map"`
+	Comment   *string     `bson:"comment,omitempty" json:"comment,omitempty"`
 }

--- a/fhir-models/fhir/encounter.go
+++ b/fhir-models/fhir/encounter.go
@@ -21,89 +21,89 @@ import "encoding/json"
 
 // Encounter is documented here http://hl7.org/fhir/StructureDefinition/Encounter
 type Encounter struct {
-	Id                *string                   `json:"id,omitempty"`
-	Meta              *Meta                     `json:"meta,omitempty"`
-	ImplicitRules     *string                   `json:"implicitRules,omitempty"`
-	Language          *string                   `json:"language,omitempty"`
-	Text              *Narrative                `json:"text,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier              `json:"identifier,omitempty"`
-	Status            EncounterStatus           `json:"status"`
-	StatusHistory     []EncounterStatusHistory  `json:"statusHistory,omitempty"`
-	Class             Coding                    `json:"class"`
-	ClassHistory      []EncounterClassHistory   `json:"classHistory,omitempty"`
-	Type              []CodeableConcept         `json:"type,omitempty"`
-	ServiceType       *CodeableConcept          `json:"serviceType,omitempty"`
-	Priority          *CodeableConcept          `json:"priority,omitempty"`
-	Subject           *Reference                `json:"subject,omitempty"`
-	EpisodeOfCare     []Reference               `json:"episodeOfCare,omitempty"`
-	BasedOn           []Reference               `json:"basedOn,omitempty"`
-	Participant       []EncounterParticipant    `json:"participant,omitempty"`
-	Appointment       []Reference               `json:"appointment,omitempty"`
-	Period            *Period                   `json:"period,omitempty"`
-	Length            *Duration                 `json:"length,omitempty"`
-	ReasonCode        []CodeableConcept         `json:"reasonCode,omitempty"`
-	ReasonReference   []Reference               `json:"reasonReference,omitempty"`
-	Diagnosis         []EncounterDiagnosis      `json:"diagnosis,omitempty"`
-	Account           []Reference               `json:"account,omitempty"`
-	Hospitalization   *EncounterHospitalization `json:"hospitalization,omitempty"`
-	Location          []EncounterLocation       `json:"location,omitempty"`
-	ServiceProvider   *Reference                `json:"serviceProvider,omitempty"`
-	PartOf            *Reference                `json:"partOf,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            EncounterStatus           `bson:"status" json:"status"`
+	StatusHistory     []EncounterStatusHistory  `bson:"statusHistory,omitempty" json:"statusHistory,omitempty"`
+	Class             Coding                    `bson:"class" json:"class"`
+	ClassHistory      []EncounterClassHistory   `bson:"classHistory,omitempty" json:"classHistory,omitempty"`
+	Type              []CodeableConcept         `bson:"type,omitempty" json:"type,omitempty"`
+	ServiceType       *CodeableConcept          `bson:"serviceType,omitempty" json:"serviceType,omitempty"`
+	Priority          *CodeableConcept          `bson:"priority,omitempty" json:"priority,omitempty"`
+	Subject           *Reference                `bson:"subject,omitempty" json:"subject,omitempty"`
+	EpisodeOfCare     []Reference               `bson:"episodeOfCare,omitempty" json:"episodeOfCare,omitempty"`
+	BasedOn           []Reference               `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Participant       []EncounterParticipant    `bson:"participant,omitempty" json:"participant,omitempty"`
+	Appointment       []Reference               `bson:"appointment,omitempty" json:"appointment,omitempty"`
+	Period            *Period                   `bson:"period,omitempty" json:"period,omitempty"`
+	Length            *Duration                 `bson:"length,omitempty" json:"length,omitempty"`
+	ReasonCode        []CodeableConcept         `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference   []Reference               `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Diagnosis         []EncounterDiagnosis      `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
+	Account           []Reference               `bson:"account,omitempty" json:"account,omitempty"`
+	Hospitalization   *EncounterHospitalization `bson:"hospitalization,omitempty" json:"hospitalization,omitempty"`
+	Location          []EncounterLocation       `bson:"location,omitempty" json:"location,omitempty"`
+	ServiceProvider   *Reference                `bson:"serviceProvider,omitempty" json:"serviceProvider,omitempty"`
+	PartOf            *Reference                `bson:"partOf,omitempty" json:"partOf,omitempty"`
 }
 type EncounterStatusHistory struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Status            EncounterStatus `json:"status"`
-	Period            Period          `json:"period"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Status            EncounterStatus `bson:"status" json:"status"`
+	Period            Period          `bson:"period" json:"period"`
 }
 type EncounterClassHistory struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Class             Coding      `json:"class"`
-	Period            Period      `json:"period"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Class             Coding      `bson:"class" json:"class"`
+	Period            Period      `bson:"period" json:"period"`
 }
 type EncounterParticipant struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              []CodeableConcept `json:"type,omitempty"`
-	Period            *Period           `json:"period,omitempty"`
-	Individual        *Reference        `json:"individual,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Period            *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Individual        *Reference        `bson:"individual,omitempty" json:"individual,omitempty"`
 }
 type EncounterDiagnosis struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Condition         Reference        `json:"condition"`
-	Use               *CodeableConcept `json:"use,omitempty"`
-	Rank              *int             `json:"rank,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Condition         Reference        `bson:"condition" json:"condition"`
+	Use               *CodeableConcept `bson:"use,omitempty" json:"use,omitempty"`
+	Rank              *int             `bson:"rank,omitempty" json:"rank,omitempty"`
 }
 type EncounterHospitalization struct {
-	Id                     *string           `json:"id,omitempty"`
-	Extension              []Extension       `json:"extension,omitempty"`
-	ModifierExtension      []Extension       `json:"modifierExtension,omitempty"`
-	PreAdmissionIdentifier *Identifier       `json:"preAdmissionIdentifier,omitempty"`
-	Origin                 *Reference        `json:"origin,omitempty"`
-	AdmitSource            *CodeableConcept  `json:"admitSource,omitempty"`
-	ReAdmission            *CodeableConcept  `json:"reAdmission,omitempty"`
-	DietPreference         []CodeableConcept `json:"dietPreference,omitempty"`
-	SpecialCourtesy        []CodeableConcept `json:"specialCourtesy,omitempty"`
-	SpecialArrangement     []CodeableConcept `json:"specialArrangement,omitempty"`
-	Destination            *Reference        `json:"destination,omitempty"`
-	DischargeDisposition   *CodeableConcept  `json:"dischargeDisposition,omitempty"`
+	Id                     *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension              []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	PreAdmissionIdentifier *Identifier       `bson:"preAdmissionIdentifier,omitempty" json:"preAdmissionIdentifier,omitempty"`
+	Origin                 *Reference        `bson:"origin,omitempty" json:"origin,omitempty"`
+	AdmitSource            *CodeableConcept  `bson:"admitSource,omitempty" json:"admitSource,omitempty"`
+	ReAdmission            *CodeableConcept  `bson:"reAdmission,omitempty" json:"reAdmission,omitempty"`
+	DietPreference         []CodeableConcept `bson:"dietPreference,omitempty" json:"dietPreference,omitempty"`
+	SpecialCourtesy        []CodeableConcept `bson:"specialCourtesy,omitempty" json:"specialCourtesy,omitempty"`
+	SpecialArrangement     []CodeableConcept `bson:"specialArrangement,omitempty" json:"specialArrangement,omitempty"`
+	Destination            *Reference        `bson:"destination,omitempty" json:"destination,omitempty"`
+	DischargeDisposition   *CodeableConcept  `bson:"dischargeDisposition,omitempty" json:"dischargeDisposition,omitempty"`
 }
 type EncounterLocation struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Location          Reference                `json:"location"`
-	Status            *EncounterLocationStatus `json:"status,omitempty"`
-	PhysicalType      *CodeableConcept         `json:"physicalType,omitempty"`
-	Period            *Period                  `json:"period,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Location          Reference                `bson:"location" json:"location"`
+	Status            *EncounterLocationStatus `bson:"status,omitempty" json:"status,omitempty"`
+	PhysicalType      *CodeableConcept         `bson:"physicalType,omitempty" json:"physicalType,omitempty"`
+	Period            *Period                  `bson:"period,omitempty" json:"period,omitempty"`
 }
 type OtherEncounter Encounter
 

--- a/fhir-models/fhir/endpoint.go
+++ b/fhir-models/fhir/endpoint.go
@@ -21,24 +21,24 @@ import "encoding/json"
 
 // Endpoint is documented here http://hl7.org/fhir/StructureDefinition/Endpoint
 type Endpoint struct {
-	Id                   *string           `json:"id,omitempty"`
-	Meta                 *Meta             `json:"meta,omitempty"`
-	ImplicitRules        *string           `json:"implicitRules,omitempty"`
-	Language             *string           `json:"language,omitempty"`
-	Text                 *Narrative        `json:"text,omitempty"`
-	Extension            []Extension       `json:"extension,omitempty"`
-	ModifierExtension    []Extension       `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier      `json:"identifier,omitempty"`
-	Status               EndpointStatus    `json:"status"`
-	ConnectionType       Coding            `json:"connectionType"`
-	Name                 *string           `json:"name,omitempty"`
-	ManagingOrganization *Reference        `json:"managingOrganization,omitempty"`
-	Contact              []ContactPoint    `json:"contact,omitempty"`
-	Period               *Period           `json:"period,omitempty"`
-	PayloadType          []CodeableConcept `json:"payloadType"`
-	PayloadMimeType      []string          `json:"payloadMimeType,omitempty"`
-	Address              string            `json:"address"`
-	Header               []string          `json:"header,omitempty"`
+	Id                   *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status               EndpointStatus    `bson:"status" json:"status"`
+	ConnectionType       Coding            `bson:"connectionType" json:"connectionType"`
+	Name                 *string           `bson:"name,omitempty" json:"name,omitempty"`
+	ManagingOrganization *Reference        `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
+	Contact              []ContactPoint    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Period               *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	PayloadType          []CodeableConcept `bson:"payloadType" json:"payloadType"`
+	PayloadMimeType      []string          `bson:"payloadMimeType,omitempty" json:"payloadMimeType,omitempty"`
+	Address              string            `bson:"address" json:"address"`
+	Header               []string          `bson:"header,omitempty" json:"header,omitempty"`
 }
 type OtherEndpoint Endpoint
 

--- a/fhir-models/fhir/enrollmentRequest.go
+++ b/fhir-models/fhir/enrollmentRequest.go
@@ -21,20 +21,20 @@ import "encoding/json"
 
 // EnrollmentRequest is documented here http://hl7.org/fhir/StructureDefinition/EnrollmentRequest
 type EnrollmentRequest struct {
-	Id                *string                       `json:"id,omitempty"`
-	Meta              *Meta                         `json:"meta,omitempty"`
-	ImplicitRules     *string                       `json:"implicitRules,omitempty"`
-	Language          *string                       `json:"language,omitempty"`
-	Text              *Narrative                    `json:"text,omitempty"`
-	Extension         []Extension                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                   `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                  `json:"identifier,omitempty"`
-	Status            *FinancialResourceStatusCodes `json:"status,omitempty"`
-	Created           *string                       `json:"created,omitempty"`
-	Insurer           *Reference                    `json:"insurer,omitempty"`
-	Provider          *Reference                    `json:"provider,omitempty"`
-	Candidate         *Reference                    `json:"candidate,omitempty"`
-	Coverage          *Reference                    `json:"coverage,omitempty"`
+	Id                *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            *FinancialResourceStatusCodes `bson:"status,omitempty" json:"status,omitempty"`
+	Created           *string                       `bson:"created,omitempty" json:"created,omitempty"`
+	Insurer           *Reference                    `bson:"insurer,omitempty" json:"insurer,omitempty"`
+	Provider          *Reference                    `bson:"provider,omitempty" json:"provider,omitempty"`
+	Candidate         *Reference                    `bson:"candidate,omitempty" json:"candidate,omitempty"`
+	Coverage          *Reference                    `bson:"coverage,omitempty" json:"coverage,omitempty"`
 }
 type OtherEnrollmentRequest EnrollmentRequest
 

--- a/fhir-models/fhir/enrollmentResponse.go
+++ b/fhir-models/fhir/enrollmentResponse.go
@@ -21,21 +21,21 @@ import "encoding/json"
 
 // EnrollmentResponse is documented here http://hl7.org/fhir/StructureDefinition/EnrollmentResponse
 type EnrollmentResponse struct {
-	Id                *string                       `json:"id,omitempty"`
-	Meta              *Meta                         `json:"meta,omitempty"`
-	ImplicitRules     *string                       `json:"implicitRules,omitempty"`
-	Language          *string                       `json:"language,omitempty"`
-	Text              *Narrative                    `json:"text,omitempty"`
-	Extension         []Extension                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                   `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                  `json:"identifier,omitempty"`
-	Status            *FinancialResourceStatusCodes `json:"status,omitempty"`
-	Request           *Reference                    `json:"request,omitempty"`
-	Outcome           *ClaimProcessingCodes         `json:"outcome,omitempty"`
-	Disposition       *string                       `json:"disposition,omitempty"`
-	Created           *string                       `json:"created,omitempty"`
-	Organization      *Reference                    `json:"organization,omitempty"`
-	RequestProvider   *Reference                    `json:"requestProvider,omitempty"`
+	Id                *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            *FinancialResourceStatusCodes `bson:"status,omitempty" json:"status,omitempty"`
+	Request           *Reference                    `bson:"request,omitempty" json:"request,omitempty"`
+	Outcome           *ClaimProcessingCodes         `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	Disposition       *string                       `bson:"disposition,omitempty" json:"disposition,omitempty"`
+	Created           *string                       `bson:"created,omitempty" json:"created,omitempty"`
+	Organization      *Reference                    `bson:"organization,omitempty" json:"organization,omitempty"`
+	RequestProvider   *Reference                    `bson:"requestProvider,omitempty" json:"requestProvider,omitempty"`
 }
 type OtherEnrollmentResponse EnrollmentResponse
 

--- a/fhir-models/fhir/episodeOfCare.go
+++ b/fhir-models/fhir/episodeOfCare.go
@@ -21,40 +21,40 @@ import "encoding/json"
 
 // EpisodeOfCare is documented here http://hl7.org/fhir/StructureDefinition/EpisodeOfCare
 type EpisodeOfCare struct {
-	Id                   *string                      `json:"id,omitempty"`
-	Meta                 *Meta                        `json:"meta,omitempty"`
-	ImplicitRules        *string                      `json:"implicitRules,omitempty"`
-	Language             *string                      `json:"language,omitempty"`
-	Text                 *Narrative                   `json:"text,omitempty"`
-	Extension            []Extension                  `json:"extension,omitempty"`
-	ModifierExtension    []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier                 `json:"identifier,omitempty"`
-	Status               EpisodeOfCareStatus          `json:"status"`
-	StatusHistory        []EpisodeOfCareStatusHistory `json:"statusHistory,omitempty"`
-	Type                 []CodeableConcept            `json:"type,omitempty"`
-	Diagnosis            []EpisodeOfCareDiagnosis     `json:"diagnosis,omitempty"`
-	Patient              Reference                    `json:"patient"`
-	ManagingOrganization *Reference                   `json:"managingOrganization,omitempty"`
-	Period               *Period                      `json:"period,omitempty"`
-	ReferralRequest      []Reference                  `json:"referralRequest,omitempty"`
-	CareManager          *Reference                   `json:"careManager,omitempty"`
-	Team                 []Reference                  `json:"team,omitempty"`
-	Account              []Reference                  `json:"account,omitempty"`
+	Id                   *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status               EpisodeOfCareStatus          `bson:"status" json:"status"`
+	StatusHistory        []EpisodeOfCareStatusHistory `bson:"statusHistory,omitempty" json:"statusHistory,omitempty"`
+	Type                 []CodeableConcept            `bson:"type,omitempty" json:"type,omitempty"`
+	Diagnosis            []EpisodeOfCareDiagnosis     `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
+	Patient              Reference                    `bson:"patient" json:"patient"`
+	ManagingOrganization *Reference                   `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
+	Period               *Period                      `bson:"period,omitempty" json:"period,omitempty"`
+	ReferralRequest      []Reference                  `bson:"referralRequest,omitempty" json:"referralRequest,omitempty"`
+	CareManager          *Reference                   `bson:"careManager,omitempty" json:"careManager,omitempty"`
+	Team                 []Reference                  `bson:"team,omitempty" json:"team,omitempty"`
+	Account              []Reference                  `bson:"account,omitempty" json:"account,omitempty"`
 }
 type EpisodeOfCareStatusHistory struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Status            EpisodeOfCareStatus `json:"status"`
-	Period            Period              `json:"period"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Status            EpisodeOfCareStatus `bson:"status" json:"status"`
+	Period            Period              `bson:"period" json:"period"`
 }
 type EpisodeOfCareDiagnosis struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Condition         Reference        `json:"condition"`
-	Role              *CodeableConcept `json:"role,omitempty"`
-	Rank              *int             `json:"rank,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Condition         Reference        `bson:"condition" json:"condition"`
+	Role              *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Rank              *int             `bson:"rank,omitempty" json:"rank,omitempty"`
 }
 type OtherEpisodeOfCare EpisodeOfCare
 

--- a/fhir-models/fhir/eventDefinition.go
+++ b/fhir-models/fhir/eventDefinition.go
@@ -21,40 +21,40 @@ import "encoding/json"
 
 // EventDefinition is documented here http://hl7.org/fhir/StructureDefinition/EventDefinition
 type EventDefinition struct {
-	Id                *string             `json:"id,omitempty"`
-	Meta              *Meta               `json:"meta,omitempty"`
-	ImplicitRules     *string             `json:"implicitRules,omitempty"`
-	Language          *string             `json:"language,omitempty"`
-	Text              *Narrative          `json:"text,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Url               *string             `json:"url,omitempty"`
-	Identifier        []Identifier        `json:"identifier,omitempty"`
-	Version           *string             `json:"version,omitempty"`
-	Name              *string             `json:"name,omitempty"`
-	Title             *string             `json:"title,omitempty"`
-	Subtitle          *string             `json:"subtitle,omitempty"`
-	Status            PublicationStatus   `json:"status"`
-	Experimental      *bool               `json:"experimental,omitempty"`
-	Date              *string             `json:"date,omitempty"`
-	Publisher         *string             `json:"publisher,omitempty"`
-	Contact           []ContactDetail     `json:"contact,omitempty"`
-	Description       *string             `json:"description,omitempty"`
-	UseContext        []UsageContext      `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept   `json:"jurisdiction,omitempty"`
-	Purpose           *string             `json:"purpose,omitempty"`
-	Usage             *string             `json:"usage,omitempty"`
-	Copyright         *string             `json:"copyright,omitempty"`
-	ApprovalDate      *string             `json:"approvalDate,omitempty"`
-	LastReviewDate    *string             `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period             `json:"effectivePeriod,omitempty"`
-	Topic             []CodeableConcept   `json:"topic,omitempty"`
-	Author            []ContactDetail     `json:"author,omitempty"`
-	Editor            []ContactDetail     `json:"editor,omitempty"`
-	Reviewer          []ContactDetail     `json:"reviewer,omitempty"`
-	Endorser          []ContactDetail     `json:"endorser,omitempty"`
-	RelatedArtifact   []RelatedArtifact   `json:"relatedArtifact,omitempty"`
-	Trigger           []TriggerDefinition `json:"trigger"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string             `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string             `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string             `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string             `bson:"title,omitempty" json:"title,omitempty"`
+	Subtitle          *string             `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status            PublicationStatus   `bson:"status" json:"status"`
+	Experimental      *bool               `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string             `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string             `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail     `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string             `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext      `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept   `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string             `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage             *string             `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright         *string             `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string             `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string             `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period             `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic             []CodeableConcept   `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author            []ContactDetail     `bson:"author,omitempty" json:"author,omitempty"`
+	Editor            []ContactDetail     `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer          []ContactDetail     `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser          []ContactDetail     `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact   []RelatedArtifact   `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Trigger           []TriggerDefinition `bson:"trigger" json:"trigger"`
 }
 type OtherEventDefinition EventDefinition
 

--- a/fhir-models/fhir/evidence.go
+++ b/fhir-models/fhir/evidence.go
@@ -21,41 +21,41 @@ import "encoding/json"
 
 // Evidence is documented here http://hl7.org/fhir/StructureDefinition/Evidence
 type Evidence struct {
-	Id                 *string           `json:"id,omitempty"`
-	Meta               *Meta             `json:"meta,omitempty"`
-	ImplicitRules      *string           `json:"implicitRules,omitempty"`
-	Language           *string           `json:"language,omitempty"`
-	Text               *Narrative        `json:"text,omitempty"`
-	Extension          []Extension       `json:"extension,omitempty"`
-	ModifierExtension  []Extension       `json:"modifierExtension,omitempty"`
-	Url                *string           `json:"url,omitempty"`
-	Identifier         []Identifier      `json:"identifier,omitempty"`
-	Version            *string           `json:"version,omitempty"`
-	Name               *string           `json:"name,omitempty"`
-	Title              *string           `json:"title,omitempty"`
-	ShortTitle         *string           `json:"shortTitle,omitempty"`
-	Subtitle           *string           `json:"subtitle,omitempty"`
-	Status             PublicationStatus `json:"status"`
-	Date               *string           `json:"date,omitempty"`
-	Publisher          *string           `json:"publisher,omitempty"`
-	Contact            []ContactDetail   `json:"contact,omitempty"`
-	Description        *string           `json:"description,omitempty"`
-	Note               []Annotation      `json:"note,omitempty"`
-	UseContext         []UsageContext    `json:"useContext,omitempty"`
-	Jurisdiction       []CodeableConcept `json:"jurisdiction,omitempty"`
-	Copyright          *string           `json:"copyright,omitempty"`
-	ApprovalDate       *string           `json:"approvalDate,omitempty"`
-	LastReviewDate     *string           `json:"lastReviewDate,omitempty"`
-	EffectivePeriod    *Period           `json:"effectivePeriod,omitempty"`
-	Topic              []CodeableConcept `json:"topic,omitempty"`
-	Author             []ContactDetail   `json:"author,omitempty"`
-	Editor             []ContactDetail   `json:"editor,omitempty"`
-	Reviewer           []ContactDetail   `json:"reviewer,omitempty"`
-	Endorser           []ContactDetail   `json:"endorser,omitempty"`
-	RelatedArtifact    []RelatedArtifact `json:"relatedArtifact,omitempty"`
-	ExposureBackground Reference         `json:"exposureBackground"`
-	ExposureVariant    []Reference       `json:"exposureVariant,omitempty"`
-	Outcome            []Reference       `json:"outcome,omitempty"`
+	Id                 *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url                *string           `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier         []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version            *string           `bson:"version,omitempty" json:"version,omitempty"`
+	Name               *string           `bson:"name,omitempty" json:"name,omitempty"`
+	Title              *string           `bson:"title,omitempty" json:"title,omitempty"`
+	ShortTitle         *string           `bson:"shortTitle,omitempty" json:"shortTitle,omitempty"`
+	Subtitle           *string           `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status             PublicationStatus `bson:"status" json:"status"`
+	Date               *string           `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher          *string           `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact            []ContactDetail   `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description        *string           `bson:"description,omitempty" json:"description,omitempty"`
+	Note               []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
+	UseContext         []UsageContext    `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction       []CodeableConcept `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright          *string           `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate       *string           `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate     *string           `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod    *Period           `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic              []CodeableConcept `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author             []ContactDetail   `bson:"author,omitempty" json:"author,omitempty"`
+	Editor             []ContactDetail   `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer           []ContactDetail   `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser           []ContactDetail   `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact    []RelatedArtifact `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	ExposureBackground Reference         `bson:"exposureBackground" json:"exposureBackground"`
+	ExposureVariant    []Reference       `bson:"exposureVariant,omitempty" json:"exposureVariant,omitempty"`
+	Outcome            []Reference       `bson:"outcome,omitempty" json:"outcome,omitempty"`
 }
 type OtherEvidence Evidence
 

--- a/fhir-models/fhir/evidenceVariable.go
+++ b/fhir-models/fhir/evidenceVariable.go
@@ -21,50 +21,50 @@ import "encoding/json"
 
 // EvidenceVariable is documented here http://hl7.org/fhir/StructureDefinition/EvidenceVariable
 type EvidenceVariable struct {
-	Id                *string                          `json:"id,omitempty"`
-	Meta              *Meta                            `json:"meta,omitempty"`
-	ImplicitRules     *string                          `json:"implicitRules,omitempty"`
-	Language          *string                          `json:"language,omitempty"`
-	Text              *Narrative                       `json:"text,omitempty"`
-	Extension         []Extension                      `json:"extension,omitempty"`
-	ModifierExtension []Extension                      `json:"modifierExtension,omitempty"`
-	Url               *string                          `json:"url,omitempty"`
-	Identifier        []Identifier                     `json:"identifier,omitempty"`
-	Version           *string                          `json:"version,omitempty"`
-	Name              *string                          `json:"name,omitempty"`
-	Title             *string                          `json:"title,omitempty"`
-	ShortTitle        *string                          `json:"shortTitle,omitempty"`
-	Subtitle          *string                          `json:"subtitle,omitempty"`
-	Status            PublicationStatus                `json:"status"`
-	Date              *string                          `json:"date,omitempty"`
-	Publisher         *string                          `json:"publisher,omitempty"`
-	Contact           []ContactDetail                  `json:"contact,omitempty"`
-	Description       *string                          `json:"description,omitempty"`
-	Note              []Annotation                     `json:"note,omitempty"`
-	UseContext        []UsageContext                   `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                `json:"jurisdiction,omitempty"`
-	Copyright         *string                          `json:"copyright,omitempty"`
-	ApprovalDate      *string                          `json:"approvalDate,omitempty"`
-	LastReviewDate    *string                          `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period                          `json:"effectivePeriod,omitempty"`
-	Topic             []CodeableConcept                `json:"topic,omitempty"`
-	Author            []ContactDetail                  `json:"author,omitempty"`
-	Editor            []ContactDetail                  `json:"editor,omitempty"`
-	Reviewer          []ContactDetail                  `json:"reviewer,omitempty"`
-	Endorser          []ContactDetail                  `json:"endorser,omitempty"`
-	RelatedArtifact   []RelatedArtifact                `json:"relatedArtifact,omitempty"`
-	Type              *EvidenceVariableType            `json:"type,omitempty"`
-	Characteristic    []EvidenceVariableCharacteristic `json:"characteristic"`
+	Id                *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                          `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                          `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                          `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                          `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                          `bson:"title,omitempty" json:"title,omitempty"`
+	ShortTitle        *string                          `bson:"shortTitle,omitempty" json:"shortTitle,omitempty"`
+	Subtitle          *string                          `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status            PublicationStatus                `bson:"status" json:"status"`
+	Date              *string                          `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                          `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                          `bson:"description,omitempty" json:"description,omitempty"`
+	Note              []Annotation                     `bson:"note,omitempty" json:"note,omitempty"`
+	UseContext        []UsageContext                   `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright         *string                          `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string                          `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string                          `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period                          `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic             []CodeableConcept                `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author            []ContactDetail                  `bson:"author,omitempty" json:"author,omitempty"`
+	Editor            []ContactDetail                  `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer          []ContactDetail                  `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser          []ContactDetail                  `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact   []RelatedArtifact                `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Type              *EvidenceVariableType            `bson:"type,omitempty" json:"type,omitempty"`
+	Characteristic    []EvidenceVariableCharacteristic `bson:"characteristic" json:"characteristic"`
 }
 type EvidenceVariableCharacteristic struct {
-	Id                *string        `json:"id,omitempty"`
-	Extension         []Extension    `json:"extension,omitempty"`
-	ModifierExtension []Extension    `json:"modifierExtension,omitempty"`
-	Description       *string        `json:"description,omitempty"`
-	UsageContext      []UsageContext `json:"usageContext,omitempty"`
-	Exclude           *bool          `json:"exclude,omitempty"`
-	TimeFromStart     *Duration      `json:"timeFromStart,omitempty"`
-	GroupMeasure      *GroupMeasure  `json:"groupMeasure,omitempty"`
+	Id                *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string        `bson:"description,omitempty" json:"description,omitempty"`
+	UsageContext      []UsageContext `bson:"usageContext,omitempty" json:"usageContext,omitempty"`
+	Exclude           *bool          `bson:"exclude,omitempty" json:"exclude,omitempty"`
+	TimeFromStart     *Duration      `bson:"timeFromStart,omitempty" json:"timeFromStart,omitempty"`
+	GroupMeasure      *GroupMeasure  `bson:"groupMeasure,omitempty" json:"groupMeasure,omitempty"`
 }
 type OtherEvidenceVariable EvidenceVariable
 

--- a/fhir-models/fhir/exampleScenario.go
+++ b/fhir-models/fhir/exampleScenario.go
@@ -21,106 +21,106 @@ import "encoding/json"
 
 // ExampleScenario is documented here http://hl7.org/fhir/StructureDefinition/ExampleScenario
 type ExampleScenario struct {
-	Id                *string                   `json:"id,omitempty"`
-	Meta              *Meta                     `json:"meta,omitempty"`
-	ImplicitRules     *string                   `json:"implicitRules,omitempty"`
-	Language          *string                   `json:"language,omitempty"`
-	Text              *Narrative                `json:"text,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Url               *string                   `json:"url,omitempty"`
-	Identifier        []Identifier              `json:"identifier,omitempty"`
-	Version           *string                   `json:"version,omitempty"`
-	Name              *string                   `json:"name,omitempty"`
-	Status            PublicationStatus         `json:"status"`
-	Experimental      *bool                     `json:"experimental,omitempty"`
-	Date              *string                   `json:"date,omitempty"`
-	Publisher         *string                   `json:"publisher,omitempty"`
-	Contact           []ContactDetail           `json:"contact,omitempty"`
-	UseContext        []UsageContext            `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept         `json:"jurisdiction,omitempty"`
-	Copyright         *string                   `json:"copyright,omitempty"`
-	Purpose           *string                   `json:"purpose,omitempty"`
-	Actor             []ExampleScenarioActor    `json:"actor,omitempty"`
-	Instance          []ExampleScenarioInstance `json:"instance,omitempty"`
-	Process           []ExampleScenarioProcess  `json:"process,omitempty"`
-	Workflow          []string                  `json:"workflow,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                   `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                   `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                   `bson:"name,omitempty" json:"name,omitempty"`
+	Status            PublicationStatus         `bson:"status" json:"status"`
+	Experimental      *bool                     `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                   `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                   `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail           `bson:"contact,omitempty" json:"contact,omitempty"`
+	UseContext        []UsageContext            `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept         `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright         *string                   `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Purpose           *string                   `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Actor             []ExampleScenarioActor    `bson:"actor,omitempty" json:"actor,omitempty"`
+	Instance          []ExampleScenarioInstance `bson:"instance,omitempty" json:"instance,omitempty"`
+	Process           []ExampleScenarioProcess  `bson:"process,omitempty" json:"process,omitempty"`
+	Workflow          []string                  `bson:"workflow,omitempty" json:"workflow,omitempty"`
 }
 type ExampleScenarioActor struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	ActorId           string                   `json:"actorId"`
-	Type              ExampleScenarioActorType `json:"type"`
-	Name              *string                  `json:"name,omitempty"`
-	Description       *string                  `json:"description,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ActorId           string                   `bson:"actorId" json:"actorId"`
+	Type              ExampleScenarioActorType `bson:"type" json:"type"`
+	Name              *string                  `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string                  `bson:"description,omitempty" json:"description,omitempty"`
 }
 type ExampleScenarioInstance struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	ResourceId        string                                     `json:"resourceId"`
-	ResourceType      ResourceType                               `json:"resourceType"`
-	Name              *string                                    `json:"name,omitempty"`
-	Description       *string                                    `json:"description,omitempty"`
-	Version           []ExampleScenarioInstanceVersion           `json:"version,omitempty"`
-	ContainedInstance []ExampleScenarioInstanceContainedInstance `json:"containedInstance,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ResourceId        string                                     `bson:"resourceId" json:"resourceId"`
+	ResourceType      ResourceType                               `bson:"resourceType" json:"resourceType"`
+	Name              *string                                    `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string                                    `bson:"description,omitempty" json:"description,omitempty"`
+	Version           []ExampleScenarioInstanceVersion           `bson:"version,omitempty" json:"version,omitempty"`
+	ContainedInstance []ExampleScenarioInstanceContainedInstance `bson:"containedInstance,omitempty" json:"containedInstance,omitempty"`
 }
 type ExampleScenarioInstanceVersion struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	VersionId         string      `json:"versionId"`
-	Description       string      `json:"description"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	VersionId         string      `bson:"versionId" json:"versionId"`
+	Description       string      `bson:"description" json:"description"`
 }
 type ExampleScenarioInstanceContainedInstance struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	ResourceId        string      `json:"resourceId"`
-	VersionId         *string     `json:"versionId,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ResourceId        string      `bson:"resourceId" json:"resourceId"`
+	VersionId         *string     `bson:"versionId,omitempty" json:"versionId,omitempty"`
 }
 type ExampleScenarioProcess struct {
-	Id                *string                      `json:"id,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Title             string                       `json:"title"`
-	Description       *string                      `json:"description,omitempty"`
-	PreConditions     *string                      `json:"preConditions,omitempty"`
-	PostConditions    *string                      `json:"postConditions,omitempty"`
-	Step              []ExampleScenarioProcessStep `json:"step,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Title             string                       `bson:"title" json:"title"`
+	Description       *string                      `bson:"description,omitempty" json:"description,omitempty"`
+	PreConditions     *string                      `bson:"preConditions,omitempty" json:"preConditions,omitempty"`
+	PostConditions    *string                      `bson:"postConditions,omitempty" json:"postConditions,omitempty"`
+	Step              []ExampleScenarioProcessStep `bson:"step,omitempty" json:"step,omitempty"`
 }
 type ExampleScenarioProcessStep struct {
-	Id                *string                                 `json:"id,omitempty"`
-	Extension         []Extension                             `json:"extension,omitempty"`
-	ModifierExtension []Extension                             `json:"modifierExtension,omitempty"`
-	Process           []ExampleScenarioProcess                `json:"process,omitempty"`
-	Pause             *bool                                   `json:"pause,omitempty"`
-	Operation         *ExampleScenarioProcessStepOperation    `json:"operation,omitempty"`
-	Alternative       []ExampleScenarioProcessStepAlternative `json:"alternative,omitempty"`
+	Id                *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Process           []ExampleScenarioProcess                `bson:"process,omitempty" json:"process,omitempty"`
+	Pause             *bool                                   `bson:"pause,omitempty" json:"pause,omitempty"`
+	Operation         *ExampleScenarioProcessStepOperation    `bson:"operation,omitempty" json:"operation,omitempty"`
+	Alternative       []ExampleScenarioProcessStepAlternative `bson:"alternative,omitempty" json:"alternative,omitempty"`
 }
 type ExampleScenarioProcessStepOperation struct {
-	Id                *string                                   `json:"id,omitempty"`
-	Extension         []Extension                               `json:"extension,omitempty"`
-	ModifierExtension []Extension                               `json:"modifierExtension,omitempty"`
-	Number            string                                    `json:"number"`
-	Type              *string                                   `json:"type,omitempty"`
-	Name              *string                                   `json:"name,omitempty"`
-	Initiator         *string                                   `json:"initiator,omitempty"`
-	Receiver          *string                                   `json:"receiver,omitempty"`
-	Description       *string                                   `json:"description,omitempty"`
-	InitiatorActive   *bool                                     `json:"initiatorActive,omitempty"`
-	ReceiverActive    *bool                                     `json:"receiverActive,omitempty"`
-	Request           *ExampleScenarioInstanceContainedInstance `json:"request,omitempty"`
-	Response          *ExampleScenarioInstanceContainedInstance `json:"response,omitempty"`
+	Id                *string                                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Number            string                                    `bson:"number" json:"number"`
+	Type              *string                                   `bson:"type,omitempty" json:"type,omitempty"`
+	Name              *string                                   `bson:"name,omitempty" json:"name,omitempty"`
+	Initiator         *string                                   `bson:"initiator,omitempty" json:"initiator,omitempty"`
+	Receiver          *string                                   `bson:"receiver,omitempty" json:"receiver,omitempty"`
+	Description       *string                                   `bson:"description,omitempty" json:"description,omitempty"`
+	InitiatorActive   *bool                                     `bson:"initiatorActive,omitempty" json:"initiatorActive,omitempty"`
+	ReceiverActive    *bool                                     `bson:"receiverActive,omitempty" json:"receiverActive,omitempty"`
+	Request           *ExampleScenarioInstanceContainedInstance `bson:"request,omitempty" json:"request,omitempty"`
+	Response          *ExampleScenarioInstanceContainedInstance `bson:"response,omitempty" json:"response,omitempty"`
 }
 type ExampleScenarioProcessStepAlternative struct {
-	Id                *string                      `json:"id,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Title             string                       `json:"title"`
-	Description       *string                      `json:"description,omitempty"`
-	Step              []ExampleScenarioProcessStep `json:"step,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Title             string                       `bson:"title" json:"title"`
+	Description       *string                      `bson:"description,omitempty" json:"description,omitempty"`
+	Step              []ExampleScenarioProcessStep `bson:"step,omitempty" json:"step,omitempty"`
 }
 type OtherExampleScenario ExampleScenario
 

--- a/fhir-models/fhir/explanationOfBenefit.go
+++ b/fhir-models/fhir/explanationOfBenefit.go
@@ -21,289 +21,289 @@ import "encoding/json"
 
 // ExplanationOfBenefit is documented here http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit
 type ExplanationOfBenefit struct {
-	Id                    *string                                `json:"id,omitempty"`
-	Meta                  *Meta                                  `json:"meta,omitempty"`
-	ImplicitRules         *string                                `json:"implicitRules,omitempty"`
-	Language              *string                                `json:"language,omitempty"`
-	Text                  *Narrative                             `json:"text,omitempty"`
-	Extension             []Extension                            `json:"extension,omitempty"`
-	ModifierExtension     []Extension                            `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier                           `json:"identifier,omitempty"`
-	Status                ExplanationOfBenefitStatus             `json:"status"`
-	Type                  CodeableConcept                        `json:"type"`
-	SubType               *CodeableConcept                       `json:"subType,omitempty"`
-	Use                   Use                                    `json:"use"`
-	Patient               Reference                              `json:"patient"`
-	BillablePeriod        *Period                                `json:"billablePeriod,omitempty"`
-	Created               string                                 `json:"created"`
-	Enterer               *Reference                             `json:"enterer,omitempty"`
-	Insurer               Reference                              `json:"insurer"`
-	Provider              Reference                              `json:"provider"`
-	Priority              *CodeableConcept                       `json:"priority,omitempty"`
-	FundsReserveRequested *CodeableConcept                       `json:"fundsReserveRequested,omitempty"`
-	FundsReserve          *CodeableConcept                       `json:"fundsReserve,omitempty"`
-	Related               []ExplanationOfBenefitRelated          `json:"related,omitempty"`
-	Prescription          *Reference                             `json:"prescription,omitempty"`
-	OriginalPrescription  *Reference                             `json:"originalPrescription,omitempty"`
-	Payee                 *ExplanationOfBenefitPayee             `json:"payee,omitempty"`
-	Referral              *Reference                             `json:"referral,omitempty"`
-	Facility              *Reference                             `json:"facility,omitempty"`
-	Claim                 *Reference                             `json:"claim,omitempty"`
-	ClaimResponse         *Reference                             `json:"claimResponse,omitempty"`
-	Outcome               ClaimProcessingCodes                   `json:"outcome"`
-	Disposition           *string                                `json:"disposition,omitempty"`
-	PreAuthRef            []string                               `json:"preAuthRef,omitempty"`
-	PreAuthRefPeriod      []Period                               `json:"preAuthRefPeriod,omitempty"`
-	CareTeam              []ExplanationOfBenefitCareTeam         `json:"careTeam,omitempty"`
-	SupportingInfo        []ExplanationOfBenefitSupportingInfo   `json:"supportingInfo,omitempty"`
-	Diagnosis             []ExplanationOfBenefitDiagnosis        `json:"diagnosis,omitempty"`
-	Procedure             []ExplanationOfBenefitProcedure        `json:"procedure,omitempty"`
-	Precedence            *int                                   `json:"precedence,omitempty"`
-	Insurance             []ExplanationOfBenefitInsurance        `json:"insurance"`
-	Accident              *ExplanationOfBenefitAccident          `json:"accident,omitempty"`
-	Item                  []ExplanationOfBenefitItem             `json:"item,omitempty"`
-	AddItem               []ExplanationOfBenefitAddItem          `json:"addItem,omitempty"`
-	Adjudication          []ExplanationOfBenefitItemAdjudication `json:"adjudication,omitempty"`
-	Total                 []ExplanationOfBenefitTotal            `json:"total,omitempty"`
-	Payment               *ExplanationOfBenefitPayment           `json:"payment,omitempty"`
-	FormCode              *CodeableConcept                       `json:"formCode,omitempty"`
-	Form                  *Attachment                            `json:"form,omitempty"`
-	ProcessNote           []ExplanationOfBenefitProcessNote      `json:"processNote,omitempty"`
-	BenefitPeriod         *Period                                `json:"benefitPeriod,omitempty"`
-	BenefitBalance        []ExplanationOfBenefitBenefitBalance   `json:"benefitBalance,omitempty"`
+	Id                    *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                                `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier                           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status                ExplanationOfBenefitStatus             `bson:"status" json:"status"`
+	Type                  CodeableConcept                        `bson:"type" json:"type"`
+	SubType               *CodeableConcept                       `bson:"subType,omitempty" json:"subType,omitempty"`
+	Use                   Use                                    `bson:"use" json:"use"`
+	Patient               Reference                              `bson:"patient" json:"patient"`
+	BillablePeriod        *Period                                `bson:"billablePeriod,omitempty" json:"billablePeriod,omitempty"`
+	Created               string                                 `bson:"created" json:"created"`
+	Enterer               *Reference                             `bson:"enterer,omitempty" json:"enterer,omitempty"`
+	Insurer               Reference                              `bson:"insurer" json:"insurer"`
+	Provider              Reference                              `bson:"provider" json:"provider"`
+	Priority              *CodeableConcept                       `bson:"priority,omitempty" json:"priority,omitempty"`
+	FundsReserveRequested *CodeableConcept                       `bson:"fundsReserveRequested,omitempty" json:"fundsReserveRequested,omitempty"`
+	FundsReserve          *CodeableConcept                       `bson:"fundsReserve,omitempty" json:"fundsReserve,omitempty"`
+	Related               []ExplanationOfBenefitRelated          `bson:"related,omitempty" json:"related,omitempty"`
+	Prescription          *Reference                             `bson:"prescription,omitempty" json:"prescription,omitempty"`
+	OriginalPrescription  *Reference                             `bson:"originalPrescription,omitempty" json:"originalPrescription,omitempty"`
+	Payee                 *ExplanationOfBenefitPayee             `bson:"payee,omitempty" json:"payee,omitempty"`
+	Referral              *Reference                             `bson:"referral,omitempty" json:"referral,omitempty"`
+	Facility              *Reference                             `bson:"facility,omitempty" json:"facility,omitempty"`
+	Claim                 *Reference                             `bson:"claim,omitempty" json:"claim,omitempty"`
+	ClaimResponse         *Reference                             `bson:"claimResponse,omitempty" json:"claimResponse,omitempty"`
+	Outcome               ClaimProcessingCodes                   `bson:"outcome" json:"outcome"`
+	Disposition           *string                                `bson:"disposition,omitempty" json:"disposition,omitempty"`
+	PreAuthRef            []string                               `bson:"preAuthRef,omitempty" json:"preAuthRef,omitempty"`
+	PreAuthRefPeriod      []Period                               `bson:"preAuthRefPeriod,omitempty" json:"preAuthRefPeriod,omitempty"`
+	CareTeam              []ExplanationOfBenefitCareTeam         `bson:"careTeam,omitempty" json:"careTeam,omitempty"`
+	SupportingInfo        []ExplanationOfBenefitSupportingInfo   `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Diagnosis             []ExplanationOfBenefitDiagnosis        `bson:"diagnosis,omitempty" json:"diagnosis,omitempty"`
+	Procedure             []ExplanationOfBenefitProcedure        `bson:"procedure,omitempty" json:"procedure,omitempty"`
+	Precedence            *int                                   `bson:"precedence,omitempty" json:"precedence,omitempty"`
+	Insurance             []ExplanationOfBenefitInsurance        `bson:"insurance" json:"insurance"`
+	Accident              *ExplanationOfBenefitAccident          `bson:"accident,omitempty" json:"accident,omitempty"`
+	Item                  []ExplanationOfBenefitItem             `bson:"item,omitempty" json:"item,omitempty"`
+	AddItem               []ExplanationOfBenefitAddItem          `bson:"addItem,omitempty" json:"addItem,omitempty"`
+	Adjudication          []ExplanationOfBenefitItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	Total                 []ExplanationOfBenefitTotal            `bson:"total,omitempty" json:"total,omitempty"`
+	Payment               *ExplanationOfBenefitPayment           `bson:"payment,omitempty" json:"payment,omitempty"`
+	FormCode              *CodeableConcept                       `bson:"formCode,omitempty" json:"formCode,omitempty"`
+	Form                  *Attachment                            `bson:"form,omitempty" json:"form,omitempty"`
+	ProcessNote           []ExplanationOfBenefitProcessNote      `bson:"processNote,omitempty" json:"processNote,omitempty"`
+	BenefitPeriod         *Period                                `bson:"benefitPeriod,omitempty" json:"benefitPeriod,omitempty"`
+	BenefitBalance        []ExplanationOfBenefitBenefitBalance   `bson:"benefitBalance,omitempty" json:"benefitBalance,omitempty"`
 }
 type ExplanationOfBenefitRelated struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Claim             *Reference       `json:"claim,omitempty"`
-	Relationship      *CodeableConcept `json:"relationship,omitempty"`
-	Reference         *Identifier      `json:"reference,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Claim             *Reference       `bson:"claim,omitempty" json:"claim,omitempty"`
+	Relationship      *CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Reference         *Identifier      `bson:"reference,omitempty" json:"reference,omitempty"`
 }
 type ExplanationOfBenefitPayee struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Party             *Reference       `json:"party,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Party             *Reference       `bson:"party,omitempty" json:"party,omitempty"`
 }
 type ExplanationOfBenefitCareTeam struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Sequence          int              `json:"sequence"`
-	Provider          Reference        `json:"provider"`
-	Responsible       *bool            `json:"responsible,omitempty"`
-	Role              *CodeableConcept `json:"role,omitempty"`
-	Qualification     *CodeableConcept `json:"qualification,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int              `bson:"sequence" json:"sequence"`
+	Provider          Reference        `bson:"provider" json:"provider"`
+	Responsible       *bool            `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Role              *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Qualification     *CodeableConcept `bson:"qualification,omitempty" json:"qualification,omitempty"`
 }
 type ExplanationOfBenefitSupportingInfo struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Sequence          int              `json:"sequence"`
-	Category          CodeableConcept  `json:"category"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Reason            *Coding          `json:"reason,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int              `bson:"sequence" json:"sequence"`
+	Category          CodeableConcept  `bson:"category" json:"category"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Reason            *Coding          `bson:"reason,omitempty" json:"reason,omitempty"`
 }
 type ExplanationOfBenefitDiagnosis struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Sequence          int               `json:"sequence"`
-	Type              []CodeableConcept `json:"type,omitempty"`
-	OnAdmission       *CodeableConcept  `json:"onAdmission,omitempty"`
-	PackageCode       *CodeableConcept  `json:"packageCode,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int               `bson:"sequence" json:"sequence"`
+	Type              []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	OnAdmission       *CodeableConcept  `bson:"onAdmission,omitempty" json:"onAdmission,omitempty"`
+	PackageCode       *CodeableConcept  `bson:"packageCode,omitempty" json:"packageCode,omitempty"`
 }
 type ExplanationOfBenefitProcedure struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Sequence          int               `json:"sequence"`
-	Type              []CodeableConcept `json:"type,omitempty"`
-	Date              *string           `json:"date,omitempty"`
-	Udi               []Reference       `json:"udi,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int               `bson:"sequence" json:"sequence"`
+	Type              []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Date              *string           `bson:"date,omitempty" json:"date,omitempty"`
+	Udi               []Reference       `bson:"udi,omitempty" json:"udi,omitempty"`
 }
 type ExplanationOfBenefitInsurance struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Focal             bool        `json:"focal"`
-	Coverage          Reference   `json:"coverage"`
-	PreAuthRef        []string    `json:"preAuthRef,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Focal             bool        `bson:"focal" json:"focal"`
+	Coverage          Reference   `bson:"coverage" json:"coverage"`
+	PreAuthRef        []string    `bson:"preAuthRef,omitempty" json:"preAuthRef,omitempty"`
 }
 type ExplanationOfBenefitAccident struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Date              *string          `json:"date,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 }
 type ExplanationOfBenefitItem struct {
-	Id                  *string                                `json:"id,omitempty"`
-	Extension           []Extension                            `json:"extension,omitempty"`
-	ModifierExtension   []Extension                            `json:"modifierExtension,omitempty"`
-	Sequence            int                                    `json:"sequence"`
-	CareTeamSequence    []int                                  `json:"careTeamSequence,omitempty"`
-	DiagnosisSequence   []int                                  `json:"diagnosisSequence,omitempty"`
-	ProcedureSequence   []int                                  `json:"procedureSequence,omitempty"`
-	InformationSequence []int                                  `json:"informationSequence,omitempty"`
-	Revenue             *CodeableConcept                       `json:"revenue,omitempty"`
-	Category            *CodeableConcept                       `json:"category,omitempty"`
-	ProductOrService    CodeableConcept                        `json:"productOrService"`
-	Modifier            []CodeableConcept                      `json:"modifier,omitempty"`
-	ProgramCode         []CodeableConcept                      `json:"programCode,omitempty"`
-	Quantity            *Quantity                              `json:"quantity,omitempty"`
-	UnitPrice           *Money                                 `json:"unitPrice,omitempty"`
-	Factor              *string                                `json:"factor,omitempty"`
-	Net                 *Money                                 `json:"net,omitempty"`
-	Udi                 []Reference                            `json:"udi,omitempty"`
-	BodySite            *CodeableConcept                       `json:"bodySite,omitempty"`
-	SubSite             []CodeableConcept                      `json:"subSite,omitempty"`
-	Encounter           []Reference                            `json:"encounter,omitempty"`
-	NoteNumber          []int                                  `json:"noteNumber,omitempty"`
-	Adjudication        []ExplanationOfBenefitItemAdjudication `json:"adjudication,omitempty"`
-	Detail              []ExplanationOfBenefitItemDetail       `json:"detail,omitempty"`
+	Id                  *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence            int                                    `bson:"sequence" json:"sequence"`
+	CareTeamSequence    []int                                  `bson:"careTeamSequence,omitempty" json:"careTeamSequence,omitempty"`
+	DiagnosisSequence   []int                                  `bson:"diagnosisSequence,omitempty" json:"diagnosisSequence,omitempty"`
+	ProcedureSequence   []int                                  `bson:"procedureSequence,omitempty" json:"procedureSequence,omitempty"`
+	InformationSequence []int                                  `bson:"informationSequence,omitempty" json:"informationSequence,omitempty"`
+	Revenue             *CodeableConcept                       `bson:"revenue,omitempty" json:"revenue,omitempty"`
+	Category            *CodeableConcept                       `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService    CodeableConcept                        `bson:"productOrService" json:"productOrService"`
+	Modifier            []CodeableConcept                      `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode         []CodeableConcept                      `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity            *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice           *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor              *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net                 *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
+	Udi                 []Reference                            `bson:"udi,omitempty" json:"udi,omitempty"`
+	BodySite            *CodeableConcept                       `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	SubSite             []CodeableConcept                      `bson:"subSite,omitempty" json:"subSite,omitempty"`
+	Encounter           []Reference                            `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	NoteNumber          []int                                  `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication        []ExplanationOfBenefitItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	Detail              []ExplanationOfBenefitItemDetail       `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type ExplanationOfBenefitItemAdjudication struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Category          CodeableConcept  `json:"category"`
-	Reason            *CodeableConcept `json:"reason,omitempty"`
-	Amount            *Money           `json:"amount,omitempty"`
-	Value             *string          `json:"value,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          CodeableConcept  `bson:"category" json:"category"`
+	Reason            *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
+	Amount            *Money           `bson:"amount,omitempty" json:"amount,omitempty"`
+	Value             *string          `bson:"value,omitempty" json:"value,omitempty"`
 }
 type ExplanationOfBenefitItemDetail struct {
-	Id                *string                                   `json:"id,omitempty"`
-	Extension         []Extension                               `json:"extension,omitempty"`
-	ModifierExtension []Extension                               `json:"modifierExtension,omitempty"`
-	Sequence          int                                       `json:"sequence"`
-	Revenue           *CodeableConcept                          `json:"revenue,omitempty"`
-	Category          *CodeableConcept                          `json:"category,omitempty"`
-	ProductOrService  CodeableConcept                           `json:"productOrService"`
-	Modifier          []CodeableConcept                         `json:"modifier,omitempty"`
-	ProgramCode       []CodeableConcept                         `json:"programCode,omitempty"`
-	Quantity          *Quantity                                 `json:"quantity,omitempty"`
-	UnitPrice         *Money                                    `json:"unitPrice,omitempty"`
-	Factor            *string                                   `json:"factor,omitempty"`
-	Net               *Money                                    `json:"net,omitempty"`
-	Udi               []Reference                               `json:"udi,omitempty"`
-	NoteNumber        []int                                     `json:"noteNumber,omitempty"`
-	Adjudication      []ExplanationOfBenefitItemAdjudication    `json:"adjudication,omitempty"`
-	SubDetail         []ExplanationOfBenefitItemDetailSubDetail `json:"subDetail,omitempty"`
+	Id                *string                                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int                                       `bson:"sequence" json:"sequence"`
+	Revenue           *CodeableConcept                          `bson:"revenue,omitempty" json:"revenue,omitempty"`
+	Category          *CodeableConcept                          `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService  CodeableConcept                           `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept                         `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode       []CodeableConcept                         `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity          *Quantity                                 `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                                    `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                                   `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                                    `bson:"net,omitempty" json:"net,omitempty"`
+	Udi               []Reference                               `bson:"udi,omitempty" json:"udi,omitempty"`
+	NoteNumber        []int                                     `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ExplanationOfBenefitItemAdjudication    `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	SubDetail         []ExplanationOfBenefitItemDetailSubDetail `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 type ExplanationOfBenefitItemDetailSubDetail struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Sequence          int                                    `json:"sequence"`
-	Revenue           *CodeableConcept                       `json:"revenue,omitempty"`
-	Category          *CodeableConcept                       `json:"category,omitempty"`
-	ProductOrService  CodeableConcept                        `json:"productOrService"`
-	Modifier          []CodeableConcept                      `json:"modifier,omitempty"`
-	ProgramCode       []CodeableConcept                      `json:"programCode,omitempty"`
-	Quantity          *Quantity                              `json:"quantity,omitempty"`
-	UnitPrice         *Money                                 `json:"unitPrice,omitempty"`
-	Factor            *string                                `json:"factor,omitempty"`
-	Net               *Money                                 `json:"net,omitempty"`
-	Udi               []Reference                            `json:"udi,omitempty"`
-	NoteNumber        []int                                  `json:"noteNumber,omitempty"`
-	Adjudication      []ExplanationOfBenefitItemAdjudication `json:"adjudication,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          int                                    `bson:"sequence" json:"sequence"`
+	Revenue           *CodeableConcept                       `bson:"revenue,omitempty" json:"revenue,omitempty"`
+	Category          *CodeableConcept                       `bson:"category,omitempty" json:"category,omitempty"`
+	ProductOrService  CodeableConcept                        `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept                      `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode       []CodeableConcept                      `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity          *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
+	Udi               []Reference                            `bson:"udi,omitempty" json:"udi,omitempty"`
+	NoteNumber        []int                                  `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ExplanationOfBenefitItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
 }
 type ExplanationOfBenefitAddItem struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	ItemSequence      []int                                  `json:"itemSequence,omitempty"`
-	DetailSequence    []int                                  `json:"detailSequence,omitempty"`
-	SubDetailSequence []int                                  `json:"subDetailSequence,omitempty"`
-	Provider          []Reference                            `json:"provider,omitempty"`
-	ProductOrService  CodeableConcept                        `json:"productOrService"`
-	Modifier          []CodeableConcept                      `json:"modifier,omitempty"`
-	ProgramCode       []CodeableConcept                      `json:"programCode,omitempty"`
-	Quantity          *Quantity                              `json:"quantity,omitempty"`
-	UnitPrice         *Money                                 `json:"unitPrice,omitempty"`
-	Factor            *string                                `json:"factor,omitempty"`
-	Net               *Money                                 `json:"net,omitempty"`
-	BodySite          *CodeableConcept                       `json:"bodySite,omitempty"`
-	SubSite           []CodeableConcept                      `json:"subSite,omitempty"`
-	NoteNumber        []int                                  `json:"noteNumber,omitempty"`
-	Adjudication      []ExplanationOfBenefitItemAdjudication `json:"adjudication,omitempty"`
-	Detail            []ExplanationOfBenefitAddItemDetail    `json:"detail,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ItemSequence      []int                                  `bson:"itemSequence,omitempty" json:"itemSequence,omitempty"`
+	DetailSequence    []int                                  `bson:"detailSequence,omitempty" json:"detailSequence,omitempty"`
+	SubDetailSequence []int                                  `bson:"subDetailSequence,omitempty" json:"subDetailSequence,omitempty"`
+	Provider          []Reference                            `bson:"provider,omitempty" json:"provider,omitempty"`
+	ProductOrService  CodeableConcept                        `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept                      `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	ProgramCode       []CodeableConcept                      `bson:"programCode,omitempty" json:"programCode,omitempty"`
+	Quantity          *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
+	BodySite          *CodeableConcept                       `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	SubSite           []CodeableConcept                      `bson:"subSite,omitempty" json:"subSite,omitempty"`
+	NoteNumber        []int                                  `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ExplanationOfBenefitItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	Detail            []ExplanationOfBenefitAddItemDetail    `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type ExplanationOfBenefitAddItemDetail struct {
-	Id                *string                                      `json:"id,omitempty"`
-	Extension         []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                                  `json:"modifierExtension,omitempty"`
-	ProductOrService  CodeableConcept                              `json:"productOrService"`
-	Modifier          []CodeableConcept                            `json:"modifier,omitempty"`
-	Quantity          *Quantity                                    `json:"quantity,omitempty"`
-	UnitPrice         *Money                                       `json:"unitPrice,omitempty"`
-	Factor            *string                                      `json:"factor,omitempty"`
-	Net               *Money                                       `json:"net,omitempty"`
-	NoteNumber        []int                                        `json:"noteNumber,omitempty"`
-	Adjudication      []ExplanationOfBenefitItemAdjudication       `json:"adjudication,omitempty"`
-	SubDetail         []ExplanationOfBenefitAddItemDetailSubDetail `json:"subDetail,omitempty"`
+	Id                *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ProductOrService  CodeableConcept                              `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept                            `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Quantity          *Quantity                                    `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                                       `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                                      `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                                       `bson:"net,omitempty" json:"net,omitempty"`
+	NoteNumber        []int                                        `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ExplanationOfBenefitItemAdjudication       `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
+	SubDetail         []ExplanationOfBenefitAddItemDetailSubDetail `bson:"subDetail,omitempty" json:"subDetail,omitempty"`
 }
 type ExplanationOfBenefitAddItemDetailSubDetail struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	ProductOrService  CodeableConcept                        `json:"productOrService"`
-	Modifier          []CodeableConcept                      `json:"modifier,omitempty"`
-	Quantity          *Quantity                              `json:"quantity,omitempty"`
-	UnitPrice         *Money                                 `json:"unitPrice,omitempty"`
-	Factor            *string                                `json:"factor,omitempty"`
-	Net               *Money                                 `json:"net,omitempty"`
-	NoteNumber        []int                                  `json:"noteNumber,omitempty"`
-	Adjudication      []ExplanationOfBenefitItemAdjudication `json:"adjudication,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ProductOrService  CodeableConcept                        `bson:"productOrService" json:"productOrService"`
+	Modifier          []CodeableConcept                      `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Quantity          *Quantity                              `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	UnitPrice         *Money                                 `bson:"unitPrice,omitempty" json:"unitPrice,omitempty"`
+	Factor            *string                                `bson:"factor,omitempty" json:"factor,omitempty"`
+	Net               *Money                                 `bson:"net,omitempty" json:"net,omitempty"`
+	NoteNumber        []int                                  `bson:"noteNumber,omitempty" json:"noteNumber,omitempty"`
+	Adjudication      []ExplanationOfBenefitItemAdjudication `bson:"adjudication,omitempty" json:"adjudication,omitempty"`
 }
 type ExplanationOfBenefitTotal struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Category          CodeableConcept `json:"category"`
-	Amount            Money           `json:"amount"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          CodeableConcept `bson:"category" json:"category"`
+	Amount            Money           `bson:"amount" json:"amount"`
 }
 type ExplanationOfBenefitPayment struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Adjustment        *Money           `json:"adjustment,omitempty"`
-	AdjustmentReason  *CodeableConcept `json:"adjustmentReason,omitempty"`
-	Date              *string          `json:"date,omitempty"`
-	Amount            *Money           `json:"amount,omitempty"`
-	Identifier        *Identifier      `json:"identifier,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Adjustment        *Money           `bson:"adjustment,omitempty" json:"adjustment,omitempty"`
+	AdjustmentReason  *CodeableConcept `bson:"adjustmentReason,omitempty" json:"adjustmentReason,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
+	Amount            *Money           `bson:"amount,omitempty" json:"amount,omitempty"`
+	Identifier        *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
 }
 type ExplanationOfBenefitProcessNote struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Number            *int             `json:"number,omitempty"`
-	Type              *NoteType        `json:"type,omitempty"`
-	Text              *string          `json:"text,omitempty"`
-	Language          *CodeableConcept `json:"language,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Number            *int             `bson:"number,omitempty" json:"number,omitempty"`
+	Type              *NoteType        `bson:"type,omitempty" json:"type,omitempty"`
+	Text              *string          `bson:"text,omitempty" json:"text,omitempty"`
+	Language          *CodeableConcept `bson:"language,omitempty" json:"language,omitempty"`
 }
 type ExplanationOfBenefitBenefitBalance struct {
-	Id                *string                                       `json:"id,omitempty"`
-	Extension         []Extension                                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                                   `json:"modifierExtension,omitempty"`
-	Category          CodeableConcept                               `json:"category"`
-	Excluded          *bool                                         `json:"excluded,omitempty"`
-	Name              *string                                       `json:"name,omitempty"`
-	Description       *string                                       `json:"description,omitempty"`
-	Network           *CodeableConcept                              `json:"network,omitempty"`
-	Unit              *CodeableConcept                              `json:"unit,omitempty"`
-	Term              *CodeableConcept                              `json:"term,omitempty"`
-	Financial         []ExplanationOfBenefitBenefitBalanceFinancial `json:"financial,omitempty"`
+	Id                *string                                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          CodeableConcept                               `bson:"category" json:"category"`
+	Excluded          *bool                                         `bson:"excluded,omitempty" json:"excluded,omitempty"`
+	Name              *string                                       `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string                                       `bson:"description,omitempty" json:"description,omitempty"`
+	Network           *CodeableConcept                              `bson:"network,omitempty" json:"network,omitempty"`
+	Unit              *CodeableConcept                              `bson:"unit,omitempty" json:"unit,omitempty"`
+	Term              *CodeableConcept                              `bson:"term,omitempty" json:"term,omitempty"`
+	Financial         []ExplanationOfBenefitBenefitBalanceFinancial `bson:"financial,omitempty" json:"financial,omitempty"`
 }
 type ExplanationOfBenefitBenefitBalanceFinancial struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
 }
 type OtherExplanationOfBenefit ExplanationOfBenefit
 

--- a/fhir-models/fhir/expression.go
+++ b/fhir-models/fhir/expression.go
@@ -19,11 +19,11 @@ package fhir
 
 // Expression is documented here http://hl7.org/fhir/StructureDefinition/Expression
 type Expression struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	Description *string     `json:"description,omitempty"`
-	Name        *string     `json:"name,omitempty"`
-	Language    string      `json:"language"`
-	Expression  *string     `json:"expression,omitempty"`
-	Reference   *string     `json:"reference,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Description *string     `bson:"description,omitempty" json:"description,omitempty"`
+	Name        *string     `bson:"name,omitempty" json:"name,omitempty"`
+	Language    string      `bson:"language" json:"language"`
+	Expression  *string     `bson:"expression,omitempty" json:"expression,omitempty"`
+	Reference   *string     `bson:"reference,omitempty" json:"reference,omitempty"`
 }

--- a/fhir-models/fhir/extension.go
+++ b/fhir-models/fhir/extension.go
@@ -19,7 +19,7 @@ package fhir
 
 // Extension is documented here http://hl7.org/fhir/StructureDefinition/Extension
 type Extension struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Url       string      `json:"url"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Url       string      `bson:"url" json:"url"`
 }

--- a/fhir-models/fhir/familyMemberHistory.go
+++ b/fhir-models/fhir/familyMemberHistory.go
@@ -21,37 +21,37 @@ import "encoding/json"
 
 // FamilyMemberHistory is documented here http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory
 type FamilyMemberHistory struct {
-	Id                    *string                        `json:"id,omitempty"`
-	Meta                  *Meta                          `json:"meta,omitempty"`
-	ImplicitRules         *string                        `json:"implicitRules,omitempty"`
-	Language              *string                        `json:"language,omitempty"`
-	Text                  *Narrative                     `json:"text,omitempty"`
-	Extension             []Extension                    `json:"extension,omitempty"`
-	ModifierExtension     []Extension                    `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier                   `json:"identifier,omitempty"`
-	InstantiatesCanonical []string                       `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string                       `json:"instantiatesUri,omitempty"`
-	Status                FamilyHistoryStatus            `json:"status"`
-	DataAbsentReason      *CodeableConcept               `json:"dataAbsentReason,omitempty"`
-	Patient               Reference                      `json:"patient"`
-	Date                  *string                        `json:"date,omitempty"`
-	Name                  *string                        `json:"name,omitempty"`
-	Relationship          CodeableConcept                `json:"relationship"`
-	Sex                   *CodeableConcept               `json:"sex,omitempty"`
-	EstimatedAge          *bool                          `json:"estimatedAge,omitempty"`
-	ReasonCode            []CodeableConcept              `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference                    `json:"reasonReference,omitempty"`
-	Note                  []Annotation                   `json:"note,omitempty"`
-	Condition             []FamilyMemberHistoryCondition `json:"condition,omitempty"`
+	Id                    *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier                   `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string                       `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string                       `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	Status                FamilyHistoryStatus            `bson:"status" json:"status"`
+	DataAbsentReason      *CodeableConcept               `bson:"dataAbsentReason,omitempty" json:"dataAbsentReason,omitempty"`
+	Patient               Reference                      `bson:"patient" json:"patient"`
+	Date                  *string                        `bson:"date,omitempty" json:"date,omitempty"`
+	Name                  *string                        `bson:"name,omitempty" json:"name,omitempty"`
+	Relationship          CodeableConcept                `bson:"relationship" json:"relationship"`
+	Sex                   *CodeableConcept               `bson:"sex,omitempty" json:"sex,omitempty"`
+	EstimatedAge          *bool                          `bson:"estimatedAge,omitempty" json:"estimatedAge,omitempty"`
+	ReasonCode            []CodeableConcept              `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference                    `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Note                  []Annotation                   `bson:"note,omitempty" json:"note,omitempty"`
+	Condition             []FamilyMemberHistoryCondition `bson:"condition,omitempty" json:"condition,omitempty"`
 }
 type FamilyMemberHistoryCondition struct {
-	Id                 *string          `json:"id,omitempty"`
-	Extension          []Extension      `json:"extension,omitempty"`
-	ModifierExtension  []Extension      `json:"modifierExtension,omitempty"`
-	Code               CodeableConcept  `json:"code"`
-	Outcome            *CodeableConcept `json:"outcome,omitempty"`
-	ContributedToDeath *bool            `json:"contributedToDeath,omitempty"`
-	Note               []Annotation     `json:"note,omitempty"`
+	Id                 *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code               CodeableConcept  `bson:"code" json:"code"`
+	Outcome            *CodeableConcept `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	ContributedToDeath *bool            `bson:"contributedToDeath,omitempty" json:"contributedToDeath,omitempty"`
+	Note               []Annotation     `bson:"note,omitempty" json:"note,omitempty"`
 }
 type OtherFamilyMemberHistory FamilyMemberHistory
 

--- a/fhir-models/fhir/flag.go
+++ b/fhir-models/fhir/flag.go
@@ -21,21 +21,21 @@ import "encoding/json"
 
 // Flag is documented here http://hl7.org/fhir/StructureDefinition/Flag
 type Flag struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier      `json:"identifier,omitempty"`
-	Status            FlagStatus        `json:"status"`
-	Category          []CodeableConcept `json:"category,omitempty"`
-	Code              CodeableConcept   `json:"code"`
-	Subject           Reference         `json:"subject"`
-	Period            *Period           `json:"period,omitempty"`
-	Encounter         *Reference        `json:"encounter,omitempty"`
-	Author            *Reference        `json:"author,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FlagStatus        `bson:"status" json:"status"`
+	Category          []CodeableConcept `bson:"category,omitempty" json:"category,omitempty"`
+	Code              CodeableConcept   `bson:"code" json:"code"`
+	Subject           Reference         `bson:"subject" json:"subject"`
+	Period            *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Encounter         *Reference        `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Author            *Reference        `bson:"author,omitempty" json:"author,omitempty"`
 }
 type OtherFlag Flag
 

--- a/fhir-models/fhir/goal.go
+++ b/fhir-models/fhir/goal.go
@@ -21,34 +21,34 @@ import "encoding/json"
 
 // Goal is documented here http://hl7.org/fhir/StructureDefinition/Goal
 type Goal struct {
-	Id                *string             `json:"id,omitempty"`
-	Meta              *Meta               `json:"meta,omitempty"`
-	ImplicitRules     *string             `json:"implicitRules,omitempty"`
-	Language          *string             `json:"language,omitempty"`
-	Text              *Narrative          `json:"text,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier        `json:"identifier,omitempty"`
-	LifecycleStatus   GoalLifecycleStatus `json:"lifecycleStatus"`
-	AchievementStatus *CodeableConcept    `json:"achievementStatus,omitempty"`
-	Category          []CodeableConcept   `json:"category,omitempty"`
-	Priority          *CodeableConcept    `json:"priority,omitempty"`
-	Description       CodeableConcept     `json:"description"`
-	Subject           Reference           `json:"subject"`
-	Target            []GoalTarget        `json:"target,omitempty"`
-	StatusDate        *string             `json:"statusDate,omitempty"`
-	StatusReason      *string             `json:"statusReason,omitempty"`
-	ExpressedBy       *Reference          `json:"expressedBy,omitempty"`
-	Addresses         []Reference         `json:"addresses,omitempty"`
-	Note              []Annotation        `json:"note,omitempty"`
-	OutcomeCode       []CodeableConcept   `json:"outcomeCode,omitempty"`
-	OutcomeReference  []Reference         `json:"outcomeReference,omitempty"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	LifecycleStatus   GoalLifecycleStatus `bson:"lifecycleStatus" json:"lifecycleStatus"`
+	AchievementStatus *CodeableConcept    `bson:"achievementStatus,omitempty" json:"achievementStatus,omitempty"`
+	Category          []CodeableConcept   `bson:"category,omitempty" json:"category,omitempty"`
+	Priority          *CodeableConcept    `bson:"priority,omitempty" json:"priority,omitempty"`
+	Description       CodeableConcept     `bson:"description" json:"description"`
+	Subject           Reference           `bson:"subject" json:"subject"`
+	Target            []GoalTarget        `bson:"target,omitempty" json:"target,omitempty"`
+	StatusDate        *string             `bson:"statusDate,omitempty" json:"statusDate,omitempty"`
+	StatusReason      *string             `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	ExpressedBy       *Reference          `bson:"expressedBy,omitempty" json:"expressedBy,omitempty"`
+	Addresses         []Reference         `bson:"addresses,omitempty" json:"addresses,omitempty"`
+	Note              []Annotation        `bson:"note,omitempty" json:"note,omitempty"`
+	OutcomeCode       []CodeableConcept   `bson:"outcomeCode,omitempty" json:"outcomeCode,omitempty"`
+	OutcomeReference  []Reference         `bson:"outcomeReference,omitempty" json:"outcomeReference,omitempty"`
 }
 type GoalTarget struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Measure           *CodeableConcept `json:"measure,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Measure           *CodeableConcept `bson:"measure,omitempty" json:"measure,omitempty"`
 }
 type OtherGoal Goal
 

--- a/fhir-models/fhir/graphDefinition.go
+++ b/fhir-models/fhir/graphDefinition.go
@@ -21,59 +21,59 @@ import "encoding/json"
 
 // GraphDefinition is documented here http://hl7.org/fhir/StructureDefinition/GraphDefinition
 type GraphDefinition struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Url               *string               `json:"url,omitempty"`
-	Version           *string               `json:"version,omitempty"`
-	Name              string                `json:"name"`
-	Status            PublicationStatus     `json:"status"`
-	Experimental      *bool                 `json:"experimental,omitempty"`
-	Date              *string               `json:"date,omitempty"`
-	Publisher         *string               `json:"publisher,omitempty"`
-	Contact           []ContactDetail       `json:"contact,omitempty"`
-	Description       *string               `json:"description,omitempty"`
-	UseContext        []UsageContext        `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept     `json:"jurisdiction,omitempty"`
-	Purpose           *string               `json:"purpose,omitempty"`
-	Start             ResourceType          `json:"start"`
-	Profile           *string               `json:"profile,omitempty"`
-	Link              []GraphDefinitionLink `json:"link,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string               `bson:"url,omitempty" json:"url,omitempty"`
+	Version           *string               `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                `bson:"name" json:"name"`
+	Status            PublicationStatus     `bson:"status" json:"status"`
+	Experimental      *bool                 `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string               `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string               `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail       `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string               `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext        `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept     `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string               `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Start             ResourceType          `bson:"start" json:"start"`
+	Profile           *string               `bson:"profile,omitempty" json:"profile,omitempty"`
+	Link              []GraphDefinitionLink `bson:"link,omitempty" json:"link,omitempty"`
 }
 type GraphDefinitionLink struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Path              *string                     `json:"path,omitempty"`
-	SliceName         *string                     `json:"sliceName,omitempty"`
-	Min               *int                        `json:"min,omitempty"`
-	Max               *string                     `json:"max,omitempty"`
-	Description       *string                     `json:"description,omitempty"`
-	Target            []GraphDefinitionLinkTarget `json:"target,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Path              *string                     `bson:"path,omitempty" json:"path,omitempty"`
+	SliceName         *string                     `bson:"sliceName,omitempty" json:"sliceName,omitempty"`
+	Min               *int                        `bson:"min,omitempty" json:"min,omitempty"`
+	Max               *string                     `bson:"max,omitempty" json:"max,omitempty"`
+	Description       *string                     `bson:"description,omitempty" json:"description,omitempty"`
+	Target            []GraphDefinitionLinkTarget `bson:"target,omitempty" json:"target,omitempty"`
 }
 type GraphDefinitionLinkTarget struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Type              ResourceType                           `json:"type"`
-	Params            *string                                `json:"params,omitempty"`
-	Profile           *string                                `json:"profile,omitempty"`
-	Compartment       []GraphDefinitionLinkTargetCompartment `json:"compartment,omitempty"`
-	Link              []GraphDefinitionLink                  `json:"link,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ResourceType                           `bson:"type" json:"type"`
+	Params            *string                                `bson:"params,omitempty" json:"params,omitempty"`
+	Profile           *string                                `bson:"profile,omitempty" json:"profile,omitempty"`
+	Compartment       []GraphDefinitionLinkTargetCompartment `bson:"compartment,omitempty" json:"compartment,omitempty"`
+	Link              []GraphDefinitionLink                  `bson:"link,omitempty" json:"link,omitempty"`
 }
 type GraphDefinitionLinkTargetCompartment struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Use               GraphCompartmentUse  `json:"use"`
-	Code              CompartmentType      `json:"code"`
-	Rule              GraphCompartmentRule `json:"rule"`
-	Expression        *string              `json:"expression,omitempty"`
-	Description       *string              `json:"description,omitempty"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Use               GraphCompartmentUse  `bson:"use" json:"use"`
+	Code              CompartmentType      `bson:"code" json:"code"`
+	Rule              GraphCompartmentRule `bson:"rule" json:"rule"`
+	Expression        *string              `bson:"expression,omitempty" json:"expression,omitempty"`
+	Description       *string              `bson:"description,omitempty" json:"description,omitempty"`
 }
 type OtherGraphDefinition GraphDefinition
 

--- a/fhir-models/fhir/group.go
+++ b/fhir-models/fhir/group.go
@@ -21,39 +21,39 @@ import "encoding/json"
 
 // Group is documented here http://hl7.org/fhir/StructureDefinition/Group
 type Group struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier          `json:"identifier,omitempty"`
-	Active            *bool                 `json:"active,omitempty"`
-	Type              GroupType             `json:"type"`
-	Actual            bool                  `json:"actual"`
-	Code              *CodeableConcept      `json:"code,omitempty"`
-	Name              *string               `json:"name,omitempty"`
-	Quantity          *int                  `json:"quantity,omitempty"`
-	ManagingEntity    *Reference            `json:"managingEntity,omitempty"`
-	Characteristic    []GroupCharacteristic `json:"characteristic,omitempty"`
-	Member            []GroupMember         `json:"member,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active            *bool                 `bson:"active,omitempty" json:"active,omitempty"`
+	Type              GroupType             `bson:"type" json:"type"`
+	Actual            bool                  `bson:"actual" json:"actual"`
+	Code              *CodeableConcept      `bson:"code,omitempty" json:"code,omitempty"`
+	Name              *string               `bson:"name,omitempty" json:"name,omitempty"`
+	Quantity          *int                  `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	ManagingEntity    *Reference            `bson:"managingEntity,omitempty" json:"managingEntity,omitempty"`
+	Characteristic    []GroupCharacteristic `bson:"characteristic,omitempty" json:"characteristic,omitempty"`
+	Member            []GroupMember         `bson:"member,omitempty" json:"member,omitempty"`
 }
 type GroupCharacteristic struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept `json:"code"`
-	Exclude           bool            `json:"exclude"`
-	Period            *Period         `json:"period,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
+	Exclude           bool            `bson:"exclude" json:"exclude"`
+	Period            *Period         `bson:"period,omitempty" json:"period,omitempty"`
 }
 type GroupMember struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Entity            Reference   `json:"entity"`
-	Period            *Period     `json:"period,omitempty"`
-	Inactive          *bool       `json:"inactive,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Entity            Reference   `bson:"entity" json:"entity"`
+	Period            *Period     `bson:"period,omitempty" json:"period,omitempty"`
+	Inactive          *bool       `bson:"inactive,omitempty" json:"inactive,omitempty"`
 }
 type OtherGroup Group
 

--- a/fhir-models/fhir/guidanceResponse.go
+++ b/fhir-models/fhir/guidanceResponse.go
@@ -21,27 +21,27 @@ import "encoding/json"
 
 // GuidanceResponse is documented here http://hl7.org/fhir/StructureDefinition/GuidanceResponse
 type GuidanceResponse struct {
-	Id                 *string                `json:"id,omitempty"`
-	Meta               *Meta                  `json:"meta,omitempty"`
-	ImplicitRules      *string                `json:"implicitRules,omitempty"`
-	Language           *string                `json:"language,omitempty"`
-	Text               *Narrative             `json:"text,omitempty"`
-	Extension          []Extension            `json:"extension,omitempty"`
-	ModifierExtension  []Extension            `json:"modifierExtension,omitempty"`
-	RequestIdentifier  *Identifier            `json:"requestIdentifier,omitempty"`
-	Identifier         []Identifier           `json:"identifier,omitempty"`
-	Status             GuidanceResponseStatus `json:"status"`
-	Subject            *Reference             `json:"subject,omitempty"`
-	Encounter          *Reference             `json:"encounter,omitempty"`
-	OccurrenceDateTime *string                `json:"occurrenceDateTime,omitempty"`
-	Performer          *Reference             `json:"performer,omitempty"`
-	ReasonCode         []CodeableConcept      `json:"reasonCode,omitempty"`
-	ReasonReference    []Reference            `json:"reasonReference,omitempty"`
-	Note               []Annotation           `json:"note,omitempty"`
-	EvaluationMessage  []Reference            `json:"evaluationMessage,omitempty"`
-	OutputParameters   *Reference             `json:"outputParameters,omitempty"`
-	Result             *Reference             `json:"result,omitempty"`
-	DataRequirement    []DataRequirement      `json:"dataRequirement,omitempty"`
+	Id                 *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	RequestIdentifier  *Identifier            `bson:"requestIdentifier,omitempty" json:"requestIdentifier,omitempty"`
+	Identifier         []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status             GuidanceResponseStatus `bson:"status" json:"status"`
+	Subject            *Reference             `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter          *Reference             `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	OccurrenceDateTime *string                `bson:"occurrenceDateTime,omitempty" json:"occurrenceDateTime,omitempty"`
+	Performer          *Reference             `bson:"performer,omitempty" json:"performer,omitempty"`
+	ReasonCode         []CodeableConcept      `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference    []Reference            `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Note               []Annotation           `bson:"note,omitempty" json:"note,omitempty"`
+	EvaluationMessage  []Reference            `bson:"evaluationMessage,omitempty" json:"evaluationMessage,omitempty"`
+	OutputParameters   *Reference             `bson:"outputParameters,omitempty" json:"outputParameters,omitempty"`
+	Result             *Reference             `bson:"result,omitempty" json:"result,omitempty"`
+	DataRequirement    []DataRequirement      `bson:"dataRequirement,omitempty" json:"dataRequirement,omitempty"`
 }
 type OtherGuidanceResponse GuidanceResponse
 

--- a/fhir-models/fhir/healthcareService.go
+++ b/fhir-models/fhir/healthcareService.go
@@ -21,60 +21,60 @@ import "encoding/json"
 
 // HealthcareService is documented here http://hl7.org/fhir/StructureDefinition/HealthcareService
 type HealthcareService struct {
-	Id                     *string                          `json:"id,omitempty"`
-	Meta                   *Meta                            `json:"meta,omitempty"`
-	ImplicitRules          *string                          `json:"implicitRules,omitempty"`
-	Language               *string                          `json:"language,omitempty"`
-	Text                   *Narrative                       `json:"text,omitempty"`
-	Extension              []Extension                      `json:"extension,omitempty"`
-	ModifierExtension      []Extension                      `json:"modifierExtension,omitempty"`
-	Identifier             []Identifier                     `json:"identifier,omitempty"`
-	Active                 *bool                            `json:"active,omitempty"`
-	ProvidedBy             *Reference                       `json:"providedBy,omitempty"`
-	Category               []CodeableConcept                `json:"category,omitempty"`
-	Type                   []CodeableConcept                `json:"type,omitempty"`
-	Specialty              []CodeableConcept                `json:"specialty,omitempty"`
-	Location               []Reference                      `json:"location,omitempty"`
-	Name                   *string                          `json:"name,omitempty"`
-	Comment                *string                          `json:"comment,omitempty"`
-	ExtraDetails           *string                          `json:"extraDetails,omitempty"`
-	Photo                  *Attachment                      `json:"photo,omitempty"`
-	Telecom                []ContactPoint                   `json:"telecom,omitempty"`
-	CoverageArea           []Reference                      `json:"coverageArea,omitempty"`
-	ServiceProvisionCode   []CodeableConcept                `json:"serviceProvisionCode,omitempty"`
-	Eligibility            []HealthcareServiceEligibility   `json:"eligibility,omitempty"`
-	Program                []CodeableConcept                `json:"program,omitempty"`
-	Characteristic         []CodeableConcept                `json:"characteristic,omitempty"`
-	Communication          []CodeableConcept                `json:"communication,omitempty"`
-	ReferralMethod         []CodeableConcept                `json:"referralMethod,omitempty"`
-	AppointmentRequired    *bool                            `json:"appointmentRequired,omitempty"`
-	AvailableTime          []HealthcareServiceAvailableTime `json:"availableTime,omitempty"`
-	NotAvailable           []HealthcareServiceNotAvailable  `json:"notAvailable,omitempty"`
-	AvailabilityExceptions *string                          `json:"availabilityExceptions,omitempty"`
-	Endpoint               []Reference                      `json:"endpoint,omitempty"`
+	Id                     *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string                          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string                          `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative                       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier             []Identifier                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active                 *bool                            `bson:"active,omitempty" json:"active,omitempty"`
+	ProvidedBy             *Reference                       `bson:"providedBy,omitempty" json:"providedBy,omitempty"`
+	Category               []CodeableConcept                `bson:"category,omitempty" json:"category,omitempty"`
+	Type                   []CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
+	Specialty              []CodeableConcept                `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	Location               []Reference                      `bson:"location,omitempty" json:"location,omitempty"`
+	Name                   *string                          `bson:"name,omitempty" json:"name,omitempty"`
+	Comment                *string                          `bson:"comment,omitempty" json:"comment,omitempty"`
+	ExtraDetails           *string                          `bson:"extraDetails,omitempty" json:"extraDetails,omitempty"`
+	Photo                  *Attachment                      `bson:"photo,omitempty" json:"photo,omitempty"`
+	Telecom                []ContactPoint                   `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	CoverageArea           []Reference                      `bson:"coverageArea,omitempty" json:"coverageArea,omitempty"`
+	ServiceProvisionCode   []CodeableConcept                `bson:"serviceProvisionCode,omitempty" json:"serviceProvisionCode,omitempty"`
+	Eligibility            []HealthcareServiceEligibility   `bson:"eligibility,omitempty" json:"eligibility,omitempty"`
+	Program                []CodeableConcept                `bson:"program,omitempty" json:"program,omitempty"`
+	Characteristic         []CodeableConcept                `bson:"characteristic,omitempty" json:"characteristic,omitempty"`
+	Communication          []CodeableConcept                `bson:"communication,omitempty" json:"communication,omitempty"`
+	ReferralMethod         []CodeableConcept                `bson:"referralMethod,omitempty" json:"referralMethod,omitempty"`
+	AppointmentRequired    *bool                            `bson:"appointmentRequired,omitempty" json:"appointmentRequired,omitempty"`
+	AvailableTime          []HealthcareServiceAvailableTime `bson:"availableTime,omitempty" json:"availableTime,omitempty"`
+	NotAvailable           []HealthcareServiceNotAvailable  `bson:"notAvailable,omitempty" json:"notAvailable,omitempty"`
+	AvailabilityExceptions *string                          `bson:"availabilityExceptions,omitempty" json:"availabilityExceptions,omitempty"`
+	Endpoint               []Reference                      `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 type HealthcareServiceEligibility struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Comment           *string          `json:"comment,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Comment           *string          `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type HealthcareServiceAvailableTime struct {
-	Id                 *string      `json:"id,omitempty"`
-	Extension          []Extension  `json:"extension,omitempty"`
-	ModifierExtension  []Extension  `json:"modifierExtension,omitempty"`
-	DaysOfWeek         []DaysOfWeek `json:"daysOfWeek,omitempty"`
-	AllDay             *bool        `json:"allDay,omitempty"`
-	AvailableStartTime *string      `json:"availableStartTime,omitempty"`
-	AvailableEndTime   *string      `json:"availableEndTime,omitempty"`
+	Id                 *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DaysOfWeek         []DaysOfWeek `bson:"daysOfWeek,omitempty" json:"daysOfWeek,omitempty"`
+	AllDay             *bool        `bson:"allDay,omitempty" json:"allDay,omitempty"`
+	AvailableStartTime *string      `bson:"availableStartTime,omitempty" json:"availableStartTime,omitempty"`
+	AvailableEndTime   *string      `bson:"availableEndTime,omitempty" json:"availableEndTime,omitempty"`
 }
 type HealthcareServiceNotAvailable struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Description       string      `json:"description"`
-	During            *Period     `json:"during,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       string      `bson:"description" json:"description"`
+	During            *Period     `bson:"during,omitempty" json:"during,omitempty"`
 }
 type OtherHealthcareService HealthcareService
 

--- a/fhir-models/fhir/humanName.go
+++ b/fhir-models/fhir/humanName.go
@@ -19,13 +19,13 @@ package fhir
 
 // HumanName is documented here http://hl7.org/fhir/StructureDefinition/HumanName
 type HumanName struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Use       *NameUse    `json:"use,omitempty"`
-	Text      *string     `json:"text,omitempty"`
-	Family    *string     `json:"family,omitempty"`
-	Given     []string    `json:"given,omitempty"`
-	Prefix    []string    `json:"prefix,omitempty"`
-	Suffix    []string    `json:"suffix,omitempty"`
-	Period    *Period     `json:"period,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Use       *NameUse    `bson:"use,omitempty" json:"use,omitempty"`
+	Text      *string     `bson:"text,omitempty" json:"text,omitempty"`
+	Family    *string     `bson:"family,omitempty" json:"family,omitempty"`
+	Given     []string    `bson:"given,omitempty" json:"given,omitempty"`
+	Prefix    []string    `bson:"prefix,omitempty" json:"prefix,omitempty"`
+	Suffix    []string    `bson:"suffix,omitempty" json:"suffix,omitempty"`
+	Period    *Period     `bson:"period,omitempty" json:"period,omitempty"`
 }

--- a/fhir-models/fhir/identifier.go
+++ b/fhir-models/fhir/identifier.go
@@ -19,12 +19,12 @@ package fhir
 
 // Identifier is documented here http://hl7.org/fhir/StructureDefinition/Identifier
 type Identifier struct {
-	Id        *string          `json:"id,omitempty"`
-	Extension []Extension      `json:"extension,omitempty"`
-	Use       *IdentifierUse   `json:"use,omitempty"`
-	Type      *CodeableConcept `json:"type,omitempty"`
-	System    *string          `json:"system,omitempty"`
-	Value     *string          `json:"value,omitempty"`
-	Period    *Period          `json:"period,omitempty"`
-	Assigner  *Reference       `json:"assigner,omitempty"`
+	Id        *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	Use       *IdentifierUse   `bson:"use,omitempty" json:"use,omitempty"`
+	Type      *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	System    *string          `bson:"system,omitempty" json:"system,omitempty"`
+	Value     *string          `bson:"value,omitempty" json:"value,omitempty"`
+	Period    *Period          `bson:"period,omitempty" json:"period,omitempty"`
+	Assigner  *Reference       `bson:"assigner,omitempty" json:"assigner,omitempty"`
 }

--- a/fhir-models/fhir/imagingStudy.go
+++ b/fhir-models/fhir/imagingStudy.go
@@ -21,66 +21,66 @@ import "encoding/json"
 
 // ImagingStudy is documented here http://hl7.org/fhir/StructureDefinition/ImagingStudy
 type ImagingStudy struct {
-	Id                 *string              `json:"id,omitempty"`
-	Meta               *Meta                `json:"meta,omitempty"`
-	ImplicitRules      *string              `json:"implicitRules,omitempty"`
-	Language           *string              `json:"language,omitempty"`
-	Text               *Narrative           `json:"text,omitempty"`
-	Extension          []Extension          `json:"extension,omitempty"`
-	ModifierExtension  []Extension          `json:"modifierExtension,omitempty"`
-	Identifier         []Identifier         `json:"identifier,omitempty"`
-	Status             ImagingStudyStatus   `json:"status"`
-	Modality           []Coding             `json:"modality,omitempty"`
-	Subject            Reference            `json:"subject"`
-	Encounter          *Reference           `json:"encounter,omitempty"`
-	Started            *string              `json:"started,omitempty"`
-	BasedOn            []Reference          `json:"basedOn,omitempty"`
-	Referrer           *Reference           `json:"referrer,omitempty"`
-	Interpreter        []Reference          `json:"interpreter,omitempty"`
-	Endpoint           []Reference          `json:"endpoint,omitempty"`
-	NumberOfSeries     *int                 `json:"numberOfSeries,omitempty"`
-	NumberOfInstances  *int                 `json:"numberOfInstances,omitempty"`
-	ProcedureReference *Reference           `json:"procedureReference,omitempty"`
-	ProcedureCode      []CodeableConcept    `json:"procedureCode,omitempty"`
-	Location           *Reference           `json:"location,omitempty"`
-	ReasonCode         []CodeableConcept    `json:"reasonCode,omitempty"`
-	ReasonReference    []Reference          `json:"reasonReference,omitempty"`
-	Note               []Annotation         `json:"note,omitempty"`
-	Description        *string              `json:"description,omitempty"`
-	Series             []ImagingStudySeries `json:"series,omitempty"`
+	Id                 *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string              `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string              `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative           `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         []Identifier         `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status             ImagingStudyStatus   `bson:"status" json:"status"`
+	Modality           []Coding             `bson:"modality,omitempty" json:"modality,omitempty"`
+	Subject            Reference            `bson:"subject" json:"subject"`
+	Encounter          *Reference           `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Started            *string              `bson:"started,omitempty" json:"started,omitempty"`
+	BasedOn            []Reference          `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Referrer           *Reference           `bson:"referrer,omitempty" json:"referrer,omitempty"`
+	Interpreter        []Reference          `bson:"interpreter,omitempty" json:"interpreter,omitempty"`
+	Endpoint           []Reference          `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	NumberOfSeries     *int                 `bson:"numberOfSeries,omitempty" json:"numberOfSeries,omitempty"`
+	NumberOfInstances  *int                 `bson:"numberOfInstances,omitempty" json:"numberOfInstances,omitempty"`
+	ProcedureReference *Reference           `bson:"procedureReference,omitempty" json:"procedureReference,omitempty"`
+	ProcedureCode      []CodeableConcept    `bson:"procedureCode,omitempty" json:"procedureCode,omitempty"`
+	Location           *Reference           `bson:"location,omitempty" json:"location,omitempty"`
+	ReasonCode         []CodeableConcept    `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference    []Reference          `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Note               []Annotation         `bson:"note,omitempty" json:"note,omitempty"`
+	Description        *string              `bson:"description,omitempty" json:"description,omitempty"`
+	Series             []ImagingStudySeries `bson:"series,omitempty" json:"series,omitempty"`
 }
 type ImagingStudySeries struct {
-	Id                *string                       `json:"id,omitempty"`
-	Extension         []Extension                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                   `json:"modifierExtension,omitempty"`
-	Uid               string                        `json:"uid"`
-	Number            *int                          `json:"number,omitempty"`
-	Modality          Coding                        `json:"modality"`
-	Description       *string                       `json:"description,omitempty"`
-	NumberOfInstances *int                          `json:"numberOfInstances,omitempty"`
-	Endpoint          []Reference                   `json:"endpoint,omitempty"`
-	BodySite          *Coding                       `json:"bodySite,omitempty"`
-	Laterality        *Coding                       `json:"laterality,omitempty"`
-	Specimen          []Reference                   `json:"specimen,omitempty"`
-	Started           *string                       `json:"started,omitempty"`
-	Performer         []ImagingStudySeriesPerformer `json:"performer,omitempty"`
-	Instance          []ImagingStudySeriesInstance  `json:"instance,omitempty"`
+	Id                *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Uid               string                        `bson:"uid" json:"uid"`
+	Number            *int                          `bson:"number,omitempty" json:"number,omitempty"`
+	Modality          Coding                        `bson:"modality" json:"modality"`
+	Description       *string                       `bson:"description,omitempty" json:"description,omitempty"`
+	NumberOfInstances *int                          `bson:"numberOfInstances,omitempty" json:"numberOfInstances,omitempty"`
+	Endpoint          []Reference                   `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	BodySite          *Coding                       `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Laterality        *Coding                       `bson:"laterality,omitempty" json:"laterality,omitempty"`
+	Specimen          []Reference                   `bson:"specimen,omitempty" json:"specimen,omitempty"`
+	Started           *string                       `bson:"started,omitempty" json:"started,omitempty"`
+	Performer         []ImagingStudySeriesPerformer `bson:"performer,omitempty" json:"performer,omitempty"`
+	Instance          []ImagingStudySeriesInstance  `bson:"instance,omitempty" json:"instance,omitempty"`
 }
 type ImagingStudySeriesPerformer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Function          *CodeableConcept `json:"function,omitempty"`
-	Actor             Reference        `json:"actor"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Function          *CodeableConcept `bson:"function,omitempty" json:"function,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
 }
 type ImagingStudySeriesInstance struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Uid               string      `json:"uid"`
-	SopClass          Coding      `json:"sopClass"`
-	Number            *int        `json:"number,omitempty"`
-	Title             *string     `json:"title,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Uid               string      `bson:"uid" json:"uid"`
+	SopClass          Coding      `bson:"sopClass" json:"sopClass"`
+	Number            *int        `bson:"number,omitempty" json:"number,omitempty"`
+	Title             *string     `bson:"title,omitempty" json:"title,omitempty"`
 }
 type OtherImagingStudy ImagingStudy
 

--- a/fhir-models/fhir/immunization.go
+++ b/fhir-models/fhir/immunization.go
@@ -21,72 +21,72 @@ import "encoding/json"
 
 // Immunization is documented here http://hl7.org/fhir/StructureDefinition/Immunization
 type Immunization struct {
-	Id                 *string                       `json:"id,omitempty"`
-	Meta               *Meta                         `json:"meta,omitempty"`
-	ImplicitRules      *string                       `json:"implicitRules,omitempty"`
-	Language           *string                       `json:"language,omitempty"`
-	Text               *Narrative                    `json:"text,omitempty"`
-	Extension          []Extension                   `json:"extension,omitempty"`
-	ModifierExtension  []Extension                   `json:"modifierExtension,omitempty"`
-	Identifier         []Identifier                  `json:"identifier,omitempty"`
-	Status             ImmunizationStatusCodes       `json:"status"`
-	StatusReason       *CodeableConcept              `json:"statusReason,omitempty"`
-	VaccineCode        CodeableConcept               `json:"vaccineCode"`
-	Patient            Reference                     `json:"patient"`
-	Encounter          *Reference                    `json:"encounter,omitempty"`
-	Recorded           *string                       `json:"recorded,omitempty"`
-	PrimarySource      *bool                         `json:"primarySource,omitempty"`
-	ReportOrigin       *CodeableConcept              `json:"reportOrigin,omitempty"`
-	Location           *Reference                    `json:"location,omitempty"`
-	Manufacturer       *Reference                    `json:"manufacturer,omitempty"`
-	LotNumber          *string                       `json:"lotNumber,omitempty"`
-	ExpirationDate     *string                       `json:"expirationDate,omitempty"`
-	Site               *CodeableConcept              `json:"site,omitempty"`
-	Route              *CodeableConcept              `json:"route,omitempty"`
-	DoseQuantity       *Quantity                     `json:"doseQuantity,omitempty"`
-	Performer          []ImmunizationPerformer       `json:"performer,omitempty"`
-	Note               []Annotation                  `json:"note,omitempty"`
-	ReasonCode         []CodeableConcept             `json:"reasonCode,omitempty"`
-	ReasonReference    []Reference                   `json:"reasonReference,omitempty"`
-	IsSubpotent        *bool                         `json:"isSubpotent,omitempty"`
-	SubpotentReason    []CodeableConcept             `json:"subpotentReason,omitempty"`
-	Education          []ImmunizationEducation       `json:"education,omitempty"`
-	ProgramEligibility []CodeableConcept             `json:"programEligibility,omitempty"`
-	FundingSource      *CodeableConcept              `json:"fundingSource,omitempty"`
-	Reaction           []ImmunizationReaction        `json:"reaction,omitempty"`
-	ProtocolApplied    []ImmunizationProtocolApplied `json:"protocolApplied,omitempty"`
+	Id                 *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status             ImmunizationStatusCodes       `bson:"status" json:"status"`
+	StatusReason       *CodeableConcept              `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	VaccineCode        CodeableConcept               `bson:"vaccineCode" json:"vaccineCode"`
+	Patient            Reference                     `bson:"patient" json:"patient"`
+	Encounter          *Reference                    `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Recorded           *string                       `bson:"recorded,omitempty" json:"recorded,omitempty"`
+	PrimarySource      *bool                         `bson:"primarySource,omitempty" json:"primarySource,omitempty"`
+	ReportOrigin       *CodeableConcept              `bson:"reportOrigin,omitempty" json:"reportOrigin,omitempty"`
+	Location           *Reference                    `bson:"location,omitempty" json:"location,omitempty"`
+	Manufacturer       *Reference                    `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	LotNumber          *string                       `bson:"lotNumber,omitempty" json:"lotNumber,omitempty"`
+	ExpirationDate     *string                       `bson:"expirationDate,omitempty" json:"expirationDate,omitempty"`
+	Site               *CodeableConcept              `bson:"site,omitempty" json:"site,omitempty"`
+	Route              *CodeableConcept              `bson:"route,omitempty" json:"route,omitempty"`
+	DoseQuantity       *Quantity                     `bson:"doseQuantity,omitempty" json:"doseQuantity,omitempty"`
+	Performer          []ImmunizationPerformer       `bson:"performer,omitempty" json:"performer,omitempty"`
+	Note               []Annotation                  `bson:"note,omitempty" json:"note,omitempty"`
+	ReasonCode         []CodeableConcept             `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference    []Reference                   `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	IsSubpotent        *bool                         `bson:"isSubpotent,omitempty" json:"isSubpotent,omitempty"`
+	SubpotentReason    []CodeableConcept             `bson:"subpotentReason,omitempty" json:"subpotentReason,omitempty"`
+	Education          []ImmunizationEducation       `bson:"education,omitempty" json:"education,omitempty"`
+	ProgramEligibility []CodeableConcept             `bson:"programEligibility,omitempty" json:"programEligibility,omitempty"`
+	FundingSource      *CodeableConcept              `bson:"fundingSource,omitempty" json:"fundingSource,omitempty"`
+	Reaction           []ImmunizationReaction        `bson:"reaction,omitempty" json:"reaction,omitempty"`
+	ProtocolApplied    []ImmunizationProtocolApplied `bson:"protocolApplied,omitempty" json:"protocolApplied,omitempty"`
 }
 type ImmunizationPerformer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Function          *CodeableConcept `json:"function,omitempty"`
-	Actor             Reference        `json:"actor"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Function          *CodeableConcept `bson:"function,omitempty" json:"function,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
 }
 type ImmunizationEducation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	DocumentType      *string     `json:"documentType,omitempty"`
-	Reference         *string     `json:"reference,omitempty"`
-	PublicationDate   *string     `json:"publicationDate,omitempty"`
-	PresentationDate  *string     `json:"presentationDate,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DocumentType      *string     `bson:"documentType,omitempty" json:"documentType,omitempty"`
+	Reference         *string     `bson:"reference,omitempty" json:"reference,omitempty"`
+	PublicationDate   *string     `bson:"publicationDate,omitempty" json:"publicationDate,omitempty"`
+	PresentationDate  *string     `bson:"presentationDate,omitempty" json:"presentationDate,omitempty"`
 }
 type ImmunizationReaction struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Date              *string     `json:"date,omitempty"`
-	Detail            *Reference  `json:"detail,omitempty"`
-	Reported          *bool       `json:"reported,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Date              *string     `bson:"date,omitempty" json:"date,omitempty"`
+	Detail            *Reference  `bson:"detail,omitempty" json:"detail,omitempty"`
+	Reported          *bool       `bson:"reported,omitempty" json:"reported,omitempty"`
 }
 type ImmunizationProtocolApplied struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Series            *string           `json:"series,omitempty"`
-	Authority         *Reference        `json:"authority,omitempty"`
-	TargetDisease     []CodeableConcept `json:"targetDisease,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Series            *string           `bson:"series,omitempty" json:"series,omitempty"`
+	Authority         *Reference        `bson:"authority,omitempty" json:"authority,omitempty"`
+	TargetDisease     []CodeableConcept `bson:"targetDisease,omitempty" json:"targetDisease,omitempty"`
 }
 type OtherImmunization Immunization
 

--- a/fhir-models/fhir/immunizationEvaluation.go
+++ b/fhir-models/fhir/immunizationEvaluation.go
@@ -21,24 +21,24 @@ import "encoding/json"
 
 // ImmunizationEvaluation is documented here http://hl7.org/fhir/StructureDefinition/ImmunizationEvaluation
 type ImmunizationEvaluation struct {
-	Id                *string                           `json:"id,omitempty"`
-	Meta              *Meta                             `json:"meta,omitempty"`
-	ImplicitRules     *string                           `json:"implicitRules,omitempty"`
-	Language          *string                           `json:"language,omitempty"`
-	Text              *Narrative                        `json:"text,omitempty"`
-	Extension         []Extension                       `json:"extension,omitempty"`
-	ModifierExtension []Extension                       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                      `json:"identifier,omitempty"`
-	Status            ImmunizationEvaluationStatusCodes `json:"status"`
-	Patient           Reference                         `json:"patient"`
-	Date              *string                           `json:"date,omitempty"`
-	Authority         *Reference                        `json:"authority,omitempty"`
-	TargetDisease     CodeableConcept                   `json:"targetDisease"`
-	ImmunizationEvent Reference                         `json:"immunizationEvent"`
-	DoseStatus        CodeableConcept                   `json:"doseStatus"`
-	DoseStatusReason  []CodeableConcept                 `json:"doseStatusReason,omitempty"`
-	Description       *string                           `json:"description,omitempty"`
-	Series            *string                           `json:"series,omitempty"`
+	Id                *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            ImmunizationEvaluationStatusCodes `bson:"status" json:"status"`
+	Patient           Reference                         `bson:"patient" json:"patient"`
+	Date              *string                           `bson:"date,omitempty" json:"date,omitempty"`
+	Authority         *Reference                        `bson:"authority,omitempty" json:"authority,omitempty"`
+	TargetDisease     CodeableConcept                   `bson:"targetDisease" json:"targetDisease"`
+	ImmunizationEvent Reference                         `bson:"immunizationEvent" json:"immunizationEvent"`
+	DoseStatus        CodeableConcept                   `bson:"doseStatus" json:"doseStatus"`
+	DoseStatusReason  []CodeableConcept                 `bson:"doseStatusReason,omitempty" json:"doseStatusReason,omitempty"`
+	Description       *string                           `bson:"description,omitempty" json:"description,omitempty"`
+	Series            *string                           `bson:"series,omitempty" json:"series,omitempty"`
 }
 type OtherImmunizationEvaluation ImmunizationEvaluation
 

--- a/fhir-models/fhir/immunizationRecommendation.go
+++ b/fhir-models/fhir/immunizationRecommendation.go
@@ -21,40 +21,40 @@ import "encoding/json"
 
 // ImmunizationRecommendation is documented here http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation
 type ImmunizationRecommendation struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Meta              *Meta                                      `json:"meta,omitempty"`
-	ImplicitRules     *string                                    `json:"implicitRules,omitempty"`
-	Language          *string                                    `json:"language,omitempty"`
-	Text              *Narrative                                 `json:"text,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                               `json:"identifier,omitempty"`
-	Patient           Reference                                  `json:"patient"`
-	Date              string                                     `json:"date"`
-	Authority         *Reference                                 `json:"authority,omitempty"`
-	Recommendation    []ImmunizationRecommendationRecommendation `json:"recommendation"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Patient           Reference                                  `bson:"patient" json:"patient"`
+	Date              string                                     `bson:"date" json:"date"`
+	Authority         *Reference                                 `bson:"authority,omitempty" json:"authority,omitempty"`
+	Recommendation    []ImmunizationRecommendationRecommendation `bson:"recommendation" json:"recommendation"`
 }
 type ImmunizationRecommendationRecommendation struct {
-	Id                           *string                                                 `json:"id,omitempty"`
-	Extension                    []Extension                                             `json:"extension,omitempty"`
-	ModifierExtension            []Extension                                             `json:"modifierExtension,omitempty"`
-	VaccineCode                  []CodeableConcept                                       `json:"vaccineCode,omitempty"`
-	TargetDisease                *CodeableConcept                                        `json:"targetDisease,omitempty"`
-	ContraindicatedVaccineCode   []CodeableConcept                                       `json:"contraindicatedVaccineCode,omitempty"`
-	ForecastStatus               CodeableConcept                                         `json:"forecastStatus"`
-	ForecastReason               []CodeableConcept                                       `json:"forecastReason,omitempty"`
-	DateCriterion                []ImmunizationRecommendationRecommendationDateCriterion `json:"dateCriterion,omitempty"`
-	Description                  *string                                                 `json:"description,omitempty"`
-	Series                       *string                                                 `json:"series,omitempty"`
-	SupportingImmunization       []Reference                                             `json:"supportingImmunization,omitempty"`
-	SupportingPatientInformation []Reference                                             `json:"supportingPatientInformation,omitempty"`
+	Id                           *string                                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                    []Extension                                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension            []Extension                                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	VaccineCode                  []CodeableConcept                                       `bson:"vaccineCode,omitempty" json:"vaccineCode,omitempty"`
+	TargetDisease                *CodeableConcept                                        `bson:"targetDisease,omitempty" json:"targetDisease,omitempty"`
+	ContraindicatedVaccineCode   []CodeableConcept                                       `bson:"contraindicatedVaccineCode,omitempty" json:"contraindicatedVaccineCode,omitempty"`
+	ForecastStatus               CodeableConcept                                         `bson:"forecastStatus" json:"forecastStatus"`
+	ForecastReason               []CodeableConcept                                       `bson:"forecastReason,omitempty" json:"forecastReason,omitempty"`
+	DateCriterion                []ImmunizationRecommendationRecommendationDateCriterion `bson:"dateCriterion,omitempty" json:"dateCriterion,omitempty"`
+	Description                  *string                                                 `bson:"description,omitempty" json:"description,omitempty"`
+	Series                       *string                                                 `bson:"series,omitempty" json:"series,omitempty"`
+	SupportingImmunization       []Reference                                             `bson:"supportingImmunization,omitempty" json:"supportingImmunization,omitempty"`
+	SupportingPatientInformation []Reference                                             `bson:"supportingPatientInformation,omitempty" json:"supportingPatientInformation,omitempty"`
 }
 type ImmunizationRecommendationRecommendationDateCriterion struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept `json:"code"`
-	Value             string          `json:"value"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
+	Value             string          `bson:"value" json:"value"`
 }
 type OtherImmunizationRecommendation ImmunizationRecommendation
 

--- a/fhir-models/fhir/implementationGuide.go
+++ b/fhir-models/fhir/implementationGuide.go
@@ -21,123 +21,123 @@ import "encoding/json"
 
 // ImplementationGuide is documented here http://hl7.org/fhir/StructureDefinition/ImplementationGuide
 type ImplementationGuide struct {
-	Id                *string                        `json:"id,omitempty"`
-	Meta              *Meta                          `json:"meta,omitempty"`
-	ImplicitRules     *string                        `json:"implicitRules,omitempty"`
-	Language          *string                        `json:"language,omitempty"`
-	Text              *Narrative                     `json:"text,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Url               string                         `json:"url"`
-	Version           *string                        `json:"version,omitempty"`
-	Name              string                         `json:"name"`
-	Title             *string                        `json:"title,omitempty"`
-	Status            PublicationStatus              `json:"status"`
-	Experimental      *bool                          `json:"experimental,omitempty"`
-	Date              *string                        `json:"date,omitempty"`
-	Publisher         *string                        `json:"publisher,omitempty"`
-	Contact           []ContactDetail                `json:"contact,omitempty"`
-	Description       *string                        `json:"description,omitempty"`
-	UseContext        []UsageContext                 `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept              `json:"jurisdiction,omitempty"`
-	Copyright         *string                        `json:"copyright,omitempty"`
-	PackageId         string                         `json:"packageId"`
-	License           *SPDXLicense                   `json:"license,omitempty"`
-	FhirVersion       []FHIRVersion                  `json:"fhirVersion"`
-	DependsOn         []ImplementationGuideDependsOn `json:"dependsOn,omitempty"`
-	Global            []ImplementationGuideGlobal    `json:"global,omitempty"`
-	Definition        *ImplementationGuideDefinition `json:"definition,omitempty"`
-	Manifest          *ImplementationGuideManifest   `json:"manifest,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                         `bson:"url" json:"url"`
+	Version           *string                        `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                         `bson:"name" json:"name"`
+	Title             *string                        `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus              `bson:"status" json:"status"`
+	Experimental      *bool                          `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                        `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                        `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                        `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                 `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept              `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright         *string                        `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	PackageId         string                         `bson:"packageId" json:"packageId"`
+	License           *SPDXLicense                   `bson:"license,omitempty" json:"license,omitempty"`
+	FhirVersion       []FHIRVersion                  `bson:"fhirVersion" json:"fhirVersion"`
+	DependsOn         []ImplementationGuideDependsOn `bson:"dependsOn,omitempty" json:"dependsOn,omitempty"`
+	Global            []ImplementationGuideGlobal    `bson:"global,omitempty" json:"global,omitempty"`
+	Definition        *ImplementationGuideDefinition `bson:"definition,omitempty" json:"definition,omitempty"`
+	Manifest          *ImplementationGuideManifest   `bson:"manifest,omitempty" json:"manifest,omitempty"`
 }
 type ImplementationGuideDependsOn struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Uri               string      `json:"uri"`
-	PackageId         *string     `json:"packageId,omitempty"`
-	Version           *string     `json:"version,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Uri               string      `bson:"uri" json:"uri"`
+	PackageId         *string     `bson:"packageId,omitempty" json:"packageId,omitempty"`
+	Version           *string     `bson:"version,omitempty" json:"version,omitempty"`
 }
 type ImplementationGuideGlobal struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Type              ResourceType `json:"type"`
-	Profile           string       `json:"profile"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ResourceType `bson:"type" json:"type"`
+	Profile           string       `bson:"profile" json:"profile"`
 }
 type ImplementationGuideDefinition struct {
-	Id                *string                                  `json:"id,omitempty"`
-	Extension         []Extension                              `json:"extension,omitempty"`
-	ModifierExtension []Extension                              `json:"modifierExtension,omitempty"`
-	Grouping          []ImplementationGuideDefinitionGrouping  `json:"grouping,omitempty"`
-	Resource          []ImplementationGuideDefinitionResource  `json:"resource"`
-	Page              *ImplementationGuideDefinitionPage       `json:"page,omitempty"`
-	Parameter         []ImplementationGuideDefinitionParameter `json:"parameter,omitempty"`
-	Template          []ImplementationGuideDefinitionTemplate  `json:"template,omitempty"`
+	Id                *string                                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Grouping          []ImplementationGuideDefinitionGrouping  `bson:"grouping,omitempty" json:"grouping,omitempty"`
+	Resource          []ImplementationGuideDefinitionResource  `bson:"resource" json:"resource"`
+	Page              *ImplementationGuideDefinitionPage       `bson:"page,omitempty" json:"page,omitempty"`
+	Parameter         []ImplementationGuideDefinitionParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	Template          []ImplementationGuideDefinitionTemplate  `bson:"template,omitempty" json:"template,omitempty"`
 }
 type ImplementationGuideDefinitionGrouping struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Description       *string     `json:"description,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Description       *string     `bson:"description,omitempty" json:"description,omitempty"`
 }
 type ImplementationGuideDefinitionResource struct {
-	Id                *string       `json:"id,omitempty"`
-	Extension         []Extension   `json:"extension,omitempty"`
-	ModifierExtension []Extension   `json:"modifierExtension,omitempty"`
-	Reference         Reference     `json:"reference"`
-	FhirVersion       []FHIRVersion `json:"fhirVersion,omitempty"`
-	Name              *string       `json:"name,omitempty"`
-	Description       *string       `json:"description,omitempty"`
-	GroupingId        *string       `json:"groupingId,omitempty"`
+	Id                *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Reference         Reference     `bson:"reference" json:"reference"`
+	FhirVersion       []FHIRVersion `bson:"fhirVersion,omitempty" json:"fhirVersion,omitempty"`
+	Name              *string       `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string       `bson:"description,omitempty" json:"description,omitempty"`
+	GroupingId        *string       `bson:"groupingId,omitempty" json:"groupingId,omitempty"`
 }
 type ImplementationGuideDefinitionPage struct {
-	Id                *string                             `json:"id,omitempty"`
-	Extension         []Extension                         `json:"extension,omitempty"`
-	ModifierExtension []Extension                         `json:"modifierExtension,omitempty"`
-	Title             string                              `json:"title"`
-	Generation        GuidePageGeneration                 `json:"generation"`
-	Page              []ImplementationGuideDefinitionPage `json:"page,omitempty"`
+	Id                *string                             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Title             string                              `bson:"title" json:"title"`
+	Generation        GuidePageGeneration                 `bson:"generation" json:"generation"`
+	Page              []ImplementationGuideDefinitionPage `bson:"page,omitempty" json:"page,omitempty"`
 }
 type ImplementationGuideDefinitionParameter struct {
-	Id                *string            `json:"id,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Code              GuideParameterCode `json:"code"`
-	Value             string             `json:"value"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              GuideParameterCode `bson:"code" json:"code"`
+	Value             string             `bson:"value" json:"value"`
 }
 type ImplementationGuideDefinitionTemplate struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Code              string      `json:"code"`
-	Source            string      `json:"source"`
-	Scope             *string     `json:"scope,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string      `bson:"code" json:"code"`
+	Source            string      `bson:"source" json:"source"`
+	Scope             *string     `bson:"scope,omitempty" json:"scope,omitempty"`
 }
 type ImplementationGuideManifest struct {
-	Id                *string                               `json:"id,omitempty"`
-	Extension         []Extension                           `json:"extension,omitempty"`
-	ModifierExtension []Extension                           `json:"modifierExtension,omitempty"`
-	Rendering         *string                               `json:"rendering,omitempty"`
-	Resource          []ImplementationGuideManifestResource `json:"resource"`
-	Page              []ImplementationGuideManifestPage     `json:"page,omitempty"`
-	Image             []string                              `json:"image,omitempty"`
-	Other             []string                              `json:"other,omitempty"`
+	Id                *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Rendering         *string                               `bson:"rendering,omitempty" json:"rendering,omitempty"`
+	Resource          []ImplementationGuideManifestResource `bson:"resource" json:"resource"`
+	Page              []ImplementationGuideManifestPage     `bson:"page,omitempty" json:"page,omitempty"`
+	Image             []string                              `bson:"image,omitempty" json:"image,omitempty"`
+	Other             []string                              `bson:"other,omitempty" json:"other,omitempty"`
 }
 type ImplementationGuideManifestResource struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Reference         Reference   `json:"reference"`
-	RelativePath      *string     `json:"relativePath,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Reference         Reference   `bson:"reference" json:"reference"`
+	RelativePath      *string     `bson:"relativePath,omitempty" json:"relativePath,omitempty"`
 }
 type ImplementationGuideManifestPage struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Title             *string     `json:"title,omitempty"`
-	Anchor            []string    `json:"anchor,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Title             *string     `bson:"title,omitempty" json:"title,omitempty"`
+	Anchor            []string    `bson:"anchor,omitempty" json:"anchor,omitempty"`
 }
 type OtherImplementationGuide ImplementationGuide
 

--- a/fhir-models/fhir/insurancePlan.go
+++ b/fhir-models/fhir/insurancePlan.go
@@ -21,102 +21,102 @@ import "encoding/json"
 
 // InsurancePlan is documented here http://hl7.org/fhir/StructureDefinition/InsurancePlan
 type InsurancePlan struct {
-	Id                *string                 `json:"id,omitempty"`
-	Meta              *Meta                   `json:"meta,omitempty"`
-	ImplicitRules     *string                 `json:"implicitRules,omitempty"`
-	Language          *string                 `json:"language,omitempty"`
-	Text              *Narrative              `json:"text,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier            `json:"identifier,omitempty"`
-	Status            *PublicationStatus      `json:"status,omitempty"`
-	Type              []CodeableConcept       `json:"type,omitempty"`
-	Name              *string                 `json:"name,omitempty"`
-	Alias             []string                `json:"alias,omitempty"`
-	Period            *Period                 `json:"period,omitempty"`
-	OwnedBy           *Reference              `json:"ownedBy,omitempty"`
-	AdministeredBy    *Reference              `json:"administeredBy,omitempty"`
-	CoverageArea      []Reference             `json:"coverageArea,omitempty"`
-	Contact           []InsurancePlanContact  `json:"contact,omitempty"`
-	Endpoint          []Reference             `json:"endpoint,omitempty"`
-	Network           []Reference             `json:"network,omitempty"`
-	Coverage          []InsurancePlanCoverage `json:"coverage,omitempty"`
-	Plan              []InsurancePlanPlan     `json:"plan,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier            `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            *PublicationStatus      `bson:"status,omitempty" json:"status,omitempty"`
+	Type              []CodeableConcept       `bson:"type,omitempty" json:"type,omitempty"`
+	Name              *string                 `bson:"name,omitempty" json:"name,omitempty"`
+	Alias             []string                `bson:"alias,omitempty" json:"alias,omitempty"`
+	Period            *Period                 `bson:"period,omitempty" json:"period,omitempty"`
+	OwnedBy           *Reference              `bson:"ownedBy,omitempty" json:"ownedBy,omitempty"`
+	AdministeredBy    *Reference              `bson:"administeredBy,omitempty" json:"administeredBy,omitempty"`
+	CoverageArea      []Reference             `bson:"coverageArea,omitempty" json:"coverageArea,omitempty"`
+	Contact           []InsurancePlanContact  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Endpoint          []Reference             `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	Network           []Reference             `bson:"network,omitempty" json:"network,omitempty"`
+	Coverage          []InsurancePlanCoverage `bson:"coverage,omitempty" json:"coverage,omitempty"`
+	Plan              []InsurancePlanPlan     `bson:"plan,omitempty" json:"plan,omitempty"`
 }
 type InsurancePlanContact struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Purpose           *CodeableConcept `json:"purpose,omitempty"`
-	Name              *HumanName       `json:"name,omitempty"`
-	Telecom           []ContactPoint   `json:"telecom,omitempty"`
-	Address           *Address         `json:"address,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Purpose           *CodeableConcept `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Name              *HumanName       `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom           []ContactPoint   `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address           *Address         `bson:"address,omitempty" json:"address,omitempty"`
 }
 type InsurancePlanCoverage struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept                `json:"type"`
-	Network           []Reference                    `json:"network,omitempty"`
-	Benefit           []InsurancePlanCoverageBenefit `json:"benefit"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept                `bson:"type" json:"type"`
+	Network           []Reference                    `bson:"network,omitempty" json:"network,omitempty"`
+	Benefit           []InsurancePlanCoverageBenefit `bson:"benefit" json:"benefit"`
 }
 type InsurancePlanCoverageBenefit struct {
-	Id                *string                             `json:"id,omitempty"`
-	Extension         []Extension                         `json:"extension,omitempty"`
-	ModifierExtension []Extension                         `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept                     `json:"type"`
-	Requirement       *string                             `json:"requirement,omitempty"`
-	Limit             []InsurancePlanCoverageBenefitLimit `json:"limit,omitempty"`
+	Id                *string                             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept                     `bson:"type" json:"type"`
+	Requirement       *string                             `bson:"requirement,omitempty" json:"requirement,omitempty"`
+	Limit             []InsurancePlanCoverageBenefitLimit `bson:"limit,omitempty" json:"limit,omitempty"`
 }
 type InsurancePlanCoverageBenefitLimit struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Value             *Quantity        `json:"value,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Value             *Quantity        `bson:"value,omitempty" json:"value,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 }
 type InsurancePlanPlan struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                    `json:"identifier,omitempty"`
-	Type              *CodeableConcept                `json:"type,omitempty"`
-	CoverageArea      []Reference                     `json:"coverageArea,omitempty"`
-	Network           []Reference                     `json:"network,omitempty"`
-	GeneralCost       []InsurancePlanPlanGeneralCost  `json:"generalCost,omitempty"`
-	SpecificCost      []InsurancePlanPlanSpecificCost `json:"specificCost,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type              *CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
+	CoverageArea      []Reference                     `bson:"coverageArea,omitempty" json:"coverageArea,omitempty"`
+	Network           []Reference                     `bson:"network,omitempty" json:"network,omitempty"`
+	GeneralCost       []InsurancePlanPlanGeneralCost  `bson:"generalCost,omitempty" json:"generalCost,omitempty"`
+	SpecificCost      []InsurancePlanPlanSpecificCost `bson:"specificCost,omitempty" json:"specificCost,omitempty"`
 }
 type InsurancePlanPlanGeneralCost struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	GroupSize         *int             `json:"groupSize,omitempty"`
-	Cost              *Money           `json:"cost,omitempty"`
-	Comment           *string          `json:"comment,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	GroupSize         *int             `bson:"groupSize,omitempty" json:"groupSize,omitempty"`
+	Cost              *Money           `bson:"cost,omitempty" json:"cost,omitempty"`
+	Comment           *string          `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type InsurancePlanPlanSpecificCost struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Category          CodeableConcept                        `json:"category"`
-	Benefit           []InsurancePlanPlanSpecificCostBenefit `json:"benefit,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          CodeableConcept                        `bson:"category" json:"category"`
+	Benefit           []InsurancePlanPlanSpecificCostBenefit `bson:"benefit,omitempty" json:"benefit,omitempty"`
 }
 type InsurancePlanPlanSpecificCostBenefit struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept                            `json:"type"`
-	Cost              []InsurancePlanPlanSpecificCostBenefitCost `json:"cost,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept                            `bson:"type" json:"type"`
+	Cost              []InsurancePlanPlanSpecificCostBenefitCost `bson:"cost,omitempty" json:"cost,omitempty"`
 }
 type InsurancePlanPlanSpecificCostBenefitCost struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept   `json:"type"`
-	Applicability     *CodeableConcept  `json:"applicability,omitempty"`
-	Qualifiers        []CodeableConcept `json:"qualifiers,omitempty"`
-	Value             *Quantity         `json:"value,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept   `bson:"type" json:"type"`
+	Applicability     *CodeableConcept  `bson:"applicability,omitempty" json:"applicability,omitempty"`
+	Qualifiers        []CodeableConcept `bson:"qualifiers,omitempty" json:"qualifiers,omitempty"`
+	Value             *Quantity         `bson:"value,omitempty" json:"value,omitempty"`
 }
 type OtherInsurancePlan InsurancePlan
 

--- a/fhir-models/fhir/invoice.go
+++ b/fhir-models/fhir/invoice.go
@@ -21,52 +21,52 @@ import "encoding/json"
 
 // Invoice is documented here http://hl7.org/fhir/StructureDefinition/Invoice
 type Invoice struct {
-	Id                  *string                         `json:"id,omitempty"`
-	Meta                *Meta                           `json:"meta,omitempty"`
-	ImplicitRules       *string                         `json:"implicitRules,omitempty"`
-	Language            *string                         `json:"language,omitempty"`
-	Text                *Narrative                      `json:"text,omitempty"`
-	Extension           []Extension                     `json:"extension,omitempty"`
-	ModifierExtension   []Extension                     `json:"modifierExtension,omitempty"`
-	Identifier          []Identifier                    `json:"identifier,omitempty"`
-	Status              InvoiceStatus                   `json:"status"`
-	CancelledReason     *string                         `json:"cancelledReason,omitempty"`
-	Type                *CodeableConcept                `json:"type,omitempty"`
-	Subject             *Reference                      `json:"subject,omitempty"`
-	Recipient           *Reference                      `json:"recipient,omitempty"`
-	Date                *string                         `json:"date,omitempty"`
-	Participant         []InvoiceParticipant            `json:"participant,omitempty"`
-	Issuer              *Reference                      `json:"issuer,omitempty"`
-	Account             *Reference                      `json:"account,omitempty"`
-	LineItem            []InvoiceLineItem               `json:"lineItem,omitempty"`
-	TotalPriceComponent []InvoiceLineItemPriceComponent `json:"totalPriceComponent,omitempty"`
-	TotalNet            *Money                          `json:"totalNet,omitempty"`
-	TotalGross          *Money                          `json:"totalGross,omitempty"`
-	PaymentTerms        *string                         `json:"paymentTerms,omitempty"`
-	Note                []Annotation                    `json:"note,omitempty"`
+	Id                  *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string                         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string                         `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative                      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status              InvoiceStatus                   `bson:"status" json:"status"`
+	CancelledReason     *string                         `bson:"cancelledReason,omitempty" json:"cancelledReason,omitempty"`
+	Type                *CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
+	Subject             *Reference                      `bson:"subject,omitempty" json:"subject,omitempty"`
+	Recipient           *Reference                      `bson:"recipient,omitempty" json:"recipient,omitempty"`
+	Date                *string                         `bson:"date,omitempty" json:"date,omitempty"`
+	Participant         []InvoiceParticipant            `bson:"participant,omitempty" json:"participant,omitempty"`
+	Issuer              *Reference                      `bson:"issuer,omitempty" json:"issuer,omitempty"`
+	Account             *Reference                      `bson:"account,omitempty" json:"account,omitempty"`
+	LineItem            []InvoiceLineItem               `bson:"lineItem,omitempty" json:"lineItem,omitempty"`
+	TotalPriceComponent []InvoiceLineItemPriceComponent `bson:"totalPriceComponent,omitempty" json:"totalPriceComponent,omitempty"`
+	TotalNet            *Money                          `bson:"totalNet,omitempty" json:"totalNet,omitempty"`
+	TotalGross          *Money                          `bson:"totalGross,omitempty" json:"totalGross,omitempty"`
+	PaymentTerms        *string                         `bson:"paymentTerms,omitempty" json:"paymentTerms,omitempty"`
+	Note                []Annotation                    `bson:"note,omitempty" json:"note,omitempty"`
 }
 type InvoiceParticipant struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Role              *CodeableConcept `json:"role,omitempty"`
-	Actor             Reference        `json:"actor"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Role              *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
 }
 type InvoiceLineItem struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Sequence          *int                            `json:"sequence,omitempty"`
-	PriceComponent    []InvoiceLineItemPriceComponent `json:"priceComponent,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Sequence          *int                            `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	PriceComponent    []InvoiceLineItemPriceComponent `bson:"priceComponent,omitempty" json:"priceComponent,omitempty"`
 }
 type InvoiceLineItemPriceComponent struct {
-	Id                *string                   `json:"id,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Type              InvoicePriceComponentType `json:"type"`
-	Code              *CodeableConcept          `json:"code,omitempty"`
-	Factor            *string                   `json:"factor,omitempty"`
-	Amount            *Money                    `json:"amount,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              InvoicePriceComponentType `bson:"type" json:"type"`
+	Code              *CodeableConcept          `bson:"code,omitempty" json:"code,omitempty"`
+	Factor            *string                   `bson:"factor,omitempty" json:"factor,omitempty"`
+	Amount            *Money                    `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type OtherInvoice Invoice
 

--- a/fhir-models/fhir/library.go
+++ b/fhir-models/fhir/library.go
@@ -21,43 +21,43 @@ import "encoding/json"
 
 // Library is documented here http://hl7.org/fhir/StructureDefinition/Library
 type Library struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Url               *string               `json:"url,omitempty"`
-	Identifier        []Identifier          `json:"identifier,omitempty"`
-	Version           *string               `json:"version,omitempty"`
-	Name              *string               `json:"name,omitempty"`
-	Title             *string               `json:"title,omitempty"`
-	Subtitle          *string               `json:"subtitle,omitempty"`
-	Status            PublicationStatus     `json:"status"`
-	Experimental      *bool                 `json:"experimental,omitempty"`
-	Type              CodeableConcept       `json:"type"`
-	Date              *string               `json:"date,omitempty"`
-	Publisher         *string               `json:"publisher,omitempty"`
-	Contact           []ContactDetail       `json:"contact,omitempty"`
-	Description       *string               `json:"description,omitempty"`
-	UseContext        []UsageContext        `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept     `json:"jurisdiction,omitempty"`
-	Purpose           *string               `json:"purpose,omitempty"`
-	Usage             *string               `json:"usage,omitempty"`
-	Copyright         *string               `json:"copyright,omitempty"`
-	ApprovalDate      *string               `json:"approvalDate,omitempty"`
-	LastReviewDate    *string               `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period               `json:"effectivePeriod,omitempty"`
-	Topic             []CodeableConcept     `json:"topic,omitempty"`
-	Author            []ContactDetail       `json:"author,omitempty"`
-	Editor            []ContactDetail       `json:"editor,omitempty"`
-	Reviewer          []ContactDetail       `json:"reviewer,omitempty"`
-	Endorser          []ContactDetail       `json:"endorser,omitempty"`
-	RelatedArtifact   []RelatedArtifact     `json:"relatedArtifact,omitempty"`
-	Parameter         []ParameterDefinition `json:"parameter,omitempty"`
-	DataRequirement   []DataRequirement     `json:"dataRequirement,omitempty"`
-	Content           []Attachment          `json:"content,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string               `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string               `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string               `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string               `bson:"title,omitempty" json:"title,omitempty"`
+	Subtitle          *string               `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status            PublicationStatus     `bson:"status" json:"status"`
+	Experimental      *bool                 `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Type              CodeableConcept       `bson:"type" json:"type"`
+	Date              *string               `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string               `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail       `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string               `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext        `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept     `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string               `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage             *string               `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright         *string               `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string               `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string               `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period               `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic             []CodeableConcept     `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author            []ContactDetail       `bson:"author,omitempty" json:"author,omitempty"`
+	Editor            []ContactDetail       `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer          []ContactDetail       `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser          []ContactDetail       `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact   []RelatedArtifact     `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Parameter         []ParameterDefinition `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	DataRequirement   []DataRequirement     `bson:"dataRequirement,omitempty" json:"dataRequirement,omitempty"`
+	Content           []Attachment          `bson:"content,omitempty" json:"content,omitempty"`
 }
 type OtherLibrary Library
 

--- a/fhir-models/fhir/linkage.go
+++ b/fhir-models/fhir/linkage.go
@@ -21,23 +21,23 @@ import "encoding/json"
 
 // Linkage is documented here http://hl7.org/fhir/StructureDefinition/Linkage
 type Linkage struct {
-	Id                *string       `json:"id,omitempty"`
-	Meta              *Meta         `json:"meta,omitempty"`
-	ImplicitRules     *string       `json:"implicitRules,omitempty"`
-	Language          *string       `json:"language,omitempty"`
-	Text              *Narrative    `json:"text,omitempty"`
-	Extension         []Extension   `json:"extension,omitempty"`
-	ModifierExtension []Extension   `json:"modifierExtension,omitempty"`
-	Active            *bool         `json:"active,omitempty"`
-	Author            *Reference    `json:"author,omitempty"`
-	Item              []LinkageItem `json:"item"`
+	Id                *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string       `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Active            *bool         `bson:"active,omitempty" json:"active,omitempty"`
+	Author            *Reference    `bson:"author,omitempty" json:"author,omitempty"`
+	Item              []LinkageItem `bson:"item" json:"item"`
 }
 type LinkageItem struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Type              LinkageType `json:"type"`
-	Resource          Reference   `json:"resource"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              LinkageType `bson:"type" json:"type"`
+	Resource          Reference   `bson:"resource" json:"resource"`
 }
 type OtherLinkage Linkage
 

--- a/fhir-models/fhir/list.go
+++ b/fhir-models/fhir/list.go
@@ -21,35 +21,35 @@ import "encoding/json"
 
 // List is documented here http://hl7.org/fhir/StructureDefinition/List
 type List struct {
-	Id                *string          `json:"id,omitempty"`
-	Meta              *Meta            `json:"meta,omitempty"`
-	ImplicitRules     *string          `json:"implicitRules,omitempty"`
-	Language          *string          `json:"language,omitempty"`
-	Text              *Narrative       `json:"text,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier     `json:"identifier,omitempty"`
-	Status            ListStatus       `json:"status"`
-	Mode              ListMode         `json:"mode"`
-	Title             *string          `json:"title,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Subject           *Reference       `json:"subject,omitempty"`
-	Encounter         *Reference       `json:"encounter,omitempty"`
-	Date              *string          `json:"date,omitempty"`
-	Source            *Reference       `json:"source,omitempty"`
-	OrderedBy         *CodeableConcept `json:"orderedBy,omitempty"`
-	Note              []Annotation     `json:"note,omitempty"`
-	Entry             []ListEntry      `json:"entry,omitempty"`
-	EmptyReason       *CodeableConcept `json:"emptyReason,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string          `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            ListStatus       `bson:"status" json:"status"`
+	Mode              ListMode         `bson:"mode" json:"mode"`
+	Title             *string          `bson:"title,omitempty" json:"title,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Subject           *Reference       `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter         *Reference       `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
+	Source            *Reference       `bson:"source,omitempty" json:"source,omitempty"`
+	OrderedBy         *CodeableConcept `bson:"orderedBy,omitempty" json:"orderedBy,omitempty"`
+	Note              []Annotation     `bson:"note,omitempty" json:"note,omitempty"`
+	Entry             []ListEntry      `bson:"entry,omitempty" json:"entry,omitempty"`
+	EmptyReason       *CodeableConcept `bson:"emptyReason,omitempty" json:"emptyReason,omitempty"`
 }
 type ListEntry struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Flag              *CodeableConcept `json:"flag,omitempty"`
-	Deleted           *bool            `json:"deleted,omitempty"`
-	Date              *string          `json:"date,omitempty"`
-	Item              Reference        `json:"item"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Flag              *CodeableConcept `bson:"flag,omitempty" json:"flag,omitempty"`
+	Deleted           *bool            `bson:"deleted,omitempty" json:"deleted,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
+	Item              Reference        `bson:"item" json:"item"`
 }
 type OtherList List
 

--- a/fhir-models/fhir/location.go
+++ b/fhir-models/fhir/location.go
@@ -21,47 +21,47 @@ import "encoding/json"
 
 // Location is documented here http://hl7.org/fhir/StructureDefinition/Location
 type Location struct {
-	Id                     *string                    `json:"id,omitempty"`
-	Meta                   *Meta                      `json:"meta,omitempty"`
-	ImplicitRules          *string                    `json:"implicitRules,omitempty"`
-	Language               *string                    `json:"language,omitempty"`
-	Text                   *Narrative                 `json:"text,omitempty"`
-	Extension              []Extension                `json:"extension,omitempty"`
-	ModifierExtension      []Extension                `json:"modifierExtension,omitempty"`
-	Identifier             []Identifier               `json:"identifier,omitempty"`
-	Status                 *LocationStatus            `json:"status,omitempty"`
-	OperationalStatus      *Coding                    `json:"operationalStatus,omitempty"`
-	Name                   *string                    `json:"name,omitempty"`
-	Alias                  []string                   `json:"alias,omitempty"`
-	Description            *string                    `json:"description,omitempty"`
-	Mode                   *LocationMode              `json:"mode,omitempty"`
-	Type                   []CodeableConcept          `json:"type,omitempty"`
-	Telecom                []ContactPoint             `json:"telecom,omitempty"`
-	Address                *Address                   `json:"address,omitempty"`
-	PhysicalType           *CodeableConcept           `json:"physicalType,omitempty"`
-	Position               *LocationPosition          `json:"position,omitempty"`
-	ManagingOrganization   *Reference                 `json:"managingOrganization,omitempty"`
-	PartOf                 *Reference                 `json:"partOf,omitempty"`
-	HoursOfOperation       []LocationHoursOfOperation `json:"hoursOfOperation,omitempty"`
-	AvailabilityExceptions *string                    `json:"availabilityExceptions,omitempty"`
-	Endpoint               []Reference                `json:"endpoint,omitempty"`
+	Id                     *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier             []Identifier               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status                 *LocationStatus            `bson:"status,omitempty" json:"status,omitempty"`
+	OperationalStatus      *Coding                    `bson:"operationalStatus,omitempty" json:"operationalStatus,omitempty"`
+	Name                   *string                    `bson:"name,omitempty" json:"name,omitempty"`
+	Alias                  []string                   `bson:"alias,omitempty" json:"alias,omitempty"`
+	Description            *string                    `bson:"description,omitempty" json:"description,omitempty"`
+	Mode                   *LocationMode              `bson:"mode,omitempty" json:"mode,omitempty"`
+	Type                   []CodeableConcept          `bson:"type,omitempty" json:"type,omitempty"`
+	Telecom                []ContactPoint             `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address                *Address                   `bson:"address,omitempty" json:"address,omitempty"`
+	PhysicalType           *CodeableConcept           `bson:"physicalType,omitempty" json:"physicalType,omitempty"`
+	Position               *LocationPosition          `bson:"position,omitempty" json:"position,omitempty"`
+	ManagingOrganization   *Reference                 `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
+	PartOf                 *Reference                 `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	HoursOfOperation       []LocationHoursOfOperation `bson:"hoursOfOperation,omitempty" json:"hoursOfOperation,omitempty"`
+	AvailabilityExceptions *string                    `bson:"availabilityExceptions,omitempty" json:"availabilityExceptions,omitempty"`
+	Endpoint               []Reference                `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 type LocationPosition struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Longitude         string      `json:"longitude"`
-	Latitude          string      `json:"latitude"`
-	Altitude          *string     `json:"altitude,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Longitude         string      `bson:"longitude" json:"longitude"`
+	Latitude          string      `bson:"latitude" json:"latitude"`
+	Altitude          *string     `bson:"altitude,omitempty" json:"altitude,omitempty"`
 }
 type LocationHoursOfOperation struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	DaysOfWeek        []DaysOfWeek `json:"daysOfWeek,omitempty"`
-	AllDay            *bool        `json:"allDay,omitempty"`
-	OpeningTime       *string      `json:"openingTime,omitempty"`
-	ClosingTime       *string      `json:"closingTime,omitempty"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DaysOfWeek        []DaysOfWeek `bson:"daysOfWeek,omitempty" json:"daysOfWeek,omitempty"`
+	AllDay            *bool        `bson:"allDay,omitempty" json:"allDay,omitempty"`
+	OpeningTime       *string      `bson:"openingTime,omitempty" json:"openingTime,omitempty"`
+	ClosingTime       *string      `bson:"closingTime,omitempty" json:"closingTime,omitempty"`
 }
 type OtherLocation Location
 

--- a/fhir-models/fhir/marketingStatus.go
+++ b/fhir-models/fhir/marketingStatus.go
@@ -19,12 +19,12 @@ package fhir
 
 // MarketingStatus is documented here http://hl7.org/fhir/StructureDefinition/MarketingStatus
 type MarketingStatus struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Country           CodeableConcept  `json:"country"`
-	Jurisdiction      *CodeableConcept `json:"jurisdiction,omitempty"`
-	Status            CodeableConcept  `json:"status"`
-	DateRange         Period           `json:"dateRange"`
-	RestoreDate       *string          `json:"restoreDate,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Country           CodeableConcept  `bson:"country" json:"country"`
+	Jurisdiction      *CodeableConcept `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Status            CodeableConcept  `bson:"status" json:"status"`
+	DateRange         Period           `bson:"dateRange" json:"dateRange"`
+	RestoreDate       *string          `bson:"restoreDate,omitempty" json:"restoreDate,omitempty"`
 }

--- a/fhir-models/fhir/measure.go
+++ b/fhir-models/fhir/measure.go
@@ -21,96 +21,96 @@ import "encoding/json"
 
 // Measure is documented here http://hl7.org/fhir/StructureDefinition/Measure
 type Measure struct {
-	Id                              *string                   `json:"id,omitempty"`
-	Meta                            *Meta                     `json:"meta,omitempty"`
-	ImplicitRules                   *string                   `json:"implicitRules,omitempty"`
-	Language                        *string                   `json:"language,omitempty"`
-	Text                            *Narrative                `json:"text,omitempty"`
-	Extension                       []Extension               `json:"extension,omitempty"`
-	ModifierExtension               []Extension               `json:"modifierExtension,omitempty"`
-	Url                             *string                   `json:"url,omitempty"`
-	Identifier                      []Identifier              `json:"identifier,omitempty"`
-	Version                         *string                   `json:"version,omitempty"`
-	Name                            *string                   `json:"name,omitempty"`
-	Title                           *string                   `json:"title,omitempty"`
-	Subtitle                        *string                   `json:"subtitle,omitempty"`
-	Status                          PublicationStatus         `json:"status"`
-	Experimental                    *bool                     `json:"experimental,omitempty"`
-	Date                            *string                   `json:"date,omitempty"`
-	Publisher                       *string                   `json:"publisher,omitempty"`
-	Contact                         []ContactDetail           `json:"contact,omitempty"`
-	Description                     *string                   `json:"description,omitempty"`
-	UseContext                      []UsageContext            `json:"useContext,omitempty"`
-	Jurisdiction                    []CodeableConcept         `json:"jurisdiction,omitempty"`
-	Purpose                         *string                   `json:"purpose,omitempty"`
-	Usage                           *string                   `json:"usage,omitempty"`
-	Copyright                       *string                   `json:"copyright,omitempty"`
-	ApprovalDate                    *string                   `json:"approvalDate,omitempty"`
-	LastReviewDate                  *string                   `json:"lastReviewDate,omitempty"`
-	EffectivePeriod                 *Period                   `json:"effectivePeriod,omitempty"`
-	Topic                           []CodeableConcept         `json:"topic,omitempty"`
-	Author                          []ContactDetail           `json:"author,omitempty"`
-	Editor                          []ContactDetail           `json:"editor,omitempty"`
-	Reviewer                        []ContactDetail           `json:"reviewer,omitempty"`
-	Endorser                        []ContactDetail           `json:"endorser,omitempty"`
-	RelatedArtifact                 []RelatedArtifact         `json:"relatedArtifact,omitempty"`
-	Library                         []string                  `json:"library,omitempty"`
-	Disclaimer                      *string                   `json:"disclaimer,omitempty"`
-	Scoring                         *CodeableConcept          `json:"scoring,omitempty"`
-	CompositeScoring                *CodeableConcept          `json:"compositeScoring,omitempty"`
-	Type                            []CodeableConcept         `json:"type,omitempty"`
-	RiskAdjustment                  *string                   `json:"riskAdjustment,omitempty"`
-	RateAggregation                 *string                   `json:"rateAggregation,omitempty"`
-	Rationale                       *string                   `json:"rationale,omitempty"`
-	ClinicalRecommendationStatement *string                   `json:"clinicalRecommendationStatement,omitempty"`
-	ImprovementNotation             *CodeableConcept          `json:"improvementNotation,omitempty"`
-	Definition                      []string                  `json:"definition,omitempty"`
-	Guidance                        *string                   `json:"guidance,omitempty"`
-	Group                           []MeasureGroup            `json:"group,omitempty"`
-	SupplementalData                []MeasureSupplementalData `json:"supplementalData,omitempty"`
+	Id                              *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                            *Meta                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules                   *string                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                        *string                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text                            *Narrative                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                       []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension               []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url                             *string                   `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier                      []Identifier              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version                         *string                   `bson:"version,omitempty" json:"version,omitempty"`
+	Name                            *string                   `bson:"name,omitempty" json:"name,omitempty"`
+	Title                           *string                   `bson:"title,omitempty" json:"title,omitempty"`
+	Subtitle                        *string                   `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status                          PublicationStatus         `bson:"status" json:"status"`
+	Experimental                    *bool                     `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date                            *string                   `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher                       *string                   `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact                         []ContactDetail           `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description                     *string                   `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext                      []UsageContext            `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction                    []CodeableConcept         `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose                         *string                   `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage                           *string                   `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright                       *string                   `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate                    *string                   `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate                  *string                   `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod                 *Period                   `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic                           []CodeableConcept         `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author                          []ContactDetail           `bson:"author,omitempty" json:"author,omitempty"`
+	Editor                          []ContactDetail           `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer                        []ContactDetail           `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser                        []ContactDetail           `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact                 []RelatedArtifact         `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Library                         []string                  `bson:"library,omitempty" json:"library,omitempty"`
+	Disclaimer                      *string                   `bson:"disclaimer,omitempty" json:"disclaimer,omitempty"`
+	Scoring                         *CodeableConcept          `bson:"scoring,omitempty" json:"scoring,omitempty"`
+	CompositeScoring                *CodeableConcept          `bson:"compositeScoring,omitempty" json:"compositeScoring,omitempty"`
+	Type                            []CodeableConcept         `bson:"type,omitempty" json:"type,omitempty"`
+	RiskAdjustment                  *string                   `bson:"riskAdjustment,omitempty" json:"riskAdjustment,omitempty"`
+	RateAggregation                 *string                   `bson:"rateAggregation,omitempty" json:"rateAggregation,omitempty"`
+	Rationale                       *string                   `bson:"rationale,omitempty" json:"rationale,omitempty"`
+	ClinicalRecommendationStatement *string                   `bson:"clinicalRecommendationStatement,omitempty" json:"clinicalRecommendationStatement,omitempty"`
+	ImprovementNotation             *CodeableConcept          `bson:"improvementNotation,omitempty" json:"improvementNotation,omitempty"`
+	Definition                      []string                  `bson:"definition,omitempty" json:"definition,omitempty"`
+	Guidance                        *string                   `bson:"guidance,omitempty" json:"guidance,omitempty"`
+	Group                           []MeasureGroup            `bson:"group,omitempty" json:"group,omitempty"`
+	SupplementalData                []MeasureSupplementalData `bson:"supplementalData,omitempty" json:"supplementalData,omitempty"`
 }
 type MeasureGroup struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept         `json:"code,omitempty"`
-	Description       *string                  `json:"description,omitempty"`
-	Population        []MeasureGroupPopulation `json:"population,omitempty"`
-	Stratifier        []MeasureGroupStratifier `json:"stratifier,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept         `bson:"code,omitempty" json:"code,omitempty"`
+	Description       *string                  `bson:"description,omitempty" json:"description,omitempty"`
+	Population        []MeasureGroupPopulation `bson:"population,omitempty" json:"population,omitempty"`
+	Stratifier        []MeasureGroupStratifier `bson:"stratifier,omitempty" json:"stratifier,omitempty"`
 }
 type MeasureGroupPopulation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Description       *string          `json:"description,omitempty"`
-	Criteria          Expression       `json:"criteria"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Criteria          Expression       `bson:"criteria" json:"criteria"`
 }
 type MeasureGroupStratifier struct {
-	Id                *string                           `json:"id,omitempty"`
-	Extension         []Extension                       `json:"extension,omitempty"`
-	ModifierExtension []Extension                       `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept                  `json:"code,omitempty"`
-	Description       *string                           `json:"description,omitempty"`
-	Criteria          *Expression                       `json:"criteria,omitempty"`
-	Component         []MeasureGroupStratifierComponent `json:"component,omitempty"`
+	Id                *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept                  `bson:"code,omitempty" json:"code,omitempty"`
+	Description       *string                           `bson:"description,omitempty" json:"description,omitempty"`
+	Criteria          *Expression                       `bson:"criteria,omitempty" json:"criteria,omitempty"`
+	Component         []MeasureGroupStratifierComponent `bson:"component,omitempty" json:"component,omitempty"`
 }
 type MeasureGroupStratifierComponent struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Description       *string          `json:"description,omitempty"`
-	Criteria          Expression       `json:"criteria"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Criteria          Expression       `bson:"criteria" json:"criteria"`
 }
 type MeasureSupplementalData struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept  `json:"code,omitempty"`
-	Usage             []CodeableConcept `json:"usage,omitempty"`
-	Description       *string           `json:"description,omitempty"`
-	Criteria          Expression        `json:"criteria"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
+	Usage             []CodeableConcept `bson:"usage,omitempty" json:"usage,omitempty"`
+	Description       *string           `bson:"description,omitempty" json:"description,omitempty"`
+	Criteria          Expression        `bson:"criteria" json:"criteria"`
 }
 type OtherMeasure Measure
 

--- a/fhir-models/fhir/measureReport.go
+++ b/fhir-models/fhir/measureReport.go
@@ -21,72 +21,72 @@ import "encoding/json"
 
 // MeasureReport is documented here http://hl7.org/fhir/StructureDefinition/MeasureReport
 type MeasureReport struct {
-	Id                  *string              `json:"id,omitempty"`
-	Meta                *Meta                `json:"meta,omitempty"`
-	ImplicitRules       *string              `json:"implicitRules,omitempty"`
-	Language            *string              `json:"language,omitempty"`
-	Text                *Narrative           `json:"text,omitempty"`
-	Extension           []Extension          `json:"extension,omitempty"`
-	ModifierExtension   []Extension          `json:"modifierExtension,omitempty"`
-	Identifier          []Identifier         `json:"identifier,omitempty"`
-	Status              MeasureReportStatus  `json:"status"`
-	Type                MeasureReportType    `json:"type"`
-	Measure             string               `json:"measure"`
-	Subject             *Reference           `json:"subject,omitempty"`
-	Date                *string              `json:"date,omitempty"`
-	Reporter            *Reference           `json:"reporter,omitempty"`
-	Period              Period               `json:"period"`
-	ImprovementNotation *CodeableConcept     `json:"improvementNotation,omitempty"`
-	Group               []MeasureReportGroup `json:"group,omitempty"`
-	EvaluatedResource   []Reference          `json:"evaluatedResource,omitempty"`
+	Id                  *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string              `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string              `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative           `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          []Identifier         `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status              MeasureReportStatus  `bson:"status" json:"status"`
+	Type                MeasureReportType    `bson:"type" json:"type"`
+	Measure             string               `bson:"measure" json:"measure"`
+	Subject             *Reference           `bson:"subject,omitempty" json:"subject,omitempty"`
+	Date                *string              `bson:"date,omitempty" json:"date,omitempty"`
+	Reporter            *Reference           `bson:"reporter,omitempty" json:"reporter,omitempty"`
+	Period              Period               `bson:"period" json:"period"`
+	ImprovementNotation *CodeableConcept     `bson:"improvementNotation,omitempty" json:"improvementNotation,omitempty"`
+	Group               []MeasureReportGroup `bson:"group,omitempty" json:"group,omitempty"`
+	EvaluatedResource   []Reference          `bson:"evaluatedResource,omitempty" json:"evaluatedResource,omitempty"`
 }
 type MeasureReportGroup struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept               `json:"code,omitempty"`
-	Population        []MeasureReportGroupPopulation `json:"population,omitempty"`
-	MeasureScore      *Quantity                      `json:"measureScore,omitempty"`
-	Stratifier        []MeasureReportGroupStratifier `json:"stratifier,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept               `bson:"code,omitempty" json:"code,omitempty"`
+	Population        []MeasureReportGroupPopulation `bson:"population,omitempty" json:"population,omitempty"`
+	MeasureScore      *Quantity                      `bson:"measureScore,omitempty" json:"measureScore,omitempty"`
+	Stratifier        []MeasureReportGroupStratifier `bson:"stratifier,omitempty" json:"stratifier,omitempty"`
 }
 type MeasureReportGroupPopulation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Count             *int             `json:"count,omitempty"`
-	SubjectResults    *Reference       `json:"subjectResults,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Count             *int             `bson:"count,omitempty" json:"count,omitempty"`
+	SubjectResults    *Reference       `bson:"subjectResults,omitempty" json:"subjectResults,omitempty"`
 }
 type MeasureReportGroupStratifier struct {
-	Id                *string                               `json:"id,omitempty"`
-	Extension         []Extension                           `json:"extension,omitempty"`
-	ModifierExtension []Extension                           `json:"modifierExtension,omitempty"`
-	Code              []CodeableConcept                     `json:"code,omitempty"`
-	Stratum           []MeasureReportGroupStratifierStratum `json:"stratum,omitempty"`
+	Id                *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              []CodeableConcept                     `bson:"code,omitempty" json:"code,omitempty"`
+	Stratum           []MeasureReportGroupStratifierStratum `bson:"stratum,omitempty" json:"stratum,omitempty"`
 }
 type MeasureReportGroupStratifierStratum struct {
-	Id                *string                                         `json:"id,omitempty"`
-	Extension         []Extension                                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                                     `json:"modifierExtension,omitempty"`
-	Value             *CodeableConcept                                `json:"value,omitempty"`
-	Component         []MeasureReportGroupStratifierStratumComponent  `json:"component,omitempty"`
-	Population        []MeasureReportGroupStratifierStratumPopulation `json:"population,omitempty"`
-	MeasureScore      *Quantity                                       `json:"measureScore,omitempty"`
+	Id                *string                                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Value             *CodeableConcept                                `bson:"value,omitempty" json:"value,omitempty"`
+	Component         []MeasureReportGroupStratifierStratumComponent  `bson:"component,omitempty" json:"component,omitempty"`
+	Population        []MeasureReportGroupStratifierStratumPopulation `bson:"population,omitempty" json:"population,omitempty"`
+	MeasureScore      *Quantity                                       `bson:"measureScore,omitempty" json:"measureScore,omitempty"`
 }
 type MeasureReportGroupStratifierStratumComponent struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept `json:"code"`
-	Value             CodeableConcept `json:"value"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
+	Value             CodeableConcept `bson:"value" json:"value"`
 }
 type MeasureReportGroupStratifierStratumPopulation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Count             *int             `json:"count,omitempty"`
-	SubjectResults    *Reference       `json:"subjectResults,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Count             *int             `bson:"count,omitempty" json:"count,omitempty"`
+	SubjectResults    *Reference       `bson:"subjectResults,omitempty" json:"subjectResults,omitempty"`
 }
 type OtherMeasureReport MeasureReport
 

--- a/fhir-models/fhir/media.go
+++ b/fhir-models/fhir/media.go
@@ -21,34 +21,34 @@ import "encoding/json"
 
 // Media is documented here http://hl7.org/fhir/StructureDefinition/Media
 type Media struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier      `json:"identifier,omitempty"`
-	BasedOn           []Reference       `json:"basedOn,omitempty"`
-	PartOf            []Reference       `json:"partOf,omitempty"`
-	Status            EventStatus       `json:"status"`
-	Type              *CodeableConcept  `json:"type,omitempty"`
-	Modality          *CodeableConcept  `json:"modality,omitempty"`
-	View              *CodeableConcept  `json:"view,omitempty"`
-	Subject           *Reference        `json:"subject,omitempty"`
-	Encounter         *Reference        `json:"encounter,omitempty"`
-	Issued            *string           `json:"issued,omitempty"`
-	Operator          *Reference        `json:"operator,omitempty"`
-	ReasonCode        []CodeableConcept `json:"reasonCode,omitempty"`
-	BodySite          *CodeableConcept  `json:"bodySite,omitempty"`
-	DeviceName        *string           `json:"deviceName,omitempty"`
-	Device            *Reference        `json:"device,omitempty"`
-	Height            *int              `json:"height,omitempty"`
-	Width             *int              `json:"width,omitempty"`
-	Frames            *int              `json:"frames,omitempty"`
-	Duration          *string           `json:"duration,omitempty"`
-	Content           Attachment        `json:"content"`
-	Note              []Annotation      `json:"note,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference       `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf            []Reference       `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status            EventStatus       `bson:"status" json:"status"`
+	Type              *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	Modality          *CodeableConcept  `bson:"modality,omitempty" json:"modality,omitempty"`
+	View              *CodeableConcept  `bson:"view,omitempty" json:"view,omitempty"`
+	Subject           *Reference        `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter         *Reference        `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Issued            *string           `bson:"issued,omitempty" json:"issued,omitempty"`
+	Operator          *Reference        `bson:"operator,omitempty" json:"operator,omitempty"`
+	ReasonCode        []CodeableConcept `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	BodySite          *CodeableConcept  `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	DeviceName        *string           `bson:"deviceName,omitempty" json:"deviceName,omitempty"`
+	Device            *Reference        `bson:"device,omitempty" json:"device,omitempty"`
+	Height            *int              `bson:"height,omitempty" json:"height,omitempty"`
+	Width             *int              `bson:"width,omitempty" json:"width,omitempty"`
+	Frames            *int              `bson:"frames,omitempty" json:"frames,omitempty"`
+	Duration          *string           `bson:"duration,omitempty" json:"duration,omitempty"`
+	Content           Attachment        `bson:"content" json:"content"`
+	Note              []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
 }
 type OtherMedia Media
 

--- a/fhir-models/fhir/medication.go
+++ b/fhir-models/fhir/medication.go
@@ -21,35 +21,35 @@ import "encoding/json"
 
 // Medication is documented here http://hl7.org/fhir/StructureDefinition/Medication
 type Medication struct {
-	Id                *string                `json:"id,omitempty"`
-	Meta              *Meta                  `json:"meta,omitempty"`
-	ImplicitRules     *string                `json:"implicitRules,omitempty"`
-	Language          *string                `json:"language,omitempty"`
-	Text              *Narrative             `json:"text,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier           `json:"identifier,omitempty"`
-	Code              *CodeableConcept       `json:"code,omitempty"`
-	Status            *string                `json:"status,omitempty"`
-	Manufacturer      *Reference             `json:"manufacturer,omitempty"`
-	Form              *CodeableConcept       `json:"form,omitempty"`
-	Amount            *Ratio                 `json:"amount,omitempty"`
-	Ingredient        []MedicationIngredient `json:"ingredient,omitempty"`
-	Batch             *MedicationBatch       `json:"batch,omitempty"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Code              *CodeableConcept       `bson:"code,omitempty" json:"code,omitempty"`
+	Status            *string                `bson:"status,omitempty" json:"status,omitempty"`
+	Manufacturer      *Reference             `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	Form              *CodeableConcept       `bson:"form,omitempty" json:"form,omitempty"`
+	Amount            *Ratio                 `bson:"amount,omitempty" json:"amount,omitempty"`
+	Ingredient        []MedicationIngredient `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
+	Batch             *MedicationBatch       `bson:"batch,omitempty" json:"batch,omitempty"`
 }
 type MedicationIngredient struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	IsActive          *bool       `json:"isActive,omitempty"`
-	Strength          *Ratio      `json:"strength,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	IsActive          *bool       `bson:"isActive,omitempty" json:"isActive,omitempty"`
+	Strength          *Ratio      `bson:"strength,omitempty" json:"strength,omitempty"`
 }
 type MedicationBatch struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	LotNumber         *string     `json:"lotNumber,omitempty"`
-	ExpirationDate    *string     `json:"expirationDate,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	LotNumber         *string     `bson:"lotNumber,omitempty" json:"lotNumber,omitempty"`
+	ExpirationDate    *string     `bson:"expirationDate,omitempty" json:"expirationDate,omitempty"`
 }
 type OtherMedication Medication
 

--- a/fhir-models/fhir/medicationAdministration.go
+++ b/fhir-models/fhir/medicationAdministration.go
@@ -21,47 +21,47 @@ import "encoding/json"
 
 // MedicationAdministration is documented here http://hl7.org/fhir/StructureDefinition/MedicationAdministration
 type MedicationAdministration struct {
-	Id                    *string                             `json:"id,omitempty"`
-	Meta                  *Meta                               `json:"meta,omitempty"`
-	ImplicitRules         *string                             `json:"implicitRules,omitempty"`
-	Language              *string                             `json:"language,omitempty"`
-	Text                  *Narrative                          `json:"text,omitempty"`
-	Extension             []Extension                         `json:"extension,omitempty"`
-	ModifierExtension     []Extension                         `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier                        `json:"identifier,omitempty"`
-	Instantiates          []string                            `json:"instantiates,omitempty"`
-	PartOf                []Reference                         `json:"partOf,omitempty"`
-	Status                string                              `json:"status"`
-	StatusReason          []CodeableConcept                   `json:"statusReason,omitempty"`
-	Category              *CodeableConcept                    `json:"category,omitempty"`
-	Subject               Reference                           `json:"subject"`
-	Context               *Reference                          `json:"context,omitempty"`
-	SupportingInformation []Reference                         `json:"supportingInformation,omitempty"`
-	Performer             []MedicationAdministrationPerformer `json:"performer,omitempty"`
-	ReasonCode            []CodeableConcept                   `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference                         `json:"reasonReference,omitempty"`
-	Request               *Reference                          `json:"request,omitempty"`
-	Device                []Reference                         `json:"device,omitempty"`
-	Note                  []Annotation                        `json:"note,omitempty"`
-	Dosage                *MedicationAdministrationDosage     `json:"dosage,omitempty"`
-	EventHistory          []Reference                         `json:"eventHistory,omitempty"`
+	Id                    *string                             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                             `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Instantiates          []string                            `bson:"instantiates,omitempty" json:"instantiates,omitempty"`
+	PartOf                []Reference                         `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status                string                              `bson:"status" json:"status"`
+	StatusReason          []CodeableConcept                   `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Category              *CodeableConcept                    `bson:"category,omitempty" json:"category,omitempty"`
+	Subject               Reference                           `bson:"subject" json:"subject"`
+	Context               *Reference                          `bson:"context,omitempty" json:"context,omitempty"`
+	SupportingInformation []Reference                         `bson:"supportingInformation,omitempty" json:"supportingInformation,omitempty"`
+	Performer             []MedicationAdministrationPerformer `bson:"performer,omitempty" json:"performer,omitempty"`
+	ReasonCode            []CodeableConcept                   `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference                         `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Request               *Reference                          `bson:"request,omitempty" json:"request,omitempty"`
+	Device                []Reference                         `bson:"device,omitempty" json:"device,omitempty"`
+	Note                  []Annotation                        `bson:"note,omitempty" json:"note,omitempty"`
+	Dosage                *MedicationAdministrationDosage     `bson:"dosage,omitempty" json:"dosage,omitempty"`
+	EventHistory          []Reference                         `bson:"eventHistory,omitempty" json:"eventHistory,omitempty"`
 }
 type MedicationAdministrationPerformer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Function          *CodeableConcept `json:"function,omitempty"`
-	Actor             Reference        `json:"actor"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Function          *CodeableConcept `bson:"function,omitempty" json:"function,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
 }
 type MedicationAdministrationDosage struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Text              *string          `json:"text,omitempty"`
-	Site              *CodeableConcept `json:"site,omitempty"`
-	Route             *CodeableConcept `json:"route,omitempty"`
-	Method            *CodeableConcept `json:"method,omitempty"`
-	Dose              *Quantity        `json:"dose,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Text              *string          `bson:"text,omitempty" json:"text,omitempty"`
+	Site              *CodeableConcept `bson:"site,omitempty" json:"site,omitempty"`
+	Route             *CodeableConcept `bson:"route,omitempty" json:"route,omitempty"`
+	Method            *CodeableConcept `bson:"method,omitempty" json:"method,omitempty"`
+	Dose              *Quantity        `bson:"dose,omitempty" json:"dose,omitempty"`
 }
 type OtherMedicationAdministration MedicationAdministration
 

--- a/fhir-models/fhir/medicationDispense.go
+++ b/fhir-models/fhir/medicationDispense.go
@@ -21,51 +21,51 @@ import "encoding/json"
 
 // MedicationDispense is documented here http://hl7.org/fhir/StructureDefinition/MedicationDispense
 type MedicationDispense struct {
-	Id                      *string                         `json:"id,omitempty"`
-	Meta                    *Meta                           `json:"meta,omitempty"`
-	ImplicitRules           *string                         `json:"implicitRules,omitempty"`
-	Language                *string                         `json:"language,omitempty"`
-	Text                    *Narrative                      `json:"text,omitempty"`
-	Extension               []Extension                     `json:"extension,omitempty"`
-	ModifierExtension       []Extension                     `json:"modifierExtension,omitempty"`
-	Identifier              []Identifier                    `json:"identifier,omitempty"`
-	PartOf                  []Reference                     `json:"partOf,omitempty"`
-	Status                  string                          `json:"status"`
-	Category                *CodeableConcept                `json:"category,omitempty"`
-	Subject                 *Reference                      `json:"subject,omitempty"`
-	Context                 *Reference                      `json:"context,omitempty"`
-	SupportingInformation   []Reference                     `json:"supportingInformation,omitempty"`
-	Performer               []MedicationDispensePerformer   `json:"performer,omitempty"`
-	Location                *Reference                      `json:"location,omitempty"`
-	AuthorizingPrescription []Reference                     `json:"authorizingPrescription,omitempty"`
-	Type                    *CodeableConcept                `json:"type,omitempty"`
-	Quantity                *Quantity                       `json:"quantity,omitempty"`
-	DaysSupply              *Quantity                       `json:"daysSupply,omitempty"`
-	WhenPrepared            *string                         `json:"whenPrepared,omitempty"`
-	WhenHandedOver          *string                         `json:"whenHandedOver,omitempty"`
-	Destination             *Reference                      `json:"destination,omitempty"`
-	Receiver                []Reference                     `json:"receiver,omitempty"`
-	Note                    []Annotation                    `json:"note,omitempty"`
-	DosageInstruction       []Dosage                        `json:"dosageInstruction,omitempty"`
-	Substitution            *MedicationDispenseSubstitution `json:"substitution,omitempty"`
-	DetectedIssue           []Reference                     `json:"detectedIssue,omitempty"`
-	EventHistory            []Reference                     `json:"eventHistory,omitempty"`
+	Id                      *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                    *Meta                           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules           *string                         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                *string                         `bson:"language,omitempty" json:"language,omitempty"`
+	Text                    *Narrative                      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension               []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier              []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	PartOf                  []Reference                     `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status                  string                          `bson:"status" json:"status"`
+	Category                *CodeableConcept                `bson:"category,omitempty" json:"category,omitempty"`
+	Subject                 *Reference                      `bson:"subject,omitempty" json:"subject,omitempty"`
+	Context                 *Reference                      `bson:"context,omitempty" json:"context,omitempty"`
+	SupportingInformation   []Reference                     `bson:"supportingInformation,omitempty" json:"supportingInformation,omitempty"`
+	Performer               []MedicationDispensePerformer   `bson:"performer,omitempty" json:"performer,omitempty"`
+	Location                *Reference                      `bson:"location,omitempty" json:"location,omitempty"`
+	AuthorizingPrescription []Reference                     `bson:"authorizingPrescription,omitempty" json:"authorizingPrescription,omitempty"`
+	Type                    *CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
+	Quantity                *Quantity                       `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	DaysSupply              *Quantity                       `bson:"daysSupply,omitempty" json:"daysSupply,omitempty"`
+	WhenPrepared            *string                         `bson:"whenPrepared,omitempty" json:"whenPrepared,omitempty"`
+	WhenHandedOver          *string                         `bson:"whenHandedOver,omitempty" json:"whenHandedOver,omitempty"`
+	Destination             *Reference                      `bson:"destination,omitempty" json:"destination,omitempty"`
+	Receiver                []Reference                     `bson:"receiver,omitempty" json:"receiver,omitempty"`
+	Note                    []Annotation                    `bson:"note,omitempty" json:"note,omitempty"`
+	DosageInstruction       []Dosage                        `bson:"dosageInstruction,omitempty" json:"dosageInstruction,omitempty"`
+	Substitution            *MedicationDispenseSubstitution `bson:"substitution,omitempty" json:"substitution,omitempty"`
+	DetectedIssue           []Reference                     `bson:"detectedIssue,omitempty" json:"detectedIssue,omitempty"`
+	EventHistory            []Reference                     `bson:"eventHistory,omitempty" json:"eventHistory,omitempty"`
 }
 type MedicationDispensePerformer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Function          *CodeableConcept `json:"function,omitempty"`
-	Actor             Reference        `json:"actor"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Function          *CodeableConcept `bson:"function,omitempty" json:"function,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
 }
 type MedicationDispenseSubstitution struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	WasSubstituted    bool              `json:"wasSubstituted"`
-	Type              *CodeableConcept  `json:"type,omitempty"`
-	Reason            []CodeableConcept `json:"reason,omitempty"`
-	ResponsibleParty  []Reference       `json:"responsibleParty,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	WasSubstituted    bool              `bson:"wasSubstituted" json:"wasSubstituted"`
+	Type              *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	Reason            []CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
+	ResponsibleParty  []Reference       `bson:"responsibleParty,omitempty" json:"responsibleParty,omitempty"`
 }
 type OtherMedicationDispense MedicationDispense
 

--- a/fhir-models/fhir/medicationKnowledge.go
+++ b/fhir-models/fhir/medicationKnowledge.go
@@ -21,148 +21,148 @@ import "encoding/json"
 
 // MedicationKnowledge is documented here http://hl7.org/fhir/StructureDefinition/MedicationKnowledge
 type MedicationKnowledge struct {
-	Id                         *string                                         `json:"id,omitempty"`
-	Meta                       *Meta                                           `json:"meta,omitempty"`
-	ImplicitRules              *string                                         `json:"implicitRules,omitempty"`
-	Language                   *string                                         `json:"language,omitempty"`
-	Text                       *Narrative                                      `json:"text,omitempty"`
-	Extension                  []Extension                                     `json:"extension,omitempty"`
-	ModifierExtension          []Extension                                     `json:"modifierExtension,omitempty"`
-	Code                       *CodeableConcept                                `json:"code,omitempty"`
-	Status                     *string                                         `json:"status,omitempty"`
-	Manufacturer               *Reference                                      `json:"manufacturer,omitempty"`
-	DoseForm                   *CodeableConcept                                `json:"doseForm,omitempty"`
-	Amount                     *Quantity                                       `json:"amount,omitempty"`
-	Synonym                    []string                                        `json:"synonym,omitempty"`
-	RelatedMedicationKnowledge []MedicationKnowledgeRelatedMedicationKnowledge `json:"relatedMedicationKnowledge,omitempty"`
-	AssociatedMedication       []Reference                                     `json:"associatedMedication,omitempty"`
-	ProductType                []CodeableConcept                               `json:"productType,omitempty"`
-	Monograph                  []MedicationKnowledgeMonograph                  `json:"monograph,omitempty"`
-	Ingredient                 []MedicationKnowledgeIngredient                 `json:"ingredient,omitempty"`
-	PreparationInstruction     *string                                         `json:"preparationInstruction,omitempty"`
-	IntendedRoute              []CodeableConcept                               `json:"intendedRoute,omitempty"`
-	Cost                       []MedicationKnowledgeCost                       `json:"cost,omitempty"`
-	MonitoringProgram          []MedicationKnowledgeMonitoringProgram          `json:"monitoringProgram,omitempty"`
-	AdministrationGuidelines   []MedicationKnowledgeAdministrationGuidelines   `json:"administrationGuidelines,omitempty"`
-	MedicineClassification     []MedicationKnowledgeMedicineClassification     `json:"medicineClassification,omitempty"`
-	Packaging                  *MedicationKnowledgePackaging                   `json:"packaging,omitempty"`
-	DrugCharacteristic         []MedicationKnowledgeDrugCharacteristic         `json:"drugCharacteristic,omitempty"`
-	Contraindication           []Reference                                     `json:"contraindication,omitempty"`
-	Regulatory                 []MedicationKnowledgeRegulatory                 `json:"regulatory,omitempty"`
-	Kinetics                   []MedicationKnowledgeKinetics                   `json:"kinetics,omitempty"`
+	Id                         *string                                         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                       *Meta                                           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules              *string                                         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                   *string                                         `bson:"language,omitempty" json:"language,omitempty"`
+	Text                       *Narrative                                      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                  []Extension                                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension          []Extension                                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code                       *CodeableConcept                                `bson:"code,omitempty" json:"code,omitempty"`
+	Status                     *string                                         `bson:"status,omitempty" json:"status,omitempty"`
+	Manufacturer               *Reference                                      `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	DoseForm                   *CodeableConcept                                `bson:"doseForm,omitempty" json:"doseForm,omitempty"`
+	Amount                     *Quantity                                       `bson:"amount,omitempty" json:"amount,omitempty"`
+	Synonym                    []string                                        `bson:"synonym,omitempty" json:"synonym,omitempty"`
+	RelatedMedicationKnowledge []MedicationKnowledgeRelatedMedicationKnowledge `bson:"relatedMedicationKnowledge,omitempty" json:"relatedMedicationKnowledge,omitempty"`
+	AssociatedMedication       []Reference                                     `bson:"associatedMedication,omitempty" json:"associatedMedication,omitempty"`
+	ProductType                []CodeableConcept                               `bson:"productType,omitempty" json:"productType,omitempty"`
+	Monograph                  []MedicationKnowledgeMonograph                  `bson:"monograph,omitempty" json:"monograph,omitempty"`
+	Ingredient                 []MedicationKnowledgeIngredient                 `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
+	PreparationInstruction     *string                                         `bson:"preparationInstruction,omitempty" json:"preparationInstruction,omitempty"`
+	IntendedRoute              []CodeableConcept                               `bson:"intendedRoute,omitempty" json:"intendedRoute,omitempty"`
+	Cost                       []MedicationKnowledgeCost                       `bson:"cost,omitempty" json:"cost,omitempty"`
+	MonitoringProgram          []MedicationKnowledgeMonitoringProgram          `bson:"monitoringProgram,omitempty" json:"monitoringProgram,omitempty"`
+	AdministrationGuidelines   []MedicationKnowledgeAdministrationGuidelines   `bson:"administrationGuidelines,omitempty" json:"administrationGuidelines,omitempty"`
+	MedicineClassification     []MedicationKnowledgeMedicineClassification     `bson:"medicineClassification,omitempty" json:"medicineClassification,omitempty"`
+	Packaging                  *MedicationKnowledgePackaging                   `bson:"packaging,omitempty" json:"packaging,omitempty"`
+	DrugCharacteristic         []MedicationKnowledgeDrugCharacteristic         `bson:"drugCharacteristic,omitempty" json:"drugCharacteristic,omitempty"`
+	Contraindication           []Reference                                     `bson:"contraindication,omitempty" json:"contraindication,omitempty"`
+	Regulatory                 []MedicationKnowledgeRegulatory                 `bson:"regulatory,omitempty" json:"regulatory,omitempty"`
+	Kinetics                   []MedicationKnowledgeKinetics                   `bson:"kinetics,omitempty" json:"kinetics,omitempty"`
 }
 type MedicationKnowledgeRelatedMedicationKnowledge struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Reference         []Reference     `json:"reference"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Reference         []Reference     `bson:"reference" json:"reference"`
 }
 type MedicationKnowledgeMonograph struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Source            *Reference       `json:"source,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Source            *Reference       `bson:"source,omitempty" json:"source,omitempty"`
 }
 type MedicationKnowledgeIngredient struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	IsActive          *bool       `json:"isActive,omitempty"`
-	Strength          *Ratio      `json:"strength,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	IsActive          *bool       `bson:"isActive,omitempty" json:"isActive,omitempty"`
+	Strength          *Ratio      `bson:"strength,omitempty" json:"strength,omitempty"`
 }
 type MedicationKnowledgeCost struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Source            *string         `json:"source,omitempty"`
-	Cost              Money           `json:"cost"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Source            *string         `bson:"source,omitempty" json:"source,omitempty"`
+	Cost              Money           `bson:"cost" json:"cost"`
 }
 type MedicationKnowledgeMonitoringProgram struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Name              *string          `json:"name,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Name              *string          `bson:"name,omitempty" json:"name,omitempty"`
 }
 type MedicationKnowledgeAdministrationGuidelines struct {
-	Id                     *string                                                             `json:"id,omitempty"`
-	Extension              []Extension                                                         `json:"extension,omitempty"`
-	ModifierExtension      []Extension                                                         `json:"modifierExtension,omitempty"`
-	Dosage                 []MedicationKnowledgeAdministrationGuidelinesDosage                 `json:"dosage,omitempty"`
-	PatientCharacteristics []MedicationKnowledgeAdministrationGuidelinesPatientCharacteristics `json:"patientCharacteristics,omitempty"`
+	Id                     *string                                                             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension              []Extension                                                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                                                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Dosage                 []MedicationKnowledgeAdministrationGuidelinesDosage                 `bson:"dosage,omitempty" json:"dosage,omitempty"`
+	PatientCharacteristics []MedicationKnowledgeAdministrationGuidelinesPatientCharacteristics `bson:"patientCharacteristics,omitempty" json:"patientCharacteristics,omitempty"`
 }
 type MedicationKnowledgeAdministrationGuidelinesDosage struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Dosage            []Dosage        `json:"dosage"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Dosage            []Dosage        `bson:"dosage" json:"dosage"`
 }
 type MedicationKnowledgeAdministrationGuidelinesPatientCharacteristics struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Value             []string    `json:"value,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Value             []string    `bson:"value,omitempty" json:"value,omitempty"`
 }
 type MedicationKnowledgeMedicineClassification struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept   `json:"type"`
-	Classification    []CodeableConcept `json:"classification,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept   `bson:"type" json:"type"`
+	Classification    []CodeableConcept `bson:"classification,omitempty" json:"classification,omitempty"`
 }
 type MedicationKnowledgePackaging struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Quantity          *Quantity        `json:"quantity,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Quantity          *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
 }
 type MedicationKnowledgeDrugCharacteristic struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 }
 type MedicationKnowledgeRegulatory struct {
-	Id                  *string                                     `json:"id,omitempty"`
-	Extension           []Extension                                 `json:"extension,omitempty"`
-	ModifierExtension   []Extension                                 `json:"modifierExtension,omitempty"`
-	RegulatoryAuthority Reference                                   `json:"regulatoryAuthority"`
-	Substitution        []MedicationKnowledgeRegulatorySubstitution `json:"substitution,omitempty"`
-	Schedule            []MedicationKnowledgeRegulatorySchedule     `json:"schedule,omitempty"`
-	MaxDispense         *MedicationKnowledgeRegulatoryMaxDispense   `json:"maxDispense,omitempty"`
+	Id                  *string                                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	RegulatoryAuthority Reference                                   `bson:"regulatoryAuthority" json:"regulatoryAuthority"`
+	Substitution        []MedicationKnowledgeRegulatorySubstitution `bson:"substitution,omitempty" json:"substitution,omitempty"`
+	Schedule            []MedicationKnowledgeRegulatorySchedule     `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	MaxDispense         *MedicationKnowledgeRegulatoryMaxDispense   `bson:"maxDispense,omitempty" json:"maxDispense,omitempty"`
 }
 type MedicationKnowledgeRegulatorySubstitution struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Allowed           bool            `json:"allowed"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Allowed           bool            `bson:"allowed" json:"allowed"`
 }
 type MedicationKnowledgeRegulatorySchedule struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Schedule          CodeableConcept `json:"schedule"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Schedule          CodeableConcept `bson:"schedule" json:"schedule"`
 }
 type MedicationKnowledgeRegulatoryMaxDispense struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Quantity          Quantity    `json:"quantity"`
-	Period            *Duration   `json:"period,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Quantity          Quantity    `bson:"quantity" json:"quantity"`
+	Period            *Duration   `bson:"period,omitempty" json:"period,omitempty"`
 }
 type MedicationKnowledgeKinetics struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	AreaUnderCurve    []Quantity  `json:"areaUnderCurve,omitempty"`
-	LethalDose50      []Quantity  `json:"lethalDose50,omitempty"`
-	HalfLifePeriod    *Duration   `json:"halfLifePeriod,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	AreaUnderCurve    []Quantity  `bson:"areaUnderCurve,omitempty" json:"areaUnderCurve,omitempty"`
+	LethalDose50      []Quantity  `bson:"lethalDose50,omitempty" json:"lethalDose50,omitempty"`
+	HalfLifePeriod    *Duration   `bson:"halfLifePeriod,omitempty" json:"halfLifePeriod,omitempty"`
 }
 type OtherMedicationKnowledge MedicationKnowledge
 

--- a/fhir-models/fhir/medicationRequest.go
+++ b/fhir-models/fhir/medicationRequest.go
@@ -21,68 +21,68 @@ import "encoding/json"
 
 // MedicationRequest is documented here http://hl7.org/fhir/StructureDefinition/MedicationRequest
 type MedicationRequest struct {
-	Id                    *string                           `json:"id,omitempty"`
-	Meta                  *Meta                             `json:"meta,omitempty"`
-	ImplicitRules         *string                           `json:"implicitRules,omitempty"`
-	Language              *string                           `json:"language,omitempty"`
-	Text                  *Narrative                        `json:"text,omitempty"`
-	Extension             []Extension                       `json:"extension,omitempty"`
-	ModifierExtension     []Extension                       `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier                      `json:"identifier,omitempty"`
-	Status                string                            `json:"status"`
-	StatusReason          *CodeableConcept                  `json:"statusReason,omitempty"`
-	Intent                string                            `json:"intent"`
-	Category              []CodeableConcept                 `json:"category,omitempty"`
-	Priority              *RequestPriority                  `json:"priority,omitempty"`
-	DoNotPerform          *bool                             `json:"doNotPerform,omitempty"`
-	Subject               Reference                         `json:"subject"`
-	Encounter             *Reference                        `json:"encounter,omitempty"`
-	SupportingInformation []Reference                       `json:"supportingInformation,omitempty"`
-	AuthoredOn            *string                           `json:"authoredOn,omitempty"`
-	Requester             *Reference                        `json:"requester,omitempty"`
-	Performer             *Reference                        `json:"performer,omitempty"`
-	PerformerType         *CodeableConcept                  `json:"performerType,omitempty"`
-	Recorder              *Reference                        `json:"recorder,omitempty"`
-	ReasonCode            []CodeableConcept                 `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference                       `json:"reasonReference,omitempty"`
-	InstantiatesCanonical []string                          `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string                          `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference                       `json:"basedOn,omitempty"`
-	GroupIdentifier       *Identifier                       `json:"groupIdentifier,omitempty"`
-	CourseOfTherapyType   *CodeableConcept                  `json:"courseOfTherapyType,omitempty"`
-	Insurance             []Reference                       `json:"insurance,omitempty"`
-	Note                  []Annotation                      `json:"note,omitempty"`
-	DosageInstruction     []Dosage                          `json:"dosageInstruction,omitempty"`
-	DispenseRequest       *MedicationRequestDispenseRequest `json:"dispenseRequest,omitempty"`
-	Substitution          *MedicationRequestSubstitution    `json:"substitution,omitempty"`
-	PriorPrescription     *Reference                        `json:"priorPrescription,omitempty"`
-	DetectedIssue         []Reference                       `json:"detectedIssue,omitempty"`
-	EventHistory          []Reference                       `json:"eventHistory,omitempty"`
+	Id                    *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status                string                            `bson:"status" json:"status"`
+	StatusReason          *CodeableConcept                  `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Intent                string                            `bson:"intent" json:"intent"`
+	Category              []CodeableConcept                 `bson:"category,omitempty" json:"category,omitempty"`
+	Priority              *RequestPriority                  `bson:"priority,omitempty" json:"priority,omitempty"`
+	DoNotPerform          *bool                             `bson:"doNotPerform,omitempty" json:"doNotPerform,omitempty"`
+	Subject               Reference                         `bson:"subject" json:"subject"`
+	Encounter             *Reference                        `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	SupportingInformation []Reference                       `bson:"supportingInformation,omitempty" json:"supportingInformation,omitempty"`
+	AuthoredOn            *string                           `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	Requester             *Reference                        `bson:"requester,omitempty" json:"requester,omitempty"`
+	Performer             *Reference                        `bson:"performer,omitempty" json:"performer,omitempty"`
+	PerformerType         *CodeableConcept                  `bson:"performerType,omitempty" json:"performerType,omitempty"`
+	Recorder              *Reference                        `bson:"recorder,omitempty" json:"recorder,omitempty"`
+	ReasonCode            []CodeableConcept                 `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference                       `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	InstantiatesCanonical []string                          `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string                          `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference                       `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	GroupIdentifier       *Identifier                       `bson:"groupIdentifier,omitempty" json:"groupIdentifier,omitempty"`
+	CourseOfTherapyType   *CodeableConcept                  `bson:"courseOfTherapyType,omitempty" json:"courseOfTherapyType,omitempty"`
+	Insurance             []Reference                       `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	Note                  []Annotation                      `bson:"note,omitempty" json:"note,omitempty"`
+	DosageInstruction     []Dosage                          `bson:"dosageInstruction,omitempty" json:"dosageInstruction,omitempty"`
+	DispenseRequest       *MedicationRequestDispenseRequest `bson:"dispenseRequest,omitempty" json:"dispenseRequest,omitempty"`
+	Substitution          *MedicationRequestSubstitution    `bson:"substitution,omitempty" json:"substitution,omitempty"`
+	PriorPrescription     *Reference                        `bson:"priorPrescription,omitempty" json:"priorPrescription,omitempty"`
+	DetectedIssue         []Reference                       `bson:"detectedIssue,omitempty" json:"detectedIssue,omitempty"`
+	EventHistory          []Reference                       `bson:"eventHistory,omitempty" json:"eventHistory,omitempty"`
 }
 type MedicationRequestDispenseRequest struct {
-	Id                     *string                                      `json:"id,omitempty"`
-	Extension              []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension      []Extension                                  `json:"modifierExtension,omitempty"`
-	InitialFill            *MedicationRequestDispenseRequestInitialFill `json:"initialFill,omitempty"`
-	DispenseInterval       *Duration                                    `json:"dispenseInterval,omitempty"`
-	ValidityPeriod         *Period                                      `json:"validityPeriod,omitempty"`
-	NumberOfRepeatsAllowed *int                                         `json:"numberOfRepeatsAllowed,omitempty"`
-	Quantity               *Quantity                                    `json:"quantity,omitempty"`
-	ExpectedSupplyDuration *Duration                                    `json:"expectedSupplyDuration,omitempty"`
-	Performer              *Reference                                   `json:"performer,omitempty"`
+	Id                     *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension              []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	InitialFill            *MedicationRequestDispenseRequestInitialFill `bson:"initialFill,omitempty" json:"initialFill,omitempty"`
+	DispenseInterval       *Duration                                    `bson:"dispenseInterval,omitempty" json:"dispenseInterval,omitempty"`
+	ValidityPeriod         *Period                                      `bson:"validityPeriod,omitempty" json:"validityPeriod,omitempty"`
+	NumberOfRepeatsAllowed *int                                         `bson:"numberOfRepeatsAllowed,omitempty" json:"numberOfRepeatsAllowed,omitempty"`
+	Quantity               *Quantity                                    `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	ExpectedSupplyDuration *Duration                                    `bson:"expectedSupplyDuration,omitempty" json:"expectedSupplyDuration,omitempty"`
+	Performer              *Reference                                   `bson:"performer,omitempty" json:"performer,omitempty"`
 }
 type MedicationRequestDispenseRequestInitialFill struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Quantity          *Quantity   `json:"quantity,omitempty"`
-	Duration          *Duration   `json:"duration,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Quantity          *Quantity   `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Duration          *Duration   `bson:"duration,omitempty" json:"duration,omitempty"`
 }
 type MedicationRequestSubstitution struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Reason            *CodeableConcept `json:"reason,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Reason            *CodeableConcept `bson:"reason,omitempty" json:"reason,omitempty"`
 }
 type OtherMedicationRequest MedicationRequest
 

--- a/fhir-models/fhir/medicationStatement.go
+++ b/fhir-models/fhir/medicationStatement.go
@@ -21,28 +21,28 @@ import "encoding/json"
 
 // MedicationStatement is documented here http://hl7.org/fhir/StructureDefinition/MedicationStatement
 type MedicationStatement struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier      `json:"identifier,omitempty"`
-	BasedOn           []Reference       `json:"basedOn,omitempty"`
-	PartOf            []Reference       `json:"partOf,omitempty"`
-	Status            string            `json:"status"`
-	StatusReason      []CodeableConcept `json:"statusReason,omitempty"`
-	Category          *CodeableConcept  `json:"category,omitempty"`
-	Subject           Reference         `json:"subject"`
-	Context           *Reference        `json:"context,omitempty"`
-	DateAsserted      *string           `json:"dateAsserted,omitempty"`
-	InformationSource *Reference        `json:"informationSource,omitempty"`
-	DerivedFrom       []Reference       `json:"derivedFrom,omitempty"`
-	ReasonCode        []CodeableConcept `json:"reasonCode,omitempty"`
-	ReasonReference   []Reference       `json:"reasonReference,omitempty"`
-	Note              []Annotation      `json:"note,omitempty"`
-	Dosage            []Dosage          `json:"dosage,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference       `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf            []Reference       `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status            string            `bson:"status" json:"status"`
+	StatusReason      []CodeableConcept `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Category          *CodeableConcept  `bson:"category,omitempty" json:"category,omitempty"`
+	Subject           Reference         `bson:"subject" json:"subject"`
+	Context           *Reference        `bson:"context,omitempty" json:"context,omitempty"`
+	DateAsserted      *string           `bson:"dateAsserted,omitempty" json:"dateAsserted,omitempty"`
+	InformationSource *Reference        `bson:"informationSource,omitempty" json:"informationSource,omitempty"`
+	DerivedFrom       []Reference       `bson:"derivedFrom,omitempty" json:"derivedFrom,omitempty"`
+	ReasonCode        []CodeableConcept `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference   []Reference       `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Note              []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
+	Dosage            []Dosage          `bson:"dosage,omitempty" json:"dosage,omitempty"`
 }
 type OtherMedicationStatement MedicationStatement
 

--- a/fhir-models/fhir/medicinalProduct.go
+++ b/fhir-models/fhir/medicinalProduct.go
@@ -21,78 +21,78 @@ import "encoding/json"
 
 // MedicinalProduct is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProduct
 type MedicinalProduct struct {
-	Id                             *string                                          `json:"id,omitempty"`
-	Meta                           *Meta                                            `json:"meta,omitempty"`
-	ImplicitRules                  *string                                          `json:"implicitRules,omitempty"`
-	Language                       *string                                          `json:"language,omitempty"`
-	Text                           *Narrative                                       `json:"text,omitempty"`
-	Extension                      []Extension                                      `json:"extension,omitempty"`
-	ModifierExtension              []Extension                                      `json:"modifierExtension,omitempty"`
-	Identifier                     []Identifier                                     `json:"identifier,omitempty"`
-	Type                           *CodeableConcept                                 `json:"type,omitempty"`
-	Domain                         *Coding                                          `json:"domain,omitempty"`
-	CombinedPharmaceuticalDoseForm *CodeableConcept                                 `json:"combinedPharmaceuticalDoseForm,omitempty"`
-	LegalStatusOfSupply            *CodeableConcept                                 `json:"legalStatusOfSupply,omitempty"`
-	AdditionalMonitoringIndicator  *CodeableConcept                                 `json:"additionalMonitoringIndicator,omitempty"`
-	SpecialMeasures                []string                                         `json:"specialMeasures,omitempty"`
-	PaediatricUseIndicator         *CodeableConcept                                 `json:"paediatricUseIndicator,omitempty"`
-	ProductClassification          []CodeableConcept                                `json:"productClassification,omitempty"`
-	MarketingStatus                []MarketingStatus                                `json:"marketingStatus,omitempty"`
-	PharmaceuticalProduct          []Reference                                      `json:"pharmaceuticalProduct,omitempty"`
-	PackagedMedicinalProduct       []Reference                                      `json:"packagedMedicinalProduct,omitempty"`
-	AttachedDocument               []Reference                                      `json:"attachedDocument,omitempty"`
-	MasterFile                     []Reference                                      `json:"masterFile,omitempty"`
-	Contact                        []Reference                                      `json:"contact,omitempty"`
-	ClinicalTrial                  []Reference                                      `json:"clinicalTrial,omitempty"`
-	Name                           []MedicinalProductName                           `json:"name"`
-	CrossReference                 []Identifier                                     `json:"crossReference,omitempty"`
-	ManufacturingBusinessOperation []MedicinalProductManufacturingBusinessOperation `json:"manufacturingBusinessOperation,omitempty"`
-	SpecialDesignation             []MedicinalProductSpecialDesignation             `json:"specialDesignation,omitempty"`
+	Id                             *string                                          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                           *Meta                                            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules                  *string                                          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                       *string                                          `bson:"language,omitempty" json:"language,omitempty"`
+	Text                           *Narrative                                       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                      []Extension                                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension              []Extension                                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier                     []Identifier                                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type                           *CodeableConcept                                 `bson:"type,omitempty" json:"type,omitempty"`
+	Domain                         *Coding                                          `bson:"domain,omitempty" json:"domain,omitempty"`
+	CombinedPharmaceuticalDoseForm *CodeableConcept                                 `bson:"combinedPharmaceuticalDoseForm,omitempty" json:"combinedPharmaceuticalDoseForm,omitempty"`
+	LegalStatusOfSupply            *CodeableConcept                                 `bson:"legalStatusOfSupply,omitempty" json:"legalStatusOfSupply,omitempty"`
+	AdditionalMonitoringIndicator  *CodeableConcept                                 `bson:"additionalMonitoringIndicator,omitempty" json:"additionalMonitoringIndicator,omitempty"`
+	SpecialMeasures                []string                                         `bson:"specialMeasures,omitempty" json:"specialMeasures,omitempty"`
+	PaediatricUseIndicator         *CodeableConcept                                 `bson:"paediatricUseIndicator,omitempty" json:"paediatricUseIndicator,omitempty"`
+	ProductClassification          []CodeableConcept                                `bson:"productClassification,omitempty" json:"productClassification,omitempty"`
+	MarketingStatus                []MarketingStatus                                `bson:"marketingStatus,omitempty" json:"marketingStatus,omitempty"`
+	PharmaceuticalProduct          []Reference                                      `bson:"pharmaceuticalProduct,omitempty" json:"pharmaceuticalProduct,omitempty"`
+	PackagedMedicinalProduct       []Reference                                      `bson:"packagedMedicinalProduct,omitempty" json:"packagedMedicinalProduct,omitempty"`
+	AttachedDocument               []Reference                                      `bson:"attachedDocument,omitempty" json:"attachedDocument,omitempty"`
+	MasterFile                     []Reference                                      `bson:"masterFile,omitempty" json:"masterFile,omitempty"`
+	Contact                        []Reference                                      `bson:"contact,omitempty" json:"contact,omitempty"`
+	ClinicalTrial                  []Reference                                      `bson:"clinicalTrial,omitempty" json:"clinicalTrial,omitempty"`
+	Name                           []MedicinalProductName                           `bson:"name" json:"name"`
+	CrossReference                 []Identifier                                     `bson:"crossReference,omitempty" json:"crossReference,omitempty"`
+	ManufacturingBusinessOperation []MedicinalProductManufacturingBusinessOperation `bson:"manufacturingBusinessOperation,omitempty" json:"manufacturingBusinessOperation,omitempty"`
+	SpecialDesignation             []MedicinalProductSpecialDesignation             `bson:"specialDesignation,omitempty" json:"specialDesignation,omitempty"`
 }
 type MedicinalProductName struct {
-	Id                *string                               `json:"id,omitempty"`
-	Extension         []Extension                           `json:"extension,omitempty"`
-	ModifierExtension []Extension                           `json:"modifierExtension,omitempty"`
-	ProductName       string                                `json:"productName"`
-	NamePart          []MedicinalProductNameNamePart        `json:"namePart,omitempty"`
-	CountryLanguage   []MedicinalProductNameCountryLanguage `json:"countryLanguage,omitempty"`
+	Id                *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ProductName       string                                `bson:"productName" json:"productName"`
+	NamePart          []MedicinalProductNameNamePart        `bson:"namePart,omitempty" json:"namePart,omitempty"`
+	CountryLanguage   []MedicinalProductNameCountryLanguage `bson:"countryLanguage,omitempty" json:"countryLanguage,omitempty"`
 }
 type MedicinalProductNameNamePart struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Part              string      `json:"part"`
-	Type              Coding      `json:"type"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Part              string      `bson:"part" json:"part"`
+	Type              Coding      `bson:"type" json:"type"`
 }
 type MedicinalProductNameCountryLanguage struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Country           CodeableConcept  `json:"country"`
-	Jurisdiction      *CodeableConcept `json:"jurisdiction,omitempty"`
-	Language          CodeableConcept  `json:"language"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Country           CodeableConcept  `bson:"country" json:"country"`
+	Jurisdiction      *CodeableConcept `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Language          CodeableConcept  `bson:"language" json:"language"`
 }
 type MedicinalProductManufacturingBusinessOperation struct {
-	Id                           *string          `json:"id,omitempty"`
-	Extension                    []Extension      `json:"extension,omitempty"`
-	ModifierExtension            []Extension      `json:"modifierExtension,omitempty"`
-	OperationType                *CodeableConcept `json:"operationType,omitempty"`
-	AuthorisationReferenceNumber *Identifier      `json:"authorisationReferenceNumber,omitempty"`
-	EffectiveDate                *string          `json:"effectiveDate,omitempty"`
-	ConfidentialityIndicator     *CodeableConcept `json:"confidentialityIndicator,omitempty"`
-	Manufacturer                 []Reference      `json:"manufacturer,omitempty"`
-	Regulator                    *Reference       `json:"regulator,omitempty"`
+	Id                           *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                    []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension            []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	OperationType                *CodeableConcept `bson:"operationType,omitempty" json:"operationType,omitempty"`
+	AuthorisationReferenceNumber *Identifier      `bson:"authorisationReferenceNumber,omitempty" json:"authorisationReferenceNumber,omitempty"`
+	EffectiveDate                *string          `bson:"effectiveDate,omitempty" json:"effectiveDate,omitempty"`
+	ConfidentialityIndicator     *CodeableConcept `bson:"confidentialityIndicator,omitempty" json:"confidentialityIndicator,omitempty"`
+	Manufacturer                 []Reference      `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	Regulator                    *Reference       `bson:"regulator,omitempty" json:"regulator,omitempty"`
 }
 type MedicinalProductSpecialDesignation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier     `json:"identifier,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	IntendedUse       *CodeableConcept `json:"intendedUse,omitempty"`
-	Status            *CodeableConcept `json:"status,omitempty"`
-	Date              *string          `json:"date,omitempty"`
-	Species           *CodeableConcept `json:"species,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	IntendedUse       *CodeableConcept `bson:"intendedUse,omitempty" json:"intendedUse,omitempty"`
+	Status            *CodeableConcept `bson:"status,omitempty" json:"status,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
+	Species           *CodeableConcept `bson:"species,omitempty" json:"species,omitempty"`
 }
 type OtherMedicinalProduct MedicinalProduct
 

--- a/fhir-models/fhir/medicinalProductAuthorization.go
+++ b/fhir-models/fhir/medicinalProductAuthorization.go
@@ -21,47 +21,47 @@ import "encoding/json"
 
 // MedicinalProductAuthorization is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductAuthorization
 type MedicinalProductAuthorization struct {
-	Id                          *string                                                    `json:"id,omitempty"`
-	Meta                        *Meta                                                      `json:"meta,omitempty"`
-	ImplicitRules               *string                                                    `json:"implicitRules,omitempty"`
-	Language                    *string                                                    `json:"language,omitempty"`
-	Text                        *Narrative                                                 `json:"text,omitempty"`
-	Extension                   []Extension                                                `json:"extension,omitempty"`
-	ModifierExtension           []Extension                                                `json:"modifierExtension,omitempty"`
-	Identifier                  []Identifier                                               `json:"identifier,omitempty"`
-	Subject                     *Reference                                                 `json:"subject,omitempty"`
-	Country                     []CodeableConcept                                          `json:"country,omitempty"`
-	Jurisdiction                []CodeableConcept                                          `json:"jurisdiction,omitempty"`
-	Status                      *CodeableConcept                                           `json:"status,omitempty"`
-	StatusDate                  *string                                                    `json:"statusDate,omitempty"`
-	RestoreDate                 *string                                                    `json:"restoreDate,omitempty"`
-	ValidityPeriod              *Period                                                    `json:"validityPeriod,omitempty"`
-	DataExclusivityPeriod       *Period                                                    `json:"dataExclusivityPeriod,omitempty"`
-	DateOfFirstAuthorization    *string                                                    `json:"dateOfFirstAuthorization,omitempty"`
-	InternationalBirthDate      *string                                                    `json:"internationalBirthDate,omitempty"`
-	LegalBasis                  *CodeableConcept                                           `json:"legalBasis,omitempty"`
-	JurisdictionalAuthorization []MedicinalProductAuthorizationJurisdictionalAuthorization `json:"jurisdictionalAuthorization,omitempty"`
-	Holder                      *Reference                                                 `json:"holder,omitempty"`
-	Regulator                   *Reference                                                 `json:"regulator,omitempty"`
-	Procedure                   *MedicinalProductAuthorizationProcedure                    `json:"procedure,omitempty"`
+	Id                          *string                                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                        *Meta                                                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules               *string                                                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                    *string                                                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text                        *Narrative                                                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                   []Extension                                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension           []Extension                                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier                  []Identifier                                               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Subject                     *Reference                                                 `bson:"subject,omitempty" json:"subject,omitempty"`
+	Country                     []CodeableConcept                                          `bson:"country,omitempty" json:"country,omitempty"`
+	Jurisdiction                []CodeableConcept                                          `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Status                      *CodeableConcept                                           `bson:"status,omitempty" json:"status,omitempty"`
+	StatusDate                  *string                                                    `bson:"statusDate,omitempty" json:"statusDate,omitempty"`
+	RestoreDate                 *string                                                    `bson:"restoreDate,omitempty" json:"restoreDate,omitempty"`
+	ValidityPeriod              *Period                                                    `bson:"validityPeriod,omitempty" json:"validityPeriod,omitempty"`
+	DataExclusivityPeriod       *Period                                                    `bson:"dataExclusivityPeriod,omitempty" json:"dataExclusivityPeriod,omitempty"`
+	DateOfFirstAuthorization    *string                                                    `bson:"dateOfFirstAuthorization,omitempty" json:"dateOfFirstAuthorization,omitempty"`
+	InternationalBirthDate      *string                                                    `bson:"internationalBirthDate,omitempty" json:"internationalBirthDate,omitempty"`
+	LegalBasis                  *CodeableConcept                                           `bson:"legalBasis,omitempty" json:"legalBasis,omitempty"`
+	JurisdictionalAuthorization []MedicinalProductAuthorizationJurisdictionalAuthorization `bson:"jurisdictionalAuthorization,omitempty" json:"jurisdictionalAuthorization,omitempty"`
+	Holder                      *Reference                                                 `bson:"holder,omitempty" json:"holder,omitempty"`
+	Regulator                   *Reference                                                 `bson:"regulator,omitempty" json:"regulator,omitempty"`
+	Procedure                   *MedicinalProductAuthorizationProcedure                    `bson:"procedure,omitempty" json:"procedure,omitempty"`
 }
 type MedicinalProductAuthorizationJurisdictionalAuthorization struct {
-	Id                  *string           `json:"id,omitempty"`
-	Extension           []Extension       `json:"extension,omitempty"`
-	ModifierExtension   []Extension       `json:"modifierExtension,omitempty"`
-	Identifier          []Identifier      `json:"identifier,omitempty"`
-	Country             *CodeableConcept  `json:"country,omitempty"`
-	Jurisdiction        []CodeableConcept `json:"jurisdiction,omitempty"`
-	LegalStatusOfSupply *CodeableConcept  `json:"legalStatusOfSupply,omitempty"`
-	ValidityPeriod      *Period           `json:"validityPeriod,omitempty"`
+	Id                  *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Country             *CodeableConcept  `bson:"country,omitempty" json:"country,omitempty"`
+	Jurisdiction        []CodeableConcept `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	LegalStatusOfSupply *CodeableConcept  `bson:"legalStatusOfSupply,omitempty" json:"legalStatusOfSupply,omitempty"`
+	ValidityPeriod      *Period           `bson:"validityPeriod,omitempty" json:"validityPeriod,omitempty"`
 }
 type MedicinalProductAuthorizationProcedure struct {
-	Id                *string                                  `json:"id,omitempty"`
-	Extension         []Extension                              `json:"extension,omitempty"`
-	ModifierExtension []Extension                              `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier                              `json:"identifier,omitempty"`
-	Type              CodeableConcept                          `json:"type"`
-	Application       []MedicinalProductAuthorizationProcedure `json:"application,omitempty"`
+	Id                *string                                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier                              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type              CodeableConcept                          `bson:"type" json:"type"`
+	Application       []MedicinalProductAuthorizationProcedure `bson:"application,omitempty" json:"application,omitempty"`
 }
 type OtherMedicinalProductAuthorization MedicinalProductAuthorization
 

--- a/fhir-models/fhir/medicinalProductContraindication.go
+++ b/fhir-models/fhir/medicinalProductContraindication.go
@@ -21,26 +21,26 @@ import "encoding/json"
 
 // MedicinalProductContraindication is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductContraindication
 type MedicinalProductContraindication struct {
-	Id                    *string                                        `json:"id,omitempty"`
-	Meta                  *Meta                                          `json:"meta,omitempty"`
-	ImplicitRules         *string                                        `json:"implicitRules,omitempty"`
-	Language              *string                                        `json:"language,omitempty"`
-	Text                  *Narrative                                     `json:"text,omitempty"`
-	Extension             []Extension                                    `json:"extension,omitempty"`
-	ModifierExtension     []Extension                                    `json:"modifierExtension,omitempty"`
-	Subject               []Reference                                    `json:"subject,omitempty"`
-	Disease               *CodeableConcept                               `json:"disease,omitempty"`
-	DiseaseStatus         *CodeableConcept                               `json:"diseaseStatus,omitempty"`
-	Comorbidity           []CodeableConcept                              `json:"comorbidity,omitempty"`
-	TherapeuticIndication []Reference                                    `json:"therapeuticIndication,omitempty"`
-	OtherTherapy          []MedicinalProductContraindicationOtherTherapy `json:"otherTherapy,omitempty"`
-	Population            []Population                                   `json:"population,omitempty"`
+	Id                    *string                                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Subject               []Reference                                    `bson:"subject,omitempty" json:"subject,omitempty"`
+	Disease               *CodeableConcept                               `bson:"disease,omitempty" json:"disease,omitempty"`
+	DiseaseStatus         *CodeableConcept                               `bson:"diseaseStatus,omitempty" json:"diseaseStatus,omitempty"`
+	Comorbidity           []CodeableConcept                              `bson:"comorbidity,omitempty" json:"comorbidity,omitempty"`
+	TherapeuticIndication []Reference                                    `bson:"therapeuticIndication,omitempty" json:"therapeuticIndication,omitempty"`
+	OtherTherapy          []MedicinalProductContraindicationOtherTherapy `bson:"otherTherapy,omitempty" json:"otherTherapy,omitempty"`
+	Population            []Population                                   `bson:"population,omitempty" json:"population,omitempty"`
 }
 type MedicinalProductContraindicationOtherTherapy struct {
-	Id                      *string         `json:"id,omitempty"`
-	Extension               []Extension     `json:"extension,omitempty"`
-	ModifierExtension       []Extension     `json:"modifierExtension,omitempty"`
-	TherapyRelationshipType CodeableConcept `json:"therapyRelationshipType"`
+	Id                      *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension               []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	TherapyRelationshipType CodeableConcept `bson:"therapyRelationshipType" json:"therapyRelationshipType"`
 }
 type OtherMedicinalProductContraindication MedicinalProductContraindication
 

--- a/fhir-models/fhir/medicinalProductIndication.go
+++ b/fhir-models/fhir/medicinalProductIndication.go
@@ -21,28 +21,28 @@ import "encoding/json"
 
 // MedicinalProductIndication is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductIndication
 type MedicinalProductIndication struct {
-	Id                      *string                                  `json:"id,omitempty"`
-	Meta                    *Meta                                    `json:"meta,omitempty"`
-	ImplicitRules           *string                                  `json:"implicitRules,omitempty"`
-	Language                *string                                  `json:"language,omitempty"`
-	Text                    *Narrative                               `json:"text,omitempty"`
-	Extension               []Extension                              `json:"extension,omitempty"`
-	ModifierExtension       []Extension                              `json:"modifierExtension,omitempty"`
-	Subject                 []Reference                              `json:"subject,omitempty"`
-	DiseaseSymptomProcedure *CodeableConcept                         `json:"diseaseSymptomProcedure,omitempty"`
-	DiseaseStatus           *CodeableConcept                         `json:"diseaseStatus,omitempty"`
-	Comorbidity             []CodeableConcept                        `json:"comorbidity,omitempty"`
-	IntendedEffect          *CodeableConcept                         `json:"intendedEffect,omitempty"`
-	Duration                *Quantity                                `json:"duration,omitempty"`
-	OtherTherapy            []MedicinalProductIndicationOtherTherapy `json:"otherTherapy,omitempty"`
-	UndesirableEffect       []Reference                              `json:"undesirableEffect,omitempty"`
-	Population              []Population                             `json:"population,omitempty"`
+	Id                      *string                                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                    *Meta                                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules           *string                                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                *string                                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text                    *Narrative                               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension               []Extension                              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension                              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Subject                 []Reference                              `bson:"subject,omitempty" json:"subject,omitempty"`
+	DiseaseSymptomProcedure *CodeableConcept                         `bson:"diseaseSymptomProcedure,omitempty" json:"diseaseSymptomProcedure,omitempty"`
+	DiseaseStatus           *CodeableConcept                         `bson:"diseaseStatus,omitempty" json:"diseaseStatus,omitempty"`
+	Comorbidity             []CodeableConcept                        `bson:"comorbidity,omitempty" json:"comorbidity,omitempty"`
+	IntendedEffect          *CodeableConcept                         `bson:"intendedEffect,omitempty" json:"intendedEffect,omitempty"`
+	Duration                *Quantity                                `bson:"duration,omitempty" json:"duration,omitempty"`
+	OtherTherapy            []MedicinalProductIndicationOtherTherapy `bson:"otherTherapy,omitempty" json:"otherTherapy,omitempty"`
+	UndesirableEffect       []Reference                              `bson:"undesirableEffect,omitempty" json:"undesirableEffect,omitempty"`
+	Population              []Population                             `bson:"population,omitempty" json:"population,omitempty"`
 }
 type MedicinalProductIndicationOtherTherapy struct {
-	Id                      *string         `json:"id,omitempty"`
-	Extension               []Extension     `json:"extension,omitempty"`
-	ModifierExtension       []Extension     `json:"modifierExtension,omitempty"`
-	TherapyRelationshipType CodeableConcept `json:"therapyRelationshipType"`
+	Id                      *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension               []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	TherapyRelationshipType CodeableConcept `bson:"therapyRelationshipType" json:"therapyRelationshipType"`
 }
 type OtherMedicinalProductIndication MedicinalProductIndication
 

--- a/fhir-models/fhir/medicinalProductIngredient.go
+++ b/fhir-models/fhir/medicinalProductIngredient.go
@@ -21,57 +21,57 @@ import "encoding/json"
 
 // MedicinalProductIngredient is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductIngredient
 type MedicinalProductIngredient struct {
-	Id                  *string                                        `json:"id,omitempty"`
-	Meta                *Meta                                          `json:"meta,omitempty"`
-	ImplicitRules       *string                                        `json:"implicitRules,omitempty"`
-	Language            *string                                        `json:"language,omitempty"`
-	Text                *Narrative                                     `json:"text,omitempty"`
-	Extension           []Extension                                    `json:"extension,omitempty"`
-	ModifierExtension   []Extension                                    `json:"modifierExtension,omitempty"`
-	Identifier          *Identifier                                    `json:"identifier,omitempty"`
-	Role                CodeableConcept                                `json:"role"`
-	AllergenicIndicator *bool                                          `json:"allergenicIndicator,omitempty"`
-	Manufacturer        []Reference                                    `json:"manufacturer,omitempty"`
-	SpecifiedSubstance  []MedicinalProductIngredientSpecifiedSubstance `json:"specifiedSubstance,omitempty"`
-	Substance           *MedicinalProductIngredientSubstance           `json:"substance,omitempty"`
+	Id                  *string                                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string                                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string                                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative                                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension                                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          *Identifier                                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Role                CodeableConcept                                `bson:"role" json:"role"`
+	AllergenicIndicator *bool                                          `bson:"allergenicIndicator,omitempty" json:"allergenicIndicator,omitempty"`
+	Manufacturer        []Reference                                    `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	SpecifiedSubstance  []MedicinalProductIngredientSpecifiedSubstance `bson:"specifiedSubstance,omitempty" json:"specifiedSubstance,omitempty"`
+	Substance           *MedicinalProductIngredientSubstance           `bson:"substance,omitempty" json:"substance,omitempty"`
 }
 type MedicinalProductIngredientSpecifiedSubstance struct {
-	Id                *string                                                `json:"id,omitempty"`
-	Extension         []Extension                                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                                            `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept                                        `json:"code"`
-	Group             CodeableConcept                                        `json:"group"`
-	Confidentiality   *CodeableConcept                                       `json:"confidentiality,omitempty"`
-	Strength          []MedicinalProductIngredientSpecifiedSubstanceStrength `json:"strength,omitempty"`
+	Id                *string                                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept                                        `bson:"code" json:"code"`
+	Group             CodeableConcept                                        `bson:"group" json:"group"`
+	Confidentiality   *CodeableConcept                                       `bson:"confidentiality,omitempty" json:"confidentiality,omitempty"`
+	Strength          []MedicinalProductIngredientSpecifiedSubstanceStrength `bson:"strength,omitempty" json:"strength,omitempty"`
 }
 type MedicinalProductIngredientSpecifiedSubstanceStrength struct {
-	Id                    *string                                                                 `json:"id,omitempty"`
-	Extension             []Extension                                                             `json:"extension,omitempty"`
-	ModifierExtension     []Extension                                                             `json:"modifierExtension,omitempty"`
-	Presentation          Ratio                                                                   `json:"presentation"`
-	PresentationLowLimit  *Ratio                                                                  `json:"presentationLowLimit,omitempty"`
-	Concentration         *Ratio                                                                  `json:"concentration,omitempty"`
-	ConcentrationLowLimit *Ratio                                                                  `json:"concentrationLowLimit,omitempty"`
-	MeasurementPoint      *string                                                                 `json:"measurementPoint,omitempty"`
-	Country               []CodeableConcept                                                       `json:"country,omitempty"`
-	ReferenceStrength     []MedicinalProductIngredientSpecifiedSubstanceStrengthReferenceStrength `json:"referenceStrength,omitempty"`
+	Id                    *string                                                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension             []Extension                                                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                                                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Presentation          Ratio                                                                   `bson:"presentation" json:"presentation"`
+	PresentationLowLimit  *Ratio                                                                  `bson:"presentationLowLimit,omitempty" json:"presentationLowLimit,omitempty"`
+	Concentration         *Ratio                                                                  `bson:"concentration,omitempty" json:"concentration,omitempty"`
+	ConcentrationLowLimit *Ratio                                                                  `bson:"concentrationLowLimit,omitempty" json:"concentrationLowLimit,omitempty"`
+	MeasurementPoint      *string                                                                 `bson:"measurementPoint,omitempty" json:"measurementPoint,omitempty"`
+	Country               []CodeableConcept                                                       `bson:"country,omitempty" json:"country,omitempty"`
+	ReferenceStrength     []MedicinalProductIngredientSpecifiedSubstanceStrengthReferenceStrength `bson:"referenceStrength,omitempty" json:"referenceStrength,omitempty"`
 }
 type MedicinalProductIngredientSpecifiedSubstanceStrengthReferenceStrength struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Substance         *CodeableConcept  `json:"substance,omitempty"`
-	Strength          Ratio             `json:"strength"`
-	StrengthLowLimit  *Ratio            `json:"strengthLowLimit,omitempty"`
-	MeasurementPoint  *string           `json:"measurementPoint,omitempty"`
-	Country           []CodeableConcept `json:"country,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Substance         *CodeableConcept  `bson:"substance,omitempty" json:"substance,omitempty"`
+	Strength          Ratio             `bson:"strength" json:"strength"`
+	StrengthLowLimit  *Ratio            `bson:"strengthLowLimit,omitempty" json:"strengthLowLimit,omitempty"`
+	MeasurementPoint  *string           `bson:"measurementPoint,omitempty" json:"measurementPoint,omitempty"`
+	Country           []CodeableConcept `bson:"country,omitempty" json:"country,omitempty"`
 }
 type MedicinalProductIngredientSubstance struct {
-	Id                *string                                                `json:"id,omitempty"`
-	Extension         []Extension                                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                                            `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept                                        `json:"code"`
-	Strength          []MedicinalProductIngredientSpecifiedSubstanceStrength `json:"strength,omitempty"`
+	Id                *string                                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept                                        `bson:"code" json:"code"`
+	Strength          []MedicinalProductIngredientSpecifiedSubstanceStrength `bson:"strength,omitempty" json:"strength,omitempty"`
 }
 type OtherMedicinalProductIngredient MedicinalProductIngredient
 

--- a/fhir-models/fhir/medicinalProductInteraction.go
+++ b/fhir-models/fhir/medicinalProductInteraction.go
@@ -21,25 +21,25 @@ import "encoding/json"
 
 // MedicinalProductInteraction is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductInteraction
 type MedicinalProductInteraction struct {
-	Id                *string                                  `json:"id,omitempty"`
-	Meta              *Meta                                    `json:"meta,omitempty"`
-	ImplicitRules     *string                                  `json:"implicitRules,omitempty"`
-	Language          *string                                  `json:"language,omitempty"`
-	Text              *Narrative                               `json:"text,omitempty"`
-	Extension         []Extension                              `json:"extension,omitempty"`
-	ModifierExtension []Extension                              `json:"modifierExtension,omitempty"`
-	Subject           []Reference                              `json:"subject,omitempty"`
-	Description       *string                                  `json:"description,omitempty"`
-	Interactant       []MedicinalProductInteractionInteractant `json:"interactant,omitempty"`
-	Type              *CodeableConcept                         `json:"type,omitempty"`
-	Effect            *CodeableConcept                         `json:"effect,omitempty"`
-	Incidence         *CodeableConcept                         `json:"incidence,omitempty"`
-	Management        *CodeableConcept                         `json:"management,omitempty"`
+	Id                *string                                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Subject           []Reference                              `bson:"subject,omitempty" json:"subject,omitempty"`
+	Description       *string                                  `bson:"description,omitempty" json:"description,omitempty"`
+	Interactant       []MedicinalProductInteractionInteractant `bson:"interactant,omitempty" json:"interactant,omitempty"`
+	Type              *CodeableConcept                         `bson:"type,omitempty" json:"type,omitempty"`
+	Effect            *CodeableConcept                         `bson:"effect,omitempty" json:"effect,omitempty"`
+	Incidence         *CodeableConcept                         `bson:"incidence,omitempty" json:"incidence,omitempty"`
+	Management        *CodeableConcept                         `bson:"management,omitempty" json:"management,omitempty"`
 }
 type MedicinalProductInteractionInteractant struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherMedicinalProductInteraction MedicinalProductInteraction
 

--- a/fhir-models/fhir/medicinalProductManufactured.go
+++ b/fhir-models/fhir/medicinalProductManufactured.go
@@ -21,20 +21,20 @@ import "encoding/json"
 
 // MedicinalProductManufactured is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductManufactured
 type MedicinalProductManufactured struct {
-	Id                      *string             `json:"id,omitempty"`
-	Meta                    *Meta               `json:"meta,omitempty"`
-	ImplicitRules           *string             `json:"implicitRules,omitempty"`
-	Language                *string             `json:"language,omitempty"`
-	Text                    *Narrative          `json:"text,omitempty"`
-	Extension               []Extension         `json:"extension,omitempty"`
-	ModifierExtension       []Extension         `json:"modifierExtension,omitempty"`
-	ManufacturedDoseForm    CodeableConcept     `json:"manufacturedDoseForm"`
-	UnitOfPresentation      *CodeableConcept    `json:"unitOfPresentation,omitempty"`
-	Quantity                Quantity            `json:"quantity"`
-	Manufacturer            []Reference         `json:"manufacturer,omitempty"`
-	Ingredient              []Reference         `json:"ingredient,omitempty"`
-	PhysicalCharacteristics *ProdCharacteristic `json:"physicalCharacteristics,omitempty"`
-	OtherCharacteristics    []CodeableConcept   `json:"otherCharacteristics,omitempty"`
+	Id                      *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                    *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules           *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text                    *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension               []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ManufacturedDoseForm    CodeableConcept     `bson:"manufacturedDoseForm" json:"manufacturedDoseForm"`
+	UnitOfPresentation      *CodeableConcept    `bson:"unitOfPresentation,omitempty" json:"unitOfPresentation,omitempty"`
+	Quantity                Quantity            `bson:"quantity" json:"quantity"`
+	Manufacturer            []Reference         `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	Ingredient              []Reference         `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
+	PhysicalCharacteristics *ProdCharacteristic `bson:"physicalCharacteristics,omitempty" json:"physicalCharacteristics,omitempty"`
+	OtherCharacteristics    []CodeableConcept   `bson:"otherCharacteristics,omitempty" json:"otherCharacteristics,omitempty"`
 }
 type OtherMedicinalProductManufactured MedicinalProductManufactured
 

--- a/fhir-models/fhir/medicinalProductPackaged.go
+++ b/fhir-models/fhir/medicinalProductPackaged.go
@@ -21,46 +21,46 @@ import "encoding/json"
 
 // MedicinalProductPackaged is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductPackaged
 type MedicinalProductPackaged struct {
-	Id                     *string                                   `json:"id,omitempty"`
-	Meta                   *Meta                                     `json:"meta,omitempty"`
-	ImplicitRules          *string                                   `json:"implicitRules,omitempty"`
-	Language               *string                                   `json:"language,omitempty"`
-	Text                   *Narrative                                `json:"text,omitempty"`
-	Extension              []Extension                               `json:"extension,omitempty"`
-	ModifierExtension      []Extension                               `json:"modifierExtension,omitempty"`
-	Identifier             []Identifier                              `json:"identifier,omitempty"`
-	Subject                []Reference                               `json:"subject,omitempty"`
-	Description            *string                                   `json:"description,omitempty"`
-	LegalStatusOfSupply    *CodeableConcept                          `json:"legalStatusOfSupply,omitempty"`
-	MarketingStatus        []MarketingStatus                         `json:"marketingStatus,omitempty"`
-	MarketingAuthorization *Reference                                `json:"marketingAuthorization,omitempty"`
-	Manufacturer           []Reference                               `json:"manufacturer,omitempty"`
-	BatchIdentifier        []MedicinalProductPackagedBatchIdentifier `json:"batchIdentifier,omitempty"`
-	PackageItem            []MedicinalProductPackagedPackageItem     `json:"packageItem"`
+	Id                     *string                                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string                                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string                                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative                                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension                               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier             []Identifier                              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Subject                []Reference                               `bson:"subject,omitempty" json:"subject,omitempty"`
+	Description            *string                                   `bson:"description,omitempty" json:"description,omitempty"`
+	LegalStatusOfSupply    *CodeableConcept                          `bson:"legalStatusOfSupply,omitempty" json:"legalStatusOfSupply,omitempty"`
+	MarketingStatus        []MarketingStatus                         `bson:"marketingStatus,omitempty" json:"marketingStatus,omitempty"`
+	MarketingAuthorization *Reference                                `bson:"marketingAuthorization,omitempty" json:"marketingAuthorization,omitempty"`
+	Manufacturer           []Reference                               `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
+	BatchIdentifier        []MedicinalProductPackagedBatchIdentifier `bson:"batchIdentifier,omitempty" json:"batchIdentifier,omitempty"`
+	PackageItem            []MedicinalProductPackagedPackageItem     `bson:"packageItem" json:"packageItem"`
 }
 type MedicinalProductPackagedBatchIdentifier struct {
-	Id                 *string     `json:"id,omitempty"`
-	Extension          []Extension `json:"extension,omitempty"`
-	ModifierExtension  []Extension `json:"modifierExtension,omitempty"`
-	OuterPackaging     Identifier  `json:"outerPackaging"`
-	ImmediatePackaging *Identifier `json:"immediatePackaging,omitempty"`
+	Id                 *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	OuterPackaging     Identifier  `bson:"outerPackaging" json:"outerPackaging"`
+	ImmediatePackaging *Identifier `bson:"immediatePackaging,omitempty" json:"immediatePackaging,omitempty"`
 }
 type MedicinalProductPackagedPackageItem struct {
-	Id                      *string                               `json:"id,omitempty"`
-	Extension               []Extension                           `json:"extension,omitempty"`
-	ModifierExtension       []Extension                           `json:"modifierExtension,omitempty"`
-	Identifier              []Identifier                          `json:"identifier,omitempty"`
-	Type                    CodeableConcept                       `json:"type"`
-	Quantity                Quantity                              `json:"quantity"`
-	Material                []CodeableConcept                     `json:"material,omitempty"`
-	AlternateMaterial       []CodeableConcept                     `json:"alternateMaterial,omitempty"`
-	Device                  []Reference                           `json:"device,omitempty"`
-	ManufacturedItem        []Reference                           `json:"manufacturedItem,omitempty"`
-	PackageItem             []MedicinalProductPackagedPackageItem `json:"packageItem,omitempty"`
-	PhysicalCharacteristics *ProdCharacteristic                   `json:"physicalCharacteristics,omitempty"`
-	OtherCharacteristics    []CodeableConcept                     `json:"otherCharacteristics,omitempty"`
-	ShelfLifeStorage        []ProductShelfLife                    `json:"shelfLifeStorage,omitempty"`
-	Manufacturer            []Reference                           `json:"manufacturer,omitempty"`
+	Id                      *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension               []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier              []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type                    CodeableConcept                       `bson:"type" json:"type"`
+	Quantity                Quantity                              `bson:"quantity" json:"quantity"`
+	Material                []CodeableConcept                     `bson:"material,omitempty" json:"material,omitempty"`
+	AlternateMaterial       []CodeableConcept                     `bson:"alternateMaterial,omitempty" json:"alternateMaterial,omitempty"`
+	Device                  []Reference                           `bson:"device,omitempty" json:"device,omitempty"`
+	ManufacturedItem        []Reference                           `bson:"manufacturedItem,omitempty" json:"manufacturedItem,omitempty"`
+	PackageItem             []MedicinalProductPackagedPackageItem `bson:"packageItem,omitempty" json:"packageItem,omitempty"`
+	PhysicalCharacteristics *ProdCharacteristic                   `bson:"physicalCharacteristics,omitempty" json:"physicalCharacteristics,omitempty"`
+	OtherCharacteristics    []CodeableConcept                     `bson:"otherCharacteristics,omitempty" json:"otherCharacteristics,omitempty"`
+	ShelfLifeStorage        []ProductShelfLife                    `bson:"shelfLifeStorage,omitempty" json:"shelfLifeStorage,omitempty"`
+	Manufacturer            []Reference                           `bson:"manufacturer,omitempty" json:"manufacturer,omitempty"`
 }
 type OtherMedicinalProductPackaged MedicinalProductPackaged
 

--- a/fhir-models/fhir/medicinalProductPharmaceutical.go
+++ b/fhir-models/fhir/medicinalProductPharmaceutical.go
@@ -21,54 +21,54 @@ import "encoding/json"
 
 // MedicinalProductPharmaceutical is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductPharmaceutical
 type MedicinalProductPharmaceutical struct {
-	Id                    *string                                               `json:"id,omitempty"`
-	Meta                  *Meta                                                 `json:"meta,omitempty"`
-	ImplicitRules         *string                                               `json:"implicitRules,omitempty"`
-	Language              *string                                               `json:"language,omitempty"`
-	Text                  *Narrative                                            `json:"text,omitempty"`
-	Extension             []Extension                                           `json:"extension,omitempty"`
-	ModifierExtension     []Extension                                           `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier                                          `json:"identifier,omitempty"`
-	AdministrableDoseForm CodeableConcept                                       `json:"administrableDoseForm"`
-	UnitOfPresentation    *CodeableConcept                                      `json:"unitOfPresentation,omitempty"`
-	Ingredient            []Reference                                           `json:"ingredient,omitempty"`
-	Device                []Reference                                           `json:"device,omitempty"`
-	Characteristics       []MedicinalProductPharmaceuticalCharacteristics       `json:"characteristics,omitempty"`
-	RouteOfAdministration []MedicinalProductPharmaceuticalRouteOfAdministration `json:"routeOfAdministration"`
+	Id                    *string                                               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                                                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                                               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                                               `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                                            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier                                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	AdministrableDoseForm CodeableConcept                                       `bson:"administrableDoseForm" json:"administrableDoseForm"`
+	UnitOfPresentation    *CodeableConcept                                      `bson:"unitOfPresentation,omitempty" json:"unitOfPresentation,omitempty"`
+	Ingredient            []Reference                                           `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
+	Device                []Reference                                           `bson:"device,omitempty" json:"device,omitempty"`
+	Characteristics       []MedicinalProductPharmaceuticalCharacteristics       `bson:"characteristics,omitempty" json:"characteristics,omitempty"`
+	RouteOfAdministration []MedicinalProductPharmaceuticalRouteOfAdministration `bson:"routeOfAdministration" json:"routeOfAdministration"`
 }
 type MedicinalProductPharmaceuticalCharacteristics struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept  `json:"code"`
-	Status            *CodeableConcept `json:"status,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept  `bson:"code" json:"code"`
+	Status            *CodeableConcept `bson:"status,omitempty" json:"status,omitempty"`
 }
 type MedicinalProductPharmaceuticalRouteOfAdministration struct {
-	Id                        *string                                                            `json:"id,omitempty"`
-	Extension                 []Extension                                                        `json:"extension,omitempty"`
-	ModifierExtension         []Extension                                                        `json:"modifierExtension,omitempty"`
-	Code                      CodeableConcept                                                    `json:"code"`
-	FirstDose                 *Quantity                                                          `json:"firstDose,omitempty"`
-	MaxSingleDose             *Quantity                                                          `json:"maxSingleDose,omitempty"`
-	MaxDosePerDay             *Quantity                                                          `json:"maxDosePerDay,omitempty"`
-	MaxDosePerTreatmentPeriod *Ratio                                                             `json:"maxDosePerTreatmentPeriod,omitempty"`
-	MaxTreatmentPeriod        *Duration                                                          `json:"maxTreatmentPeriod,omitempty"`
-	TargetSpecies             []MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpecies `json:"targetSpecies,omitempty"`
+	Id                        *string                                                            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                 []Extension                                                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension         []Extension                                                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code                      CodeableConcept                                                    `bson:"code" json:"code"`
+	FirstDose                 *Quantity                                                          `bson:"firstDose,omitempty" json:"firstDose,omitempty"`
+	MaxSingleDose             *Quantity                                                          `bson:"maxSingleDose,omitempty" json:"maxSingleDose,omitempty"`
+	MaxDosePerDay             *Quantity                                                          `bson:"maxDosePerDay,omitempty" json:"maxDosePerDay,omitempty"`
+	MaxDosePerTreatmentPeriod *Ratio                                                             `bson:"maxDosePerTreatmentPeriod,omitempty" json:"maxDosePerTreatmentPeriod,omitempty"`
+	MaxTreatmentPeriod        *Duration                                                          `bson:"maxTreatmentPeriod,omitempty" json:"maxTreatmentPeriod,omitempty"`
+	TargetSpecies             []MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpecies `bson:"targetSpecies,omitempty" json:"targetSpecies,omitempty"`
 }
 type MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpecies struct {
-	Id                *string                                                                            `json:"id,omitempty"`
-	Extension         []Extension                                                                        `json:"extension,omitempty"`
-	ModifierExtension []Extension                                                                        `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept                                                                    `json:"code"`
-	WithdrawalPeriod  []MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpeciesWithdrawalPeriod `json:"withdrawalPeriod,omitempty"`
+	Id                *string                                                                            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                                                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                                                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept                                                                    `bson:"code" json:"code"`
+	WithdrawalPeriod  []MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpeciesWithdrawalPeriod `bson:"withdrawalPeriod,omitempty" json:"withdrawalPeriod,omitempty"`
 }
 type MedicinalProductPharmaceuticalRouteOfAdministrationTargetSpeciesWithdrawalPeriod struct {
-	Id                    *string         `json:"id,omitempty"`
-	Extension             []Extension     `json:"extension,omitempty"`
-	ModifierExtension     []Extension     `json:"modifierExtension,omitempty"`
-	Tissue                CodeableConcept `json:"tissue"`
-	Value                 Quantity        `json:"value"`
-	SupportingInformation *string         `json:"supportingInformation,omitempty"`
+	Id                    *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension             []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Tissue                CodeableConcept `bson:"tissue" json:"tissue"`
+	Value                 Quantity        `bson:"value" json:"value"`
+	SupportingInformation *string         `bson:"supportingInformation,omitempty" json:"supportingInformation,omitempty"`
 }
 type OtherMedicinalProductPharmaceutical MedicinalProductPharmaceutical
 

--- a/fhir-models/fhir/medicinalProductUndesirableEffect.go
+++ b/fhir-models/fhir/medicinalProductUndesirableEffect.go
@@ -21,18 +21,18 @@ import "encoding/json"
 
 // MedicinalProductUndesirableEffect is documented here http://hl7.org/fhir/StructureDefinition/MedicinalProductUndesirableEffect
 type MedicinalProductUndesirableEffect struct {
-	Id                     *string          `json:"id,omitempty"`
-	Meta                   *Meta            `json:"meta,omitempty"`
-	ImplicitRules          *string          `json:"implicitRules,omitempty"`
-	Language               *string          `json:"language,omitempty"`
-	Text                   *Narrative       `json:"text,omitempty"`
-	Extension              []Extension      `json:"extension,omitempty"`
-	ModifierExtension      []Extension      `json:"modifierExtension,omitempty"`
-	Subject                []Reference      `json:"subject,omitempty"`
-	SymptomConditionEffect *CodeableConcept `json:"symptomConditionEffect,omitempty"`
-	Classification         *CodeableConcept `json:"classification,omitempty"`
-	FrequencyOfOccurrence  *CodeableConcept `json:"frequencyOfOccurrence,omitempty"`
-	Population             []Population     `json:"population,omitempty"`
+	Id                     *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string          `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Subject                []Reference      `bson:"subject,omitempty" json:"subject,omitempty"`
+	SymptomConditionEffect *CodeableConcept `bson:"symptomConditionEffect,omitempty" json:"symptomConditionEffect,omitempty"`
+	Classification         *CodeableConcept `bson:"classification,omitempty" json:"classification,omitempty"`
+	FrequencyOfOccurrence  *CodeableConcept `bson:"frequencyOfOccurrence,omitempty" json:"frequencyOfOccurrence,omitempty"`
+	Population             []Population     `bson:"population,omitempty" json:"population,omitempty"`
 }
 type OtherMedicinalProductUndesirableEffect MedicinalProductUndesirableEffect
 

--- a/fhir-models/fhir/messageDefinition.go
+++ b/fhir-models/fhir/messageDefinition.go
@@ -21,52 +21,52 @@ import "encoding/json"
 
 // MessageDefinition is documented here http://hl7.org/fhir/StructureDefinition/MessageDefinition
 type MessageDefinition struct {
-	Id                *string                            `json:"id,omitempty"`
-	Meta              *Meta                              `json:"meta,omitempty"`
-	ImplicitRules     *string                            `json:"implicitRules,omitempty"`
-	Language          *string                            `json:"language,omitempty"`
-	Text              *Narrative                         `json:"text,omitempty"`
-	Extension         []Extension                        `json:"extension,omitempty"`
-	ModifierExtension []Extension                        `json:"modifierExtension,omitempty"`
-	Url               *string                            `json:"url,omitempty"`
-	Identifier        []Identifier                       `json:"identifier,omitempty"`
-	Version           *string                            `json:"version,omitempty"`
-	Name              *string                            `json:"name,omitempty"`
-	Title             *string                            `json:"title,omitempty"`
-	Replaces          []string                           `json:"replaces,omitempty"`
-	Status            PublicationStatus                  `json:"status"`
-	Experimental      *bool                              `json:"experimental,omitempty"`
-	Date              string                             `json:"date"`
-	Publisher         *string                            `json:"publisher,omitempty"`
-	Contact           []ContactDetail                    `json:"contact,omitempty"`
-	Description       *string                            `json:"description,omitempty"`
-	UseContext        []UsageContext                     `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                  `json:"jurisdiction,omitempty"`
-	Purpose           *string                            `json:"purpose,omitempty"`
-	Copyright         *string                            `json:"copyright,omitempty"`
-	Base              *string                            `json:"base,omitempty"`
-	Parent            []string                           `json:"parent,omitempty"`
-	Category          *MessageSignificanceCategory       `json:"category,omitempty"`
-	Focus             []MessageDefinitionFocus           `json:"focus,omitempty"`
-	ResponseRequired  *string                            `json:"responseRequired,omitempty"`
-	AllowedResponse   []MessageDefinitionAllowedResponse `json:"allowedResponse,omitempty"`
-	Graph             []string                           `json:"graph,omitempty"`
+	Id                *string                            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                            `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                            `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                            `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                            `bson:"title,omitempty" json:"title,omitempty"`
+	Replaces          []string                           `bson:"replaces,omitempty" json:"replaces,omitempty"`
+	Status            PublicationStatus                  `bson:"status" json:"status"`
+	Experimental      *bool                              `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              string                             `bson:"date" json:"date"`
+	Publisher         *string                            `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                            `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                     `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                  `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                            `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                            `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Base              *string                            `bson:"base,omitempty" json:"base,omitempty"`
+	Parent            []string                           `bson:"parent,omitempty" json:"parent,omitempty"`
+	Category          *MessageSignificanceCategory       `bson:"category,omitempty" json:"category,omitempty"`
+	Focus             []MessageDefinitionFocus           `bson:"focus,omitempty" json:"focus,omitempty"`
+	ResponseRequired  *string                            `bson:"responseRequired,omitempty" json:"responseRequired,omitempty"`
+	AllowedResponse   []MessageDefinitionAllowedResponse `bson:"allowedResponse,omitempty" json:"allowedResponse,omitempty"`
+	Graph             []string                           `bson:"graph,omitempty" json:"graph,omitempty"`
 }
 type MessageDefinitionFocus struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Code              ResourceType `json:"code"`
-	Profile           *string      `json:"profile,omitempty"`
-	Min               int          `json:"min"`
-	Max               *string      `json:"max,omitempty"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              ResourceType `bson:"code" json:"code"`
+	Profile           *string      `bson:"profile,omitempty" json:"profile,omitempty"`
+	Min               int          `bson:"min" json:"min"`
+	Max               *string      `bson:"max,omitempty" json:"max,omitempty"`
 }
 type MessageDefinitionAllowedResponse struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Message           string      `json:"message"`
-	Situation         *string     `json:"situation,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Message           string      `bson:"message" json:"message"`
+	Situation         *string     `bson:"situation,omitempty" json:"situation,omitempty"`
 }
 type OtherMessageDefinition MessageDefinition
 

--- a/fhir-models/fhir/messageHeader.go
+++ b/fhir-models/fhir/messageHeader.go
@@ -21,50 +21,50 @@ import "encoding/json"
 
 // MessageHeader is documented here http://hl7.org/fhir/StructureDefinition/MessageHeader
 type MessageHeader struct {
-	Id                *string                    `json:"id,omitempty"`
-	Meta              *Meta                      `json:"meta,omitempty"`
-	ImplicitRules     *string                    `json:"implicitRules,omitempty"`
-	Language          *string                    `json:"language,omitempty"`
-	Text              *Narrative                 `json:"text,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Destination       []MessageHeaderDestination `json:"destination,omitempty"`
-	Sender            *Reference                 `json:"sender,omitempty"`
-	Enterer           *Reference                 `json:"enterer,omitempty"`
-	Author            *Reference                 `json:"author,omitempty"`
-	Source            MessageHeaderSource        `json:"source"`
-	Responsible       *Reference                 `json:"responsible,omitempty"`
-	Reason            *CodeableConcept           `json:"reason,omitempty"`
-	Response          *MessageHeaderResponse     `json:"response,omitempty"`
-	Focus             []Reference                `json:"focus,omitempty"`
-	Definition        *string                    `json:"definition,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Destination       []MessageHeaderDestination `bson:"destination,omitempty" json:"destination,omitempty"`
+	Sender            *Reference                 `bson:"sender,omitempty" json:"sender,omitempty"`
+	Enterer           *Reference                 `bson:"enterer,omitempty" json:"enterer,omitempty"`
+	Author            *Reference                 `bson:"author,omitempty" json:"author,omitempty"`
+	Source            MessageHeaderSource        `bson:"source" json:"source"`
+	Responsible       *Reference                 `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Reason            *CodeableConcept           `bson:"reason,omitempty" json:"reason,omitempty"`
+	Response          *MessageHeaderResponse     `bson:"response,omitempty" json:"response,omitempty"`
+	Focus             []Reference                `bson:"focus,omitempty" json:"focus,omitempty"`
+	Definition        *string                    `bson:"definition,omitempty" json:"definition,omitempty"`
 }
 type MessageHeaderDestination struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              *string     `json:"name,omitempty"`
-	Target            *Reference  `json:"target,omitempty"`
-	Endpoint          string      `json:"endpoint"`
-	Receiver          *Reference  `json:"receiver,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              *string     `bson:"name,omitempty" json:"name,omitempty"`
+	Target            *Reference  `bson:"target,omitempty" json:"target,omitempty"`
+	Endpoint          string      `bson:"endpoint" json:"endpoint"`
+	Receiver          *Reference  `bson:"receiver,omitempty" json:"receiver,omitempty"`
 }
 type MessageHeaderSource struct {
-	Id                *string       `json:"id,omitempty"`
-	Extension         []Extension   `json:"extension,omitempty"`
-	ModifierExtension []Extension   `json:"modifierExtension,omitempty"`
-	Name              *string       `json:"name,omitempty"`
-	Software          *string       `json:"software,omitempty"`
-	Version           *string       `json:"version,omitempty"`
-	Contact           *ContactPoint `json:"contact,omitempty"`
-	Endpoint          string        `json:"endpoint"`
+	Id                *string       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              *string       `bson:"name,omitempty" json:"name,omitempty"`
+	Software          *string       `bson:"software,omitempty" json:"software,omitempty"`
+	Version           *string       `bson:"version,omitempty" json:"version,omitempty"`
+	Contact           *ContactPoint `bson:"contact,omitempty" json:"contact,omitempty"`
+	Endpoint          string        `bson:"endpoint" json:"endpoint"`
 }
 type MessageHeaderResponse struct {
-	Id                *string      `json:"id,omitempty"`
-	Extension         []Extension  `json:"extension,omitempty"`
-	ModifierExtension []Extension  `json:"modifierExtension,omitempty"`
-	Identifier        string       `json:"identifier"`
-	Code              ResponseType `json:"code"`
-	Details           *Reference   `json:"details,omitempty"`
+	Id                *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        string       `bson:"identifier" json:"identifier"`
+	Code              ResponseType `bson:"code" json:"code"`
+	Details           *Reference   `bson:"details,omitempty" json:"details,omitempty"`
 }
 type OtherMessageHeader MessageHeader
 

--- a/fhir-models/fhir/meta.go
+++ b/fhir-models/fhir/meta.go
@@ -19,12 +19,12 @@ package fhir
 
 // Meta is documented here http://hl7.org/fhir/StructureDefinition/Meta
 type Meta struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	VersionId   *string     `json:"versionId,omitempty"`
-	LastUpdated *string     `json:"lastUpdated,omitempty"`
-	Source      *string     `json:"source,omitempty"`
-	Profile     []string    `json:"profile,omitempty"`
-	Security    []Coding    `json:"security,omitempty"`
-	Tag         []Coding    `json:"tag,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	VersionId   *string     `bson:"versionId,omitempty" json:"versionId,omitempty"`
+	LastUpdated *string     `bson:"lastUpdated,omitempty" json:"lastUpdated,omitempty"`
+	Source      *string     `bson:"source,omitempty" json:"source,omitempty"`
+	Profile     []string    `bson:"profile,omitempty" json:"profile,omitempty"`
+	Security    []Coding    `bson:"security,omitempty" json:"security,omitempty"`
+	Tag         []Coding    `bson:"tag,omitempty" json:"tag,omitempty"`
 }

--- a/fhir-models/fhir/molecularSequence.go
+++ b/fhir-models/fhir/molecularSequence.go
@@ -21,121 +21,121 @@ import "encoding/json"
 
 // MolecularSequence is documented here http://hl7.org/fhir/StructureDefinition/MolecularSequence
 type MolecularSequence struct {
-	Id                *string                             `json:"id,omitempty"`
-	Meta              *Meta                               `json:"meta,omitempty"`
-	ImplicitRules     *string                             `json:"implicitRules,omitempty"`
-	Language          *string                             `json:"language,omitempty"`
-	Text              *Narrative                          `json:"text,omitempty"`
-	Extension         []Extension                         `json:"extension,omitempty"`
-	ModifierExtension []Extension                         `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                        `json:"identifier,omitempty"`
-	Type              *string                             `json:"type,omitempty"`
-	CoordinateSystem  int                                 `json:"coordinateSystem"`
-	Patient           *Reference                          `json:"patient,omitempty"`
-	Specimen          *Reference                          `json:"specimen,omitempty"`
-	Device            *Reference                          `json:"device,omitempty"`
-	Performer         *Reference                          `json:"performer,omitempty"`
-	Quantity          *Quantity                           `json:"quantity,omitempty"`
-	ReferenceSeq      *MolecularSequenceReferenceSeq      `json:"referenceSeq,omitempty"`
-	Variant           []MolecularSequenceVariant          `json:"variant,omitempty"`
-	ObservedSeq       *string                             `json:"observedSeq,omitempty"`
-	Quality           []MolecularSequenceQuality          `json:"quality,omitempty"`
-	ReadCoverage      *int                                `json:"readCoverage,omitempty"`
-	Repository        []MolecularSequenceRepository       `json:"repository,omitempty"`
-	Pointer           []Reference                         `json:"pointer,omitempty"`
-	StructureVariant  []MolecularSequenceStructureVariant `json:"structureVariant,omitempty"`
+	Id                *string                             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type              *string                             `bson:"type,omitempty" json:"type,omitempty"`
+	CoordinateSystem  int                                 `bson:"coordinateSystem" json:"coordinateSystem"`
+	Patient           *Reference                          `bson:"patient,omitempty" json:"patient,omitempty"`
+	Specimen          *Reference                          `bson:"specimen,omitempty" json:"specimen,omitempty"`
+	Device            *Reference                          `bson:"device,omitempty" json:"device,omitempty"`
+	Performer         *Reference                          `bson:"performer,omitempty" json:"performer,omitempty"`
+	Quantity          *Quantity                           `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	ReferenceSeq      *MolecularSequenceReferenceSeq      `bson:"referenceSeq,omitempty" json:"referenceSeq,omitempty"`
+	Variant           []MolecularSequenceVariant          `bson:"variant,omitempty" json:"variant,omitempty"`
+	ObservedSeq       *string                             `bson:"observedSeq,omitempty" json:"observedSeq,omitempty"`
+	Quality           []MolecularSequenceQuality          `bson:"quality,omitempty" json:"quality,omitempty"`
+	ReadCoverage      *int                                `bson:"readCoverage,omitempty" json:"readCoverage,omitempty"`
+	Repository        []MolecularSequenceRepository       `bson:"repository,omitempty" json:"repository,omitempty"`
+	Pointer           []Reference                         `bson:"pointer,omitempty" json:"pointer,omitempty"`
+	StructureVariant  []MolecularSequenceStructureVariant `bson:"structureVariant,omitempty" json:"structureVariant,omitempty"`
 }
 type MolecularSequenceReferenceSeq struct {
-	Id                  *string          `json:"id,omitempty"`
-	Extension           []Extension      `json:"extension,omitempty"`
-	ModifierExtension   []Extension      `json:"modifierExtension,omitempty"`
-	Chromosome          *CodeableConcept `json:"chromosome,omitempty"`
-	GenomeBuild         *string          `json:"genomeBuild,omitempty"`
-	Orientation         *string          `json:"orientation,omitempty"`
-	ReferenceSeqId      *CodeableConcept `json:"referenceSeqId,omitempty"`
-	ReferenceSeqPointer *Reference       `json:"referenceSeqPointer,omitempty"`
-	ReferenceSeqString  *string          `json:"referenceSeqString,omitempty"`
-	Strand              *string          `json:"strand,omitempty"`
-	WindowStart         *int             `json:"windowStart,omitempty"`
-	WindowEnd           *int             `json:"windowEnd,omitempty"`
+	Id                  *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Chromosome          *CodeableConcept `bson:"chromosome,omitempty" json:"chromosome,omitempty"`
+	GenomeBuild         *string          `bson:"genomeBuild,omitempty" json:"genomeBuild,omitempty"`
+	Orientation         *string          `bson:"orientation,omitempty" json:"orientation,omitempty"`
+	ReferenceSeqId      *CodeableConcept `bson:"referenceSeqId,omitempty" json:"referenceSeqId,omitempty"`
+	ReferenceSeqPointer *Reference       `bson:"referenceSeqPointer,omitempty" json:"referenceSeqPointer,omitempty"`
+	ReferenceSeqString  *string          `bson:"referenceSeqString,omitempty" json:"referenceSeqString,omitempty"`
+	Strand              *string          `bson:"strand,omitempty" json:"strand,omitempty"`
+	WindowStart         *int             `bson:"windowStart,omitempty" json:"windowStart,omitempty"`
+	WindowEnd           *int             `bson:"windowEnd,omitempty" json:"windowEnd,omitempty"`
 }
 type MolecularSequenceVariant struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Start             *int        `json:"start,omitempty"`
-	End               *int        `json:"end,omitempty"`
-	ObservedAllele    *string     `json:"observedAllele,omitempty"`
-	ReferenceAllele   *string     `json:"referenceAllele,omitempty"`
-	Cigar             *string     `json:"cigar,omitempty"`
-	VariantPointer    *Reference  `json:"variantPointer,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Start             *int        `bson:"start,omitempty" json:"start,omitempty"`
+	End               *int        `bson:"end,omitempty" json:"end,omitempty"`
+	ObservedAllele    *string     `bson:"observedAllele,omitempty" json:"observedAllele,omitempty"`
+	ReferenceAllele   *string     `bson:"referenceAllele,omitempty" json:"referenceAllele,omitempty"`
+	Cigar             *string     `bson:"cigar,omitempty" json:"cigar,omitempty"`
+	VariantPointer    *Reference  `bson:"variantPointer,omitempty" json:"variantPointer,omitempty"`
 }
 type MolecularSequenceQuality struct {
-	Id                *string                      `json:"id,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Type              string                       `json:"type"`
-	StandardSequence  *CodeableConcept             `json:"standardSequence,omitempty"`
-	Start             *int                         `json:"start,omitempty"`
-	End               *int                         `json:"end,omitempty"`
-	Score             *Quantity                    `json:"score,omitempty"`
-	Method            *CodeableConcept             `json:"method,omitempty"`
-	TruthTP           *string                      `json:"truthTP,omitempty"`
-	QueryTP           *string                      `json:"queryTP,omitempty"`
-	TruthFN           *string                      `json:"truthFN,omitempty"`
-	QueryFP           *string                      `json:"queryFP,omitempty"`
-	GtFP              *string                      `json:"gtFP,omitempty"`
-	Precision         *string                      `json:"precision,omitempty"`
-	Recall            *string                      `json:"recall,omitempty"`
-	FScore            *string                      `json:"fScore,omitempty"`
-	Roc               *MolecularSequenceQualityRoc `json:"roc,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              string                       `bson:"type" json:"type"`
+	StandardSequence  *CodeableConcept             `bson:"standardSequence,omitempty" json:"standardSequence,omitempty"`
+	Start             *int                         `bson:"start,omitempty" json:"start,omitempty"`
+	End               *int                         `bson:"end,omitempty" json:"end,omitempty"`
+	Score             *Quantity                    `bson:"score,omitempty" json:"score,omitempty"`
+	Method            *CodeableConcept             `bson:"method,omitempty" json:"method,omitempty"`
+	TruthTP           *string                      `bson:"truthTP,omitempty" json:"truthTP,omitempty"`
+	QueryTP           *string                      `bson:"queryTP,omitempty" json:"queryTP,omitempty"`
+	TruthFN           *string                      `bson:"truthFN,omitempty" json:"truthFN,omitempty"`
+	QueryFP           *string                      `bson:"queryFP,omitempty" json:"queryFP,omitempty"`
+	GtFP              *string                      `bson:"gtFP,omitempty" json:"gtFP,omitempty"`
+	Precision         *string                      `bson:"precision,omitempty" json:"precision,omitempty"`
+	Recall            *string                      `bson:"recall,omitempty" json:"recall,omitempty"`
+	FScore            *string                      `bson:"fScore,omitempty" json:"fScore,omitempty"`
+	Roc               *MolecularSequenceQualityRoc `bson:"roc,omitempty" json:"roc,omitempty"`
 }
 type MolecularSequenceQualityRoc struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Score             []int       `json:"score,omitempty"`
-	NumTP             []int       `json:"numTP,omitempty"`
-	NumFP             []int       `json:"numFP,omitempty"`
-	NumFN             []int       `json:"numFN,omitempty"`
-	Precision         []string    `json:"precision,omitempty"`
-	Sensitivity       []string    `json:"sensitivity,omitempty"`
-	FMeasure          []string    `json:"fMeasure,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Score             []int       `bson:"score,omitempty" json:"score,omitempty"`
+	NumTP             []int       `bson:"numTP,omitempty" json:"numTP,omitempty"`
+	NumFP             []int       `bson:"numFP,omitempty" json:"numFP,omitempty"`
+	NumFN             []int       `bson:"numFN,omitempty" json:"numFN,omitempty"`
+	Precision         []string    `bson:"precision,omitempty" json:"precision,omitempty"`
+	Sensitivity       []string    `bson:"sensitivity,omitempty" json:"sensitivity,omitempty"`
+	FMeasure          []string    `bson:"fMeasure,omitempty" json:"fMeasure,omitempty"`
 }
 type MolecularSequenceRepository struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Type              string      `json:"type"`
-	Url               *string     `json:"url,omitempty"`
-	Name              *string     `json:"name,omitempty"`
-	DatasetId         *string     `json:"datasetId,omitempty"`
-	VariantsetId      *string     `json:"variantsetId,omitempty"`
-	ReadsetId         *string     `json:"readsetId,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              string      `bson:"type" json:"type"`
+	Url               *string     `bson:"url,omitempty" json:"url,omitempty"`
+	Name              *string     `bson:"name,omitempty" json:"name,omitempty"`
+	DatasetId         *string     `bson:"datasetId,omitempty" json:"datasetId,omitempty"`
+	VariantsetId      *string     `bson:"variantsetId,omitempty" json:"variantsetId,omitempty"`
+	ReadsetId         *string     `bson:"readsetId,omitempty" json:"readsetId,omitempty"`
 }
 type MolecularSequenceStructureVariant struct {
-	Id                *string                                 `json:"id,omitempty"`
-	Extension         []Extension                             `json:"extension,omitempty"`
-	ModifierExtension []Extension                             `json:"modifierExtension,omitempty"`
-	VariantType       *CodeableConcept                        `json:"variantType,omitempty"`
-	Exact             *bool                                   `json:"exact,omitempty"`
-	Length            *int                                    `json:"length,omitempty"`
-	Outer             *MolecularSequenceStructureVariantOuter `json:"outer,omitempty"`
-	Inner             *MolecularSequenceStructureVariantInner `json:"inner,omitempty"`
+	Id                *string                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	VariantType       *CodeableConcept                        `bson:"variantType,omitempty" json:"variantType,omitempty"`
+	Exact             *bool                                   `bson:"exact,omitempty" json:"exact,omitempty"`
+	Length            *int                                    `bson:"length,omitempty" json:"length,omitempty"`
+	Outer             *MolecularSequenceStructureVariantOuter `bson:"outer,omitempty" json:"outer,omitempty"`
+	Inner             *MolecularSequenceStructureVariantInner `bson:"inner,omitempty" json:"inner,omitempty"`
 }
 type MolecularSequenceStructureVariantOuter struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Start             *int        `json:"start,omitempty"`
-	End               *int        `json:"end,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Start             *int        `bson:"start,omitempty" json:"start,omitempty"`
+	End               *int        `bson:"end,omitempty" json:"end,omitempty"`
 }
 type MolecularSequenceStructureVariantInner struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Start             *int        `json:"start,omitempty"`
-	End               *int        `json:"end,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Start             *int        `bson:"start,omitempty" json:"start,omitempty"`
+	End               *int        `bson:"end,omitempty" json:"end,omitempty"`
 }
 type OtherMolecularSequence MolecularSequence
 

--- a/fhir-models/fhir/money.go
+++ b/fhir-models/fhir/money.go
@@ -19,8 +19,8 @@ package fhir
 
 // Money is documented here http://hl7.org/fhir/StructureDefinition/Money
 type Money struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Value     *string     `json:"value,omitempty"`
-	Currency  *string     `json:"currency,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Value     *string     `bson:"value,omitempty" json:"value,omitempty"`
+	Currency  *string     `bson:"currency,omitempty" json:"currency,omitempty"`
 }

--- a/fhir-models/fhir/namingSystem.go
+++ b/fhir-models/fhir/namingSystem.go
@@ -21,36 +21,36 @@ import "encoding/json"
 
 // NamingSystem is documented here http://hl7.org/fhir/StructureDefinition/NamingSystem
 type NamingSystem struct {
-	Id                *string                `json:"id,omitempty"`
-	Meta              *Meta                  `json:"meta,omitempty"`
-	ImplicitRules     *string                `json:"implicitRules,omitempty"`
-	Language          *string                `json:"language,omitempty"`
-	Text              *Narrative             `json:"text,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Name              string                 `json:"name"`
-	Status            PublicationStatus      `json:"status"`
-	Kind              NamingSystemType       `json:"kind"`
-	Date              string                 `json:"date"`
-	Publisher         *string                `json:"publisher,omitempty"`
-	Contact           []ContactDetail        `json:"contact,omitempty"`
-	Responsible       *string                `json:"responsible,omitempty"`
-	Type              *CodeableConcept       `json:"type,omitempty"`
-	Description       *string                `json:"description,omitempty"`
-	UseContext        []UsageContext         `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept      `json:"jurisdiction,omitempty"`
-	Usage             *string                `json:"usage,omitempty"`
-	UniqueId          []NamingSystemUniqueId `json:"uniqueId"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                 `bson:"name" json:"name"`
+	Status            PublicationStatus      `bson:"status" json:"status"`
+	Kind              NamingSystemType       `bson:"kind" json:"kind"`
+	Date              string                 `bson:"date" json:"date"`
+	Publisher         *string                `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail        `bson:"contact,omitempty" json:"contact,omitempty"`
+	Responsible       *string                `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Type              *CodeableConcept       `bson:"type,omitempty" json:"type,omitempty"`
+	Description       *string                `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext         `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept      `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Usage             *string                `bson:"usage,omitempty" json:"usage,omitempty"`
+	UniqueId          []NamingSystemUniqueId `bson:"uniqueId" json:"uniqueId"`
 }
 type NamingSystemUniqueId struct {
-	Id                *string                    `json:"id,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Type              NamingSystemIdentifierType `json:"type"`
-	Value             string                     `json:"value"`
-	Preferred         *bool                      `json:"preferred,omitempty"`
-	Comment           *string                    `json:"comment,omitempty"`
-	Period            *Period                    `json:"period,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              NamingSystemIdentifierType `bson:"type" json:"type"`
+	Value             string                     `bson:"value" json:"value"`
+	Preferred         *bool                      `bson:"preferred,omitempty" json:"preferred,omitempty"`
+	Comment           *string                    `bson:"comment,omitempty" json:"comment,omitempty"`
+	Period            *Period                    `bson:"period,omitempty" json:"period,omitempty"`
 }
 type OtherNamingSystem NamingSystem
 

--- a/fhir-models/fhir/narrative.go
+++ b/fhir-models/fhir/narrative.go
@@ -19,8 +19,8 @@ package fhir
 
 // Narrative is documented here http://hl7.org/fhir/StructureDefinition/Narrative
 type Narrative struct {
-	Id        *string         `json:"id,omitempty"`
-	Extension []Extension     `json:"extension,omitempty"`
-	Status    NarrativeStatus `json:"status"`
-	Div       string          `json:"div"`
+	Id        *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	Status    NarrativeStatus `bson:"status" json:"status"`
+	Div       string          `bson:"div" json:"div"`
 }

--- a/fhir-models/fhir/nutritionOrder.go
+++ b/fhir-models/fhir/nutritionOrder.go
@@ -21,86 +21,86 @@ import "encoding/json"
 
 // NutritionOrder is documented here http://hl7.org/fhir/StructureDefinition/NutritionOrder
 type NutritionOrder struct {
-	Id                     *string                       `json:"id,omitempty"`
-	Meta                   *Meta                         `json:"meta,omitempty"`
-	ImplicitRules          *string                       `json:"implicitRules,omitempty"`
-	Language               *string                       `json:"language,omitempty"`
-	Text                   *Narrative                    `json:"text,omitempty"`
-	Extension              []Extension                   `json:"extension,omitempty"`
-	ModifierExtension      []Extension                   `json:"modifierExtension,omitempty"`
-	Identifier             []Identifier                  `json:"identifier,omitempty"`
-	InstantiatesCanonical  []string                      `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri        []string                      `json:"instantiatesUri,omitempty"`
-	Instantiates           []string                      `json:"instantiates,omitempty"`
-	Status                 RequestStatus                 `json:"status"`
-	Intent                 RequestIntent                 `json:"intent"`
-	Patient                Reference                     `json:"patient"`
-	Encounter              *Reference                    `json:"encounter,omitempty"`
-	DateTime               string                        `json:"dateTime"`
-	Orderer                *Reference                    `json:"orderer,omitempty"`
-	AllergyIntolerance     []Reference                   `json:"allergyIntolerance,omitempty"`
-	FoodPreferenceModifier []CodeableConcept             `json:"foodPreferenceModifier,omitempty"`
-	ExcludeFoodModifier    []CodeableConcept             `json:"excludeFoodModifier,omitempty"`
-	OralDiet               *NutritionOrderOralDiet       `json:"oralDiet,omitempty"`
-	Supplement             []NutritionOrderSupplement    `json:"supplement,omitempty"`
-	EnteralFormula         *NutritionOrderEnteralFormula `json:"enteralFormula,omitempty"`
-	Note                   []Annotation                  `json:"note,omitempty"`
+	Id                     *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier             []Identifier                  `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical  []string                      `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri        []string                      `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	Instantiates           []string                      `bson:"instantiates,omitempty" json:"instantiates,omitempty"`
+	Status                 RequestStatus                 `bson:"status" json:"status"`
+	Intent                 RequestIntent                 `bson:"intent" json:"intent"`
+	Patient                Reference                     `bson:"patient" json:"patient"`
+	Encounter              *Reference                    `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	DateTime               string                        `bson:"dateTime" json:"dateTime"`
+	Orderer                *Reference                    `bson:"orderer,omitempty" json:"orderer,omitempty"`
+	AllergyIntolerance     []Reference                   `bson:"allergyIntolerance,omitempty" json:"allergyIntolerance,omitempty"`
+	FoodPreferenceModifier []CodeableConcept             `bson:"foodPreferenceModifier,omitempty" json:"foodPreferenceModifier,omitempty"`
+	ExcludeFoodModifier    []CodeableConcept             `bson:"excludeFoodModifier,omitempty" json:"excludeFoodModifier,omitempty"`
+	OralDiet               *NutritionOrderOralDiet       `bson:"oralDiet,omitempty" json:"oralDiet,omitempty"`
+	Supplement             []NutritionOrderSupplement    `bson:"supplement,omitempty" json:"supplement,omitempty"`
+	EnteralFormula         *NutritionOrderEnteralFormula `bson:"enteralFormula,omitempty" json:"enteralFormula,omitempty"`
+	Note                   []Annotation                  `bson:"note,omitempty" json:"note,omitempty"`
 }
 type NutritionOrderOralDiet struct {
-	Id                   *string                          `json:"id,omitempty"`
-	Extension            []Extension                      `json:"extension,omitempty"`
-	ModifierExtension    []Extension                      `json:"modifierExtension,omitempty"`
-	Type                 []CodeableConcept                `json:"type,omitempty"`
-	Schedule             []Timing                         `json:"schedule,omitempty"`
-	Nutrient             []NutritionOrderOralDietNutrient `json:"nutrient,omitempty"`
-	Texture              []NutritionOrderOralDietTexture  `json:"texture,omitempty"`
-	FluidConsistencyType []CodeableConcept                `json:"fluidConsistencyType,omitempty"`
-	Instruction          *string                          `json:"instruction,omitempty"`
+	Id                   *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension            []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type                 []CodeableConcept                `bson:"type,omitempty" json:"type,omitempty"`
+	Schedule             []Timing                         `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	Nutrient             []NutritionOrderOralDietNutrient `bson:"nutrient,omitempty" json:"nutrient,omitempty"`
+	Texture              []NutritionOrderOralDietTexture  `bson:"texture,omitempty" json:"texture,omitempty"`
+	FluidConsistencyType []CodeableConcept                `bson:"fluidConsistencyType,omitempty" json:"fluidConsistencyType,omitempty"`
+	Instruction          *string                          `bson:"instruction,omitempty" json:"instruction,omitempty"`
 }
 type NutritionOrderOralDietNutrient struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Modifier          *CodeableConcept `json:"modifier,omitempty"`
-	Amount            *Quantity        `json:"amount,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Modifier          *CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Amount            *Quantity        `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type NutritionOrderOralDietTexture struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Modifier          *CodeableConcept `json:"modifier,omitempty"`
-	FoodType          *CodeableConcept `json:"foodType,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Modifier          *CodeableConcept `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	FoodType          *CodeableConcept `bson:"foodType,omitempty" json:"foodType,omitempty"`
 }
 type NutritionOrderSupplement struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	ProductName       *string          `json:"productName,omitempty"`
-	Schedule          []Timing         `json:"schedule,omitempty"`
-	Quantity          *Quantity        `json:"quantity,omitempty"`
-	Instruction       *string          `json:"instruction,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	ProductName       *string          `bson:"productName,omitempty" json:"productName,omitempty"`
+	Schedule          []Timing         `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	Quantity          *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Instruction       *string          `bson:"instruction,omitempty" json:"instruction,omitempty"`
 }
 type NutritionOrderEnteralFormula struct {
-	Id                        *string                                      `json:"id,omitempty"`
-	Extension                 []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension         []Extension                                  `json:"modifierExtension,omitempty"`
-	BaseFormulaType           *CodeableConcept                             `json:"baseFormulaType,omitempty"`
-	BaseFormulaProductName    *string                                      `json:"baseFormulaProductName,omitempty"`
-	AdditiveType              *CodeableConcept                             `json:"additiveType,omitempty"`
-	AdditiveProductName       *string                                      `json:"additiveProductName,omitempty"`
-	CaloricDensity            *Quantity                                    `json:"caloricDensity,omitempty"`
-	RouteofAdministration     *CodeableConcept                             `json:"routeofAdministration,omitempty"`
-	Administration            []NutritionOrderEnteralFormulaAdministration `json:"administration,omitempty"`
-	MaxVolumeToDeliver        *Quantity                                    `json:"maxVolumeToDeliver,omitempty"`
-	AdministrationInstruction *string                                      `json:"administrationInstruction,omitempty"`
+	Id                        *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                 []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension         []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	BaseFormulaType           *CodeableConcept                             `bson:"baseFormulaType,omitempty" json:"baseFormulaType,omitempty"`
+	BaseFormulaProductName    *string                                      `bson:"baseFormulaProductName,omitempty" json:"baseFormulaProductName,omitempty"`
+	AdditiveType              *CodeableConcept                             `bson:"additiveType,omitempty" json:"additiveType,omitempty"`
+	AdditiveProductName       *string                                      `bson:"additiveProductName,omitempty" json:"additiveProductName,omitempty"`
+	CaloricDensity            *Quantity                                    `bson:"caloricDensity,omitempty" json:"caloricDensity,omitempty"`
+	RouteofAdministration     *CodeableConcept                             `bson:"routeofAdministration,omitempty" json:"routeofAdministration,omitempty"`
+	Administration            []NutritionOrderEnteralFormulaAdministration `bson:"administration,omitempty" json:"administration,omitempty"`
+	MaxVolumeToDeliver        *Quantity                                    `bson:"maxVolumeToDeliver,omitempty" json:"maxVolumeToDeliver,omitempty"`
+	AdministrationInstruction *string                                      `bson:"administrationInstruction,omitempty" json:"administrationInstruction,omitempty"`
 }
 type NutritionOrderEnteralFormulaAdministration struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Schedule          *Timing     `json:"schedule,omitempty"`
-	Quantity          *Quantity   `json:"quantity,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Schedule          *Timing     `bson:"schedule,omitempty" json:"schedule,omitempty"`
+	Quantity          *Quantity   `bson:"quantity,omitempty" json:"quantity,omitempty"`
 }
 type OtherNutritionOrder NutritionOrder
 

--- a/fhir-models/fhir/observation.go
+++ b/fhir-models/fhir/observation.go
@@ -21,55 +21,55 @@ import "encoding/json"
 
 // Observation is documented here http://hl7.org/fhir/StructureDefinition/Observation
 type Observation struct {
-	Id                *string                     `json:"id,omitempty"`
-	Meta              *Meta                       `json:"meta,omitempty"`
-	ImplicitRules     *string                     `json:"implicitRules,omitempty"`
-	Language          *string                     `json:"language,omitempty"`
-	Text              *Narrative                  `json:"text,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                `json:"identifier,omitempty"`
-	BasedOn           []Reference                 `json:"basedOn,omitempty"`
-	PartOf            []Reference                 `json:"partOf,omitempty"`
-	Status            ObservationStatus           `json:"status"`
-	Category          []CodeableConcept           `json:"category,omitempty"`
-	Code              CodeableConcept             `json:"code"`
-	Subject           *Reference                  `json:"subject,omitempty"`
-	Focus             []Reference                 `json:"focus,omitempty"`
-	Encounter         *Reference                  `json:"encounter,omitempty"`
-	Issued            *string                     `json:"issued,omitempty"`
-	Performer         []Reference                 `json:"performer,omitempty"`
-	DataAbsentReason  *CodeableConcept            `json:"dataAbsentReason,omitempty"`
-	Interpretation    []CodeableConcept           `json:"interpretation,omitempty"`
-	Note              []Annotation                `json:"note,omitempty"`
-	BodySite          *CodeableConcept            `json:"bodySite,omitempty"`
-	Method            *CodeableConcept            `json:"method,omitempty"`
-	Specimen          *Reference                  `json:"specimen,omitempty"`
-	Device            *Reference                  `json:"device,omitempty"`
-	ReferenceRange    []ObservationReferenceRange `json:"referenceRange,omitempty"`
-	HasMember         []Reference                 `json:"hasMember,omitempty"`
-	DerivedFrom       []Reference                 `json:"derivedFrom,omitempty"`
-	Component         []ObservationComponent      `json:"component,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference                 `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf            []Reference                 `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status            ObservationStatus           `bson:"status" json:"status"`
+	Category          []CodeableConcept           `bson:"category,omitempty" json:"category,omitempty"`
+	Code              CodeableConcept             `bson:"code" json:"code"`
+	Subject           *Reference                  `bson:"subject,omitempty" json:"subject,omitempty"`
+	Focus             []Reference                 `bson:"focus,omitempty" json:"focus,omitempty"`
+	Encounter         *Reference                  `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Issued            *string                     `bson:"issued,omitempty" json:"issued,omitempty"`
+	Performer         []Reference                 `bson:"performer,omitempty" json:"performer,omitempty"`
+	DataAbsentReason  *CodeableConcept            `bson:"dataAbsentReason,omitempty" json:"dataAbsentReason,omitempty"`
+	Interpretation    []CodeableConcept           `bson:"interpretation,omitempty" json:"interpretation,omitempty"`
+	Note              []Annotation                `bson:"note,omitempty" json:"note,omitempty"`
+	BodySite          *CodeableConcept            `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Method            *CodeableConcept            `bson:"method,omitempty" json:"method,omitempty"`
+	Specimen          *Reference                  `bson:"specimen,omitempty" json:"specimen,omitempty"`
+	Device            *Reference                  `bson:"device,omitempty" json:"device,omitempty"`
+	ReferenceRange    []ObservationReferenceRange `bson:"referenceRange,omitempty" json:"referenceRange,omitempty"`
+	HasMember         []Reference                 `bson:"hasMember,omitempty" json:"hasMember,omitempty"`
+	DerivedFrom       []Reference                 `bson:"derivedFrom,omitempty" json:"derivedFrom,omitempty"`
+	Component         []ObservationComponent      `bson:"component,omitempty" json:"component,omitempty"`
 }
 type ObservationReferenceRange struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Low               *Quantity         `json:"low,omitempty"`
-	High              *Quantity         `json:"high,omitempty"`
-	Type              *CodeableConcept  `json:"type,omitempty"`
-	AppliesTo         []CodeableConcept `json:"appliesTo,omitempty"`
-	Age               *Range            `json:"age,omitempty"`
-	Text              *string           `json:"text,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Low               *Quantity         `bson:"low,omitempty" json:"low,omitempty"`
+	High              *Quantity         `bson:"high,omitempty" json:"high,omitempty"`
+	Type              *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	AppliesTo         []CodeableConcept `bson:"appliesTo,omitempty" json:"appliesTo,omitempty"`
+	Age               *Range            `bson:"age,omitempty" json:"age,omitempty"`
+	Text              *string           `bson:"text,omitempty" json:"text,omitempty"`
 }
 type ObservationComponent struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Code              CodeableConcept             `json:"code"`
-	DataAbsentReason  *CodeableConcept            `json:"dataAbsentReason,omitempty"`
-	Interpretation    []CodeableConcept           `json:"interpretation,omitempty"`
-	ReferenceRange    []ObservationReferenceRange `json:"referenceRange,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              CodeableConcept             `bson:"code" json:"code"`
+	DataAbsentReason  *CodeableConcept            `bson:"dataAbsentReason,omitempty" json:"dataAbsentReason,omitempty"`
+	Interpretation    []CodeableConcept           `bson:"interpretation,omitempty" json:"interpretation,omitempty"`
+	ReferenceRange    []ObservationReferenceRange `bson:"referenceRange,omitempty" json:"referenceRange,omitempty"`
 }
 type OtherObservation Observation
 

--- a/fhir-models/fhir/observationDefinition.go
+++ b/fhir-models/fhir/observationDefinition.go
@@ -21,48 +21,48 @@ import "encoding/json"
 
 // ObservationDefinition is documented here http://hl7.org/fhir/StructureDefinition/ObservationDefinition
 type ObservationDefinition struct {
-	Id                     *string                                   `json:"id,omitempty"`
-	Meta                   *Meta                                     `json:"meta,omitempty"`
-	ImplicitRules          *string                                   `json:"implicitRules,omitempty"`
-	Language               *string                                   `json:"language,omitempty"`
-	Text                   *Narrative                                `json:"text,omitempty"`
-	Extension              []Extension                               `json:"extension,omitempty"`
-	ModifierExtension      []Extension                               `json:"modifierExtension,omitempty"`
-	Category               []CodeableConcept                         `json:"category,omitempty"`
-	Code                   CodeableConcept                           `json:"code"`
-	Identifier             []Identifier                              `json:"identifier,omitempty"`
-	PermittedDataType      []ObservationDataType                     `json:"permittedDataType,omitempty"`
-	MultipleResultsAllowed *bool                                     `json:"multipleResultsAllowed,omitempty"`
-	Method                 *CodeableConcept                          `json:"method,omitempty"`
-	PreferredReportName    *string                                   `json:"preferredReportName,omitempty"`
-	QuantitativeDetails    *ObservationDefinitionQuantitativeDetails `json:"quantitativeDetails,omitempty"`
-	QualifiedInterval      []ObservationDefinitionQualifiedInterval  `json:"qualifiedInterval,omitempty"`
-	ValidCodedValueSet     *Reference                                `json:"validCodedValueSet,omitempty"`
-	NormalCodedValueSet    *Reference                                `json:"normalCodedValueSet,omitempty"`
-	AbnormalCodedValueSet  *Reference                                `json:"abnormalCodedValueSet,omitempty"`
-	CriticalCodedValueSet  *Reference                                `json:"criticalCodedValueSet,omitempty"`
+	Id                     *string                                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string                                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string                                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative                                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension                               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category               []CodeableConcept                         `bson:"category,omitempty" json:"category,omitempty"`
+	Code                   CodeableConcept                           `bson:"code" json:"code"`
+	Identifier             []Identifier                              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	PermittedDataType      []ObservationDataType                     `bson:"permittedDataType,omitempty" json:"permittedDataType,omitempty"`
+	MultipleResultsAllowed *bool                                     `bson:"multipleResultsAllowed,omitempty" json:"multipleResultsAllowed,omitempty"`
+	Method                 *CodeableConcept                          `bson:"method,omitempty" json:"method,omitempty"`
+	PreferredReportName    *string                                   `bson:"preferredReportName,omitempty" json:"preferredReportName,omitempty"`
+	QuantitativeDetails    *ObservationDefinitionQuantitativeDetails `bson:"quantitativeDetails,omitempty" json:"quantitativeDetails,omitempty"`
+	QualifiedInterval      []ObservationDefinitionQualifiedInterval  `bson:"qualifiedInterval,omitempty" json:"qualifiedInterval,omitempty"`
+	ValidCodedValueSet     *Reference                                `bson:"validCodedValueSet,omitempty" json:"validCodedValueSet,omitempty"`
+	NormalCodedValueSet    *Reference                                `bson:"normalCodedValueSet,omitempty" json:"normalCodedValueSet,omitempty"`
+	AbnormalCodedValueSet  *Reference                                `bson:"abnormalCodedValueSet,omitempty" json:"abnormalCodedValueSet,omitempty"`
+	CriticalCodedValueSet  *Reference                                `bson:"criticalCodedValueSet,omitempty" json:"criticalCodedValueSet,omitempty"`
 }
 type ObservationDefinitionQuantitativeDetails struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	CustomaryUnit     *CodeableConcept `json:"customaryUnit,omitempty"`
-	Unit              *CodeableConcept `json:"unit,omitempty"`
-	ConversionFactor  *string          `json:"conversionFactor,omitempty"`
-	DecimalPrecision  *int             `json:"decimalPrecision,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	CustomaryUnit     *CodeableConcept `bson:"customaryUnit,omitempty" json:"customaryUnit,omitempty"`
+	Unit              *CodeableConcept `bson:"unit,omitempty" json:"unit,omitempty"`
+	ConversionFactor  *string          `bson:"conversionFactor,omitempty" json:"conversionFactor,omitempty"`
+	DecimalPrecision  *int             `bson:"decimalPrecision,omitempty" json:"decimalPrecision,omitempty"`
 }
 type ObservationDefinitionQualifiedInterval struct {
-	Id                *string                   `json:"id,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Category          *ObservationRangeCategory `json:"category,omitempty"`
-	Range             *Range                    `json:"range,omitempty"`
-	Context           *CodeableConcept          `json:"context,omitempty"`
-	AppliesTo         []CodeableConcept         `json:"appliesTo,omitempty"`
-	Gender            *AdministrativeGender     `json:"gender,omitempty"`
-	Age               *Range                    `json:"age,omitempty"`
-	GestationalAge    *Range                    `json:"gestationalAge,omitempty"`
-	Condition         *string                   `json:"condition,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          *ObservationRangeCategory `bson:"category,omitempty" json:"category,omitempty"`
+	Range             *Range                    `bson:"range,omitempty" json:"range,omitempty"`
+	Context           *CodeableConcept          `bson:"context,omitempty" json:"context,omitempty"`
+	AppliesTo         []CodeableConcept         `bson:"appliesTo,omitempty" json:"appliesTo,omitempty"`
+	Gender            *AdministrativeGender     `bson:"gender,omitempty" json:"gender,omitempty"`
+	Age               *Range                    `bson:"age,omitempty" json:"age,omitempty"`
+	GestationalAge    *Range                    `bson:"gestationalAge,omitempty" json:"gestationalAge,omitempty"`
+	Condition         *string                   `bson:"condition,omitempty" json:"condition,omitempty"`
 }
 type OtherObservationDefinition ObservationDefinition
 

--- a/fhir-models/fhir/operationDefinition.go
+++ b/fhir-models/fhir/operationDefinition.go
@@ -21,76 +21,76 @@ import "encoding/json"
 
 // OperationDefinition is documented here http://hl7.org/fhir/StructureDefinition/OperationDefinition
 type OperationDefinition struct {
-	Id                *string                        `json:"id,omitempty"`
-	Meta              *Meta                          `json:"meta,omitempty"`
-	ImplicitRules     *string                        `json:"implicitRules,omitempty"`
-	Language          *string                        `json:"language,omitempty"`
-	Text              *Narrative                     `json:"text,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Url               *string                        `json:"url,omitempty"`
-	Version           *string                        `json:"version,omitempty"`
-	Name              string                         `json:"name"`
-	Title             *string                        `json:"title,omitempty"`
-	Status            PublicationStatus              `json:"status"`
-	Kind              OperationKind                  `json:"kind"`
-	Experimental      *bool                          `json:"experimental,omitempty"`
-	Date              *string                        `json:"date,omitempty"`
-	Publisher         *string                        `json:"publisher,omitempty"`
-	Contact           []ContactDetail                `json:"contact,omitempty"`
-	Description       *string                        `json:"description,omitempty"`
-	UseContext        []UsageContext                 `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept              `json:"jurisdiction,omitempty"`
-	Purpose           *string                        `json:"purpose,omitempty"`
-	AffectsState      *bool                          `json:"affectsState,omitempty"`
-	Code              string                         `json:"code"`
-	Comment           *string                        `json:"comment,omitempty"`
-	Base              *string                        `json:"base,omitempty"`
-	Resource          []ResourceType                 `json:"resource,omitempty"`
-	System            bool                           `json:"system"`
-	Type              bool                           `json:"type"`
-	Instance          bool                           `json:"instance"`
-	InputProfile      *string                        `json:"inputProfile,omitempty"`
-	OutputProfile     *string                        `json:"outputProfile,omitempty"`
-	Parameter         []OperationDefinitionParameter `json:"parameter,omitempty"`
-	Overload          []OperationDefinitionOverload  `json:"overload,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                        `bson:"url,omitempty" json:"url,omitempty"`
+	Version           *string                        `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                         `bson:"name" json:"name"`
+	Title             *string                        `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus              `bson:"status" json:"status"`
+	Kind              OperationKind                  `bson:"kind" json:"kind"`
+	Experimental      *bool                          `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                        `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                        `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                        `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                 `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept              `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                        `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	AffectsState      *bool                          `bson:"affectsState,omitempty" json:"affectsState,omitempty"`
+	Code              string                         `bson:"code" json:"code"`
+	Comment           *string                        `bson:"comment,omitempty" json:"comment,omitempty"`
+	Base              *string                        `bson:"base,omitempty" json:"base,omitempty"`
+	Resource          []ResourceType                 `bson:"resource,omitempty" json:"resource,omitempty"`
+	System            bool                           `bson:"system" json:"system"`
+	Type              bool                           `bson:"type" json:"type"`
+	Instance          bool                           `bson:"instance" json:"instance"`
+	InputProfile      *string                        `bson:"inputProfile,omitempty" json:"inputProfile,omitempty"`
+	OutputProfile     *string                        `bson:"outputProfile,omitempty" json:"outputProfile,omitempty"`
+	Parameter         []OperationDefinitionParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	Overload          []OperationDefinitionOverload  `bson:"overload,omitempty" json:"overload,omitempty"`
 }
 type OperationDefinitionParameter struct {
-	Id                *string                                      `json:"id,omitempty"`
-	Extension         []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                                  `json:"modifierExtension,omitempty"`
-	Name              string                                       `json:"name"`
-	Use               OperationParameterUse                        `json:"use"`
-	Min               int                                          `json:"min"`
-	Max               string                                       `json:"max"`
-	Documentation     *string                                      `json:"documentation,omitempty"`
-	Type              *string                                      `json:"type,omitempty"`
-	TargetProfile     []string                                     `json:"targetProfile,omitempty"`
-	SearchType        *SearchParamType                             `json:"searchType,omitempty"`
-	Binding           *OperationDefinitionParameterBinding         `json:"binding,omitempty"`
-	ReferencedFrom    []OperationDefinitionParameterReferencedFrom `json:"referencedFrom,omitempty"`
-	Part              []OperationDefinitionParameter               `json:"part,omitempty"`
+	Id                *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                                       `bson:"name" json:"name"`
+	Use               OperationParameterUse                        `bson:"use" json:"use"`
+	Min               int                                          `bson:"min" json:"min"`
+	Max               string                                       `bson:"max" json:"max"`
+	Documentation     *string                                      `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Type              *string                                      `bson:"type,omitempty" json:"type,omitempty"`
+	TargetProfile     []string                                     `bson:"targetProfile,omitempty" json:"targetProfile,omitempty"`
+	SearchType        *SearchParamType                             `bson:"searchType,omitempty" json:"searchType,omitempty"`
+	Binding           *OperationDefinitionParameterBinding         `bson:"binding,omitempty" json:"binding,omitempty"`
+	ReferencedFrom    []OperationDefinitionParameterReferencedFrom `bson:"referencedFrom,omitempty" json:"referencedFrom,omitempty"`
+	Part              []OperationDefinitionParameter               `bson:"part,omitempty" json:"part,omitempty"`
 }
 type OperationDefinitionParameterBinding struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Strength          BindingStrength `json:"strength"`
-	ValueSet          string          `json:"valueSet"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Strength          BindingStrength `bson:"strength" json:"strength"`
+	ValueSet          string          `bson:"valueSet" json:"valueSet"`
 }
 type OperationDefinitionParameterReferencedFrom struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Source            string      `json:"source"`
-	SourceId          *string     `json:"sourceId,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Source            string      `bson:"source" json:"source"`
+	SourceId          *string     `bson:"sourceId,omitempty" json:"sourceId,omitempty"`
 }
 type OperationDefinitionOverload struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	ParameterName     []string    `json:"parameterName,omitempty"`
-	Comment           *string     `json:"comment,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ParameterName     []string    `bson:"parameterName,omitempty" json:"parameterName,omitempty"`
+	Comment           *string     `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type OtherOperationDefinition OperationDefinition
 

--- a/fhir-models/fhir/operationOutcome.go
+++ b/fhir-models/fhir/operationOutcome.go
@@ -21,25 +21,25 @@ import "encoding/json"
 
 // OperationOutcome is documented here http://hl7.org/fhir/StructureDefinition/OperationOutcome
 type OperationOutcome struct {
-	Id                *string                 `json:"id,omitempty"`
-	Meta              *Meta                   `json:"meta,omitempty"`
-	ImplicitRules     *string                 `json:"implicitRules,omitempty"`
-	Language          *string                 `json:"language,omitempty"`
-	Text              *Narrative              `json:"text,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Issue             []OperationOutcomeIssue `json:"issue"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Issue             []OperationOutcomeIssue `bson:"issue" json:"issue"`
 }
 type OperationOutcomeIssue struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Severity          IssueSeverity    `json:"severity"`
-	Code              IssueType        `json:"code"`
-	Details           *CodeableConcept `json:"details,omitempty"`
-	Diagnostics       *string          `json:"diagnostics,omitempty"`
-	Location          []string         `json:"location,omitempty"`
-	Expression        []string         `json:"expression,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Severity          IssueSeverity    `bson:"severity" json:"severity"`
+	Code              IssueType        `bson:"code" json:"code"`
+	Details           *CodeableConcept `bson:"details,omitempty" json:"details,omitempty"`
+	Diagnostics       *string          `bson:"diagnostics,omitempty" json:"diagnostics,omitempty"`
+	Location          []string         `bson:"location,omitempty" json:"location,omitempty"`
+	Expression        []string         `bson:"expression,omitempty" json:"expression,omitempty"`
 }
 type OtherOperationOutcome OperationOutcome
 

--- a/fhir-models/fhir/organization.go
+++ b/fhir-models/fhir/organization.go
@@ -21,32 +21,32 @@ import "encoding/json"
 
 // Organization is documented here http://hl7.org/fhir/StructureDefinition/Organization
 type Organization struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier          `json:"identifier,omitempty"`
-	Active            *bool                 `json:"active,omitempty"`
-	Type              []CodeableConcept     `json:"type,omitempty"`
-	Name              *string               `json:"name,omitempty"`
-	Alias             []string              `json:"alias,omitempty"`
-	Telecom           []ContactPoint        `json:"telecom,omitempty"`
-	Address           []Address             `json:"address,omitempty"`
-	PartOf            *Reference            `json:"partOf,omitempty"`
-	Contact           []OrganizationContact `json:"contact,omitempty"`
-	Endpoint          []Reference           `json:"endpoint,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active            *bool                 `bson:"active,omitempty" json:"active,omitempty"`
+	Type              []CodeableConcept     `bson:"type,omitempty" json:"type,omitempty"`
+	Name              *string               `bson:"name,omitempty" json:"name,omitempty"`
+	Alias             []string              `bson:"alias,omitempty" json:"alias,omitempty"`
+	Telecom           []ContactPoint        `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address           []Address             `bson:"address,omitempty" json:"address,omitempty"`
+	PartOf            *Reference            `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Contact           []OrganizationContact `bson:"contact,omitempty" json:"contact,omitempty"`
+	Endpoint          []Reference           `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 type OrganizationContact struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Purpose           *CodeableConcept `json:"purpose,omitempty"`
-	Name              *HumanName       `json:"name,omitempty"`
-	Telecom           []ContactPoint   `json:"telecom,omitempty"`
-	Address           *Address         `json:"address,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Purpose           *CodeableConcept `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Name              *HumanName       `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom           []ContactPoint   `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address           *Address         `bson:"address,omitempty" json:"address,omitempty"`
 }
 type OtherOrganization Organization
 

--- a/fhir-models/fhir/organizationAffiliation.go
+++ b/fhir-models/fhir/organizationAffiliation.go
@@ -21,25 +21,25 @@ import "encoding/json"
 
 // OrganizationAffiliation is documented here http://hl7.org/fhir/StructureDefinition/OrganizationAffiliation
 type OrganizationAffiliation struct {
-	Id                        *string           `json:"id,omitempty"`
-	Meta                      *Meta             `json:"meta,omitempty"`
-	ImplicitRules             *string           `json:"implicitRules,omitempty"`
-	Language                  *string           `json:"language,omitempty"`
-	Text                      *Narrative        `json:"text,omitempty"`
-	Extension                 []Extension       `json:"extension,omitempty"`
-	ModifierExtension         []Extension       `json:"modifierExtension,omitempty"`
-	Identifier                []Identifier      `json:"identifier,omitempty"`
-	Active                    *bool             `json:"active,omitempty"`
-	Period                    *Period           `json:"period,omitempty"`
-	Organization              *Reference        `json:"organization,omitempty"`
-	ParticipatingOrganization *Reference        `json:"participatingOrganization,omitempty"`
-	Network                   []Reference       `json:"network,omitempty"`
-	Code                      []CodeableConcept `json:"code,omitempty"`
-	Specialty                 []CodeableConcept `json:"specialty,omitempty"`
-	Location                  []Reference       `json:"location,omitempty"`
-	HealthcareService         []Reference       `json:"healthcareService,omitempty"`
-	Telecom                   []ContactPoint    `json:"telecom,omitempty"`
-	Endpoint                  []Reference       `json:"endpoint,omitempty"`
+	Id                        *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                      *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules             *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language                  *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                      *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension                 []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension         []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier                []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active                    *bool             `bson:"active,omitempty" json:"active,omitempty"`
+	Period                    *Period           `bson:"period,omitempty" json:"period,omitempty"`
+	Organization              *Reference        `bson:"organization,omitempty" json:"organization,omitempty"`
+	ParticipatingOrganization *Reference        `bson:"participatingOrganization,omitempty" json:"participatingOrganization,omitempty"`
+	Network                   []Reference       `bson:"network,omitempty" json:"network,omitempty"`
+	Code                      []CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Specialty                 []CodeableConcept `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	Location                  []Reference       `bson:"location,omitempty" json:"location,omitempty"`
+	HealthcareService         []Reference       `bson:"healthcareService,omitempty" json:"healthcareService,omitempty"`
+	Telecom                   []ContactPoint    `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Endpoint                  []Reference       `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 type OtherOrganizationAffiliation OrganizationAffiliation
 

--- a/fhir-models/fhir/parameterDefinition.go
+++ b/fhir-models/fhir/parameterDefinition.go
@@ -19,13 +19,13 @@ package fhir
 
 // ParameterDefinition is documented here http://hl7.org/fhir/StructureDefinition/ParameterDefinition
 type ParameterDefinition struct {
-	Id            *string               `json:"id,omitempty"`
-	Extension     []Extension           `json:"extension,omitempty"`
-	Name          *string               `json:"name,omitempty"`
-	Use           OperationParameterUse `json:"use"`
-	Min           *int                  `json:"min,omitempty"`
-	Max           *string               `json:"max,omitempty"`
-	Documentation *string               `json:"documentation,omitempty"`
-	Type          string                `json:"type"`
-	Profile       *string               `json:"profile,omitempty"`
+	Id            *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension     []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	Name          *string               `bson:"name,omitempty" json:"name,omitempty"`
+	Use           OperationParameterUse `bson:"use" json:"use"`
+	Min           *int                  `bson:"min,omitempty" json:"min,omitempty"`
+	Max           *string               `bson:"max,omitempty" json:"max,omitempty"`
+	Documentation *string               `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Type          string                `bson:"type" json:"type"`
+	Profile       *string               `bson:"profile,omitempty" json:"profile,omitempty"`
 }

--- a/fhir-models/fhir/parameters.go
+++ b/fhir-models/fhir/parameters.go
@@ -21,19 +21,19 @@ import "encoding/json"
 
 // Parameters is documented here http://hl7.org/fhir/StructureDefinition/Parameters
 type Parameters struct {
-	Id            *string               `json:"id,omitempty"`
-	Meta          *Meta                 `json:"meta,omitempty"`
-	ImplicitRules *string               `json:"implicitRules,omitempty"`
-	Language      *string               `json:"language,omitempty"`
-	Parameter     []ParametersParameter `json:"parameter,omitempty"`
+	Id            *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta          *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language      *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Parameter     []ParametersParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
 }
 type ParametersParameter struct {
-	Id                *string               `json:"id,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Name              string                `json:"name"`
-	Resource          json.RawMessage       `json:"resource,omitempty"`
-	Part              []ParametersParameter `json:"part,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                `bson:"name" json:"name"`
+	Resource          json.RawMessage       `bson:"resource,omitempty" json:"resource,omitempty"`
+	Part              []ParametersParameter `bson:"part,omitempty" json:"part,omitempty"`
 }
 type OtherParameters Parameters
 

--- a/fhir-models/fhir/patient.go
+++ b/fhir-models/fhir/patient.go
@@ -21,53 +21,53 @@ import "encoding/json"
 
 // Patient is documented here http://hl7.org/fhir/StructureDefinition/Patient
 type Patient struct {
-	Id                   *string                `json:"id,omitempty"`
-	Meta                 *Meta                  `json:"meta,omitempty"`
-	ImplicitRules        *string                `json:"implicitRules,omitempty"`
-	Language             *string                `json:"language,omitempty"`
-	Text                 *Narrative             `json:"text,omitempty"`
-	Extension            []Extension            `json:"extension,omitempty"`
-	ModifierExtension    []Extension            `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier           `json:"identifier,omitempty"`
-	Active               *bool                  `json:"active,omitempty"`
-	Name                 []HumanName            `json:"name,omitempty"`
-	Telecom              []ContactPoint         `json:"telecom,omitempty"`
-	Gender               *AdministrativeGender  `json:"gender,omitempty"`
-	BirthDate            *string                `json:"birthDate,omitempty"`
-	Address              []Address              `json:"address,omitempty"`
-	MaritalStatus        *CodeableConcept       `json:"maritalStatus,omitempty"`
-	Photo                []Attachment           `json:"photo,omitempty"`
-	Contact              []PatientContact       `json:"contact,omitempty"`
-	Communication        []PatientCommunication `json:"communication,omitempty"`
-	GeneralPractitioner  []Reference            `json:"generalPractitioner,omitempty"`
-	ManagingOrganization *Reference             `json:"managingOrganization,omitempty"`
-	Link                 []PatientLink          `json:"link,omitempty"`
+	Id                   *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active               *bool                  `bson:"active,omitempty" json:"active,omitempty"`
+	Name                 []HumanName            `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom              []ContactPoint         `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Gender               *AdministrativeGender  `bson:"gender,omitempty" json:"gender,omitempty"`
+	BirthDate            *string                `bson:"birthDate,omitempty" json:"birthDate,omitempty"`
+	Address              []Address              `bson:"address,omitempty" json:"address,omitempty"`
+	MaritalStatus        *CodeableConcept       `bson:"maritalStatus,omitempty" json:"maritalStatus,omitempty"`
+	Photo                []Attachment           `bson:"photo,omitempty" json:"photo,omitempty"`
+	Contact              []PatientContact       `bson:"contact,omitempty" json:"contact,omitempty"`
+	Communication        []PatientCommunication `bson:"communication,omitempty" json:"communication,omitempty"`
+	GeneralPractitioner  []Reference            `bson:"generalPractitioner,omitempty" json:"generalPractitioner,omitempty"`
+	ManagingOrganization *Reference             `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
+	Link                 []PatientLink          `bson:"link,omitempty" json:"link,omitempty"`
 }
 type PatientContact struct {
-	Id                *string               `json:"id,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Relationship      []CodeableConcept     `json:"relationship,omitempty"`
-	Name              *HumanName            `json:"name,omitempty"`
-	Telecom           []ContactPoint        `json:"telecom,omitempty"`
-	Address           *Address              `json:"address,omitempty"`
-	Gender            *AdministrativeGender `json:"gender,omitempty"`
-	Organization      *Reference            `json:"organization,omitempty"`
-	Period            *Period               `json:"period,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Relationship      []CodeableConcept     `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Name              *HumanName            `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom           []ContactPoint        `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address           *Address              `bson:"address,omitempty" json:"address,omitempty"`
+	Gender            *AdministrativeGender `bson:"gender,omitempty" json:"gender,omitempty"`
+	Organization      *Reference            `bson:"organization,omitempty" json:"organization,omitempty"`
+	Period            *Period               `bson:"period,omitempty" json:"period,omitempty"`
 }
 type PatientCommunication struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Language          CodeableConcept `json:"language"`
-	Preferred         *bool           `json:"preferred,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Language          CodeableConcept `bson:"language" json:"language"`
+	Preferred         *bool           `bson:"preferred,omitempty" json:"preferred,omitempty"`
 }
 type PatientLink struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Other             Reference   `json:"other"`
-	Type              LinkType    `json:"type"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Other             Reference   `bson:"other" json:"other"`
+	Type              LinkType    `bson:"type" json:"type"`
 }
 type OtherPatient Patient
 

--- a/fhir-models/fhir/paymentNotice.go
+++ b/fhir-models/fhir/paymentNotice.go
@@ -21,25 +21,25 @@ import "encoding/json"
 
 // PaymentNotice is documented here http://hl7.org/fhir/StructureDefinition/PaymentNotice
 type PaymentNotice struct {
-	Id                *string                      `json:"id,omitempty"`
-	Meta              *Meta                        `json:"meta,omitempty"`
-	ImplicitRules     *string                      `json:"implicitRules,omitempty"`
-	Language          *string                      `json:"language,omitempty"`
-	Text              *Narrative                   `json:"text,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                 `json:"identifier,omitempty"`
-	Status            FinancialResourceStatusCodes `json:"status"`
-	Request           *Reference                   `json:"request,omitempty"`
-	Response          *Reference                   `json:"response,omitempty"`
-	Created           string                       `json:"created"`
-	Provider          *Reference                   `json:"provider,omitempty"`
-	Payment           Reference                    `json:"payment"`
-	PaymentDate       *string                      `json:"paymentDate,omitempty"`
-	Payee             *Reference                   `json:"payee,omitempty"`
-	Recipient         Reference                    `json:"recipient"`
-	Amount            Money                        `json:"amount"`
-	PaymentStatus     *CodeableConcept             `json:"paymentStatus,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FinancialResourceStatusCodes `bson:"status" json:"status"`
+	Request           *Reference                   `bson:"request,omitempty" json:"request,omitempty"`
+	Response          *Reference                   `bson:"response,omitempty" json:"response,omitempty"`
+	Created           string                       `bson:"created" json:"created"`
+	Provider          *Reference                   `bson:"provider,omitempty" json:"provider,omitempty"`
+	Payment           Reference                    `bson:"payment" json:"payment"`
+	PaymentDate       *string                      `bson:"paymentDate,omitempty" json:"paymentDate,omitempty"`
+	Payee             *Reference                   `bson:"payee,omitempty" json:"payee,omitempty"`
+	Recipient         Reference                    `bson:"recipient" json:"recipient"`
+	Amount            Money                        `bson:"amount" json:"amount"`
+	PaymentStatus     *CodeableConcept             `bson:"paymentStatus,omitempty" json:"paymentStatus,omitempty"`
 }
 type OtherPaymentNotice PaymentNotice
 

--- a/fhir-models/fhir/paymentReconciliation.go
+++ b/fhir-models/fhir/paymentReconciliation.go
@@ -21,50 +21,50 @@ import "encoding/json"
 
 // PaymentReconciliation is documented here http://hl7.org/fhir/StructureDefinition/PaymentReconciliation
 type PaymentReconciliation struct {
-	Id                *string                            `json:"id,omitempty"`
-	Meta              *Meta                              `json:"meta,omitempty"`
-	ImplicitRules     *string                            `json:"implicitRules,omitempty"`
-	Language          *string                            `json:"language,omitempty"`
-	Text              *Narrative                         `json:"text,omitempty"`
-	Extension         []Extension                        `json:"extension,omitempty"`
-	ModifierExtension []Extension                        `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                       `json:"identifier,omitempty"`
-	Status            FinancialResourceStatusCodes       `json:"status"`
-	Period            *Period                            `json:"period,omitempty"`
-	Created           string                             `json:"created"`
-	PaymentIssuer     *Reference                         `json:"paymentIssuer,omitempty"`
-	Request           *Reference                         `json:"request,omitempty"`
-	Requestor         *Reference                         `json:"requestor,omitempty"`
-	Outcome           *ClaimProcessingCodes              `json:"outcome,omitempty"`
-	Disposition       *string                            `json:"disposition,omitempty"`
-	PaymentDate       string                             `json:"paymentDate"`
-	PaymentAmount     Money                              `json:"paymentAmount"`
-	PaymentIdentifier *Identifier                        `json:"paymentIdentifier,omitempty"`
-	Detail            []PaymentReconciliationDetail      `json:"detail,omitempty"`
-	FormCode          *CodeableConcept                   `json:"formCode,omitempty"`
-	ProcessNote       []PaymentReconciliationProcessNote `json:"processNote,omitempty"`
+	Id                *string                            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FinancialResourceStatusCodes       `bson:"status" json:"status"`
+	Period            *Period                            `bson:"period,omitempty" json:"period,omitempty"`
+	Created           string                             `bson:"created" json:"created"`
+	PaymentIssuer     *Reference                         `bson:"paymentIssuer,omitempty" json:"paymentIssuer,omitempty"`
+	Request           *Reference                         `bson:"request,omitempty" json:"request,omitempty"`
+	Requestor         *Reference                         `bson:"requestor,omitempty" json:"requestor,omitempty"`
+	Outcome           *ClaimProcessingCodes              `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	Disposition       *string                            `bson:"disposition,omitempty" json:"disposition,omitempty"`
+	PaymentDate       string                             `bson:"paymentDate" json:"paymentDate"`
+	PaymentAmount     Money                              `bson:"paymentAmount" json:"paymentAmount"`
+	PaymentIdentifier *Identifier                        `bson:"paymentIdentifier,omitempty" json:"paymentIdentifier,omitempty"`
+	Detail            []PaymentReconciliationDetail      `bson:"detail,omitempty" json:"detail,omitempty"`
+	FormCode          *CodeableConcept                   `bson:"formCode,omitempty" json:"formCode,omitempty"`
+	ProcessNote       []PaymentReconciliationProcessNote `bson:"processNote,omitempty" json:"processNote,omitempty"`
 }
 type PaymentReconciliationDetail struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier     `json:"identifier,omitempty"`
-	Predecessor       *Identifier     `json:"predecessor,omitempty"`
-	Type              CodeableConcept `json:"type"`
-	Request           *Reference      `json:"request,omitempty"`
-	Submitter         *Reference      `json:"submitter,omitempty"`
-	Response          *Reference      `json:"response,omitempty"`
-	Date              *string         `json:"date,omitempty"`
-	Responsible       *Reference      `json:"responsible,omitempty"`
-	Payee             *Reference      `json:"payee,omitempty"`
-	Amount            *Money          `json:"amount,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Predecessor       *Identifier     `bson:"predecessor,omitempty" json:"predecessor,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
+	Request           *Reference      `bson:"request,omitempty" json:"request,omitempty"`
+	Submitter         *Reference      `bson:"submitter,omitempty" json:"submitter,omitempty"`
+	Response          *Reference      `bson:"response,omitempty" json:"response,omitempty"`
+	Date              *string         `bson:"date,omitempty" json:"date,omitempty"`
+	Responsible       *Reference      `bson:"responsible,omitempty" json:"responsible,omitempty"`
+	Payee             *Reference      `bson:"payee,omitempty" json:"payee,omitempty"`
+	Amount            *Money          `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type PaymentReconciliationProcessNote struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Type              *NoteType   `json:"type,omitempty"`
-	Text              *string     `json:"text,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *NoteType   `bson:"type,omitempty" json:"type,omitempty"`
+	Text              *string     `bson:"text,omitempty" json:"text,omitempty"`
 }
 type OtherPaymentReconciliation PaymentReconciliation
 

--- a/fhir-models/fhir/period.go
+++ b/fhir-models/fhir/period.go
@@ -19,8 +19,8 @@ package fhir
 
 // Period is documented here http://hl7.org/fhir/StructureDefinition/Period
 type Period struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Start     *string     `json:"start,omitempty"`
-	End       *string     `json:"end,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Start     *string     `bson:"start,omitempty" json:"start,omitempty"`
+	End       *string     `bson:"end,omitempty" json:"end,omitempty"`
 }

--- a/fhir-models/fhir/person.go
+++ b/fhir-models/fhir/person.go
@@ -21,30 +21,30 @@ import "encoding/json"
 
 // Person is documented here http://hl7.org/fhir/StructureDefinition/Person
 type Person struct {
-	Id                   *string               `json:"id,omitempty"`
-	Meta                 *Meta                 `json:"meta,omitempty"`
-	ImplicitRules        *string               `json:"implicitRules,omitempty"`
-	Language             *string               `json:"language,omitempty"`
-	Text                 *Narrative            `json:"text,omitempty"`
-	Extension            []Extension           `json:"extension,omitempty"`
-	ModifierExtension    []Extension           `json:"modifierExtension,omitempty"`
-	Identifier           []Identifier          `json:"identifier,omitempty"`
-	Name                 []HumanName           `json:"name,omitempty"`
-	Telecom              []ContactPoint        `json:"telecom,omitempty"`
-	Gender               *AdministrativeGender `json:"gender,omitempty"`
-	BirthDate            *string               `json:"birthDate,omitempty"`
-	Address              []Address             `json:"address,omitempty"`
-	Photo                *Attachment           `json:"photo,omitempty"`
-	ManagingOrganization *Reference            `json:"managingOrganization,omitempty"`
-	Active               *bool                 `json:"active,omitempty"`
-	Link                 []PersonLink          `json:"link,omitempty"`
+	Id                   *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Name                 []HumanName           `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom              []ContactPoint        `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Gender               *AdministrativeGender `bson:"gender,omitempty" json:"gender,omitempty"`
+	BirthDate            *string               `bson:"birthDate,omitempty" json:"birthDate,omitempty"`
+	Address              []Address             `bson:"address,omitempty" json:"address,omitempty"`
+	Photo                *Attachment           `bson:"photo,omitempty" json:"photo,omitempty"`
+	ManagingOrganization *Reference            `bson:"managingOrganization,omitempty" json:"managingOrganization,omitempty"`
+	Active               *bool                 `bson:"active,omitempty" json:"active,omitempty"`
+	Link                 []PersonLink          `bson:"link,omitempty" json:"link,omitempty"`
 }
 type PersonLink struct {
-	Id                *string                 `json:"id,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Target            Reference               `json:"target"`
-	Assurance         *IdentityAssuranceLevel `json:"assurance,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Target            Reference               `bson:"target" json:"target"`
+	Assurance         *IdentityAssuranceLevel `bson:"assurance,omitempty" json:"assurance,omitempty"`
 }
 type OtherPerson Person
 

--- a/fhir-models/fhir/planDefinition.go
+++ b/fhir-models/fhir/planDefinition.go
@@ -21,119 +21,119 @@ import "encoding/json"
 
 // PlanDefinition is documented here http://hl7.org/fhir/StructureDefinition/PlanDefinition
 type PlanDefinition struct {
-	Id                *string                `json:"id,omitempty"`
-	Meta              *Meta                  `json:"meta,omitempty"`
-	ImplicitRules     *string                `json:"implicitRules,omitempty"`
-	Language          *string                `json:"language,omitempty"`
-	Text              *Narrative             `json:"text,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Url               *string                `json:"url,omitempty"`
-	Identifier        []Identifier           `json:"identifier,omitempty"`
-	Version           *string                `json:"version,omitempty"`
-	Name              *string                `json:"name,omitempty"`
-	Title             *string                `json:"title,omitempty"`
-	Subtitle          *string                `json:"subtitle,omitempty"`
-	Type              *CodeableConcept       `json:"type,omitempty"`
-	Status            PublicationStatus      `json:"status"`
-	Experimental      *bool                  `json:"experimental,omitempty"`
-	Date              *string                `json:"date,omitempty"`
-	Publisher         *string                `json:"publisher,omitempty"`
-	Contact           []ContactDetail        `json:"contact,omitempty"`
-	Description       *string                `json:"description,omitempty"`
-	UseContext        []UsageContext         `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept      `json:"jurisdiction,omitempty"`
-	Purpose           *string                `json:"purpose,omitempty"`
-	Usage             *string                `json:"usage,omitempty"`
-	Copyright         *string                `json:"copyright,omitempty"`
-	ApprovalDate      *string                `json:"approvalDate,omitempty"`
-	LastReviewDate    *string                `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period                `json:"effectivePeriod,omitempty"`
-	Topic             []CodeableConcept      `json:"topic,omitempty"`
-	Author            []ContactDetail        `json:"author,omitempty"`
-	Editor            []ContactDetail        `json:"editor,omitempty"`
-	Reviewer          []ContactDetail        `json:"reviewer,omitempty"`
-	Endorser          []ContactDetail        `json:"endorser,omitempty"`
-	RelatedArtifact   []RelatedArtifact      `json:"relatedArtifact,omitempty"`
-	Library           []string               `json:"library,omitempty"`
-	Goal              []PlanDefinitionGoal   `json:"goal,omitempty"`
-	Action            []PlanDefinitionAction `json:"action,omitempty"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                `bson:"title,omitempty" json:"title,omitempty"`
+	Subtitle          *string                `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Type              *CodeableConcept       `bson:"type,omitempty" json:"type,omitempty"`
+	Status            PublicationStatus      `bson:"status" json:"status"`
+	Experimental      *bool                  `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail        `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext         `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept      `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage             *string                `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright         *string                `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string                `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string                `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period                `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic             []CodeableConcept      `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author            []ContactDetail        `bson:"author,omitempty" json:"author,omitempty"`
+	Editor            []ContactDetail        `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer          []ContactDetail        `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser          []ContactDetail        `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact   []RelatedArtifact      `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Library           []string               `bson:"library,omitempty" json:"library,omitempty"`
+	Goal              []PlanDefinitionGoal   `bson:"goal,omitempty" json:"goal,omitempty"`
+	Action            []PlanDefinitionAction `bson:"action,omitempty" json:"action,omitempty"`
 }
 type PlanDefinitionGoal struct {
-	Id                *string                    `json:"id,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Category          *CodeableConcept           `json:"category,omitempty"`
-	Description       CodeableConcept            `json:"description"`
-	Priority          *CodeableConcept           `json:"priority,omitempty"`
-	Start             *CodeableConcept           `json:"start,omitempty"`
-	Addresses         []CodeableConcept          `json:"addresses,omitempty"`
-	Documentation     []RelatedArtifact          `json:"documentation,omitempty"`
-	Target            []PlanDefinitionGoalTarget `json:"target,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          *CodeableConcept           `bson:"category,omitempty" json:"category,omitempty"`
+	Description       CodeableConcept            `bson:"description" json:"description"`
+	Priority          *CodeableConcept           `bson:"priority,omitempty" json:"priority,omitempty"`
+	Start             *CodeableConcept           `bson:"start,omitempty" json:"start,omitempty"`
+	Addresses         []CodeableConcept          `bson:"addresses,omitempty" json:"addresses,omitempty"`
+	Documentation     []RelatedArtifact          `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Target            []PlanDefinitionGoalTarget `bson:"target,omitempty" json:"target,omitempty"`
 }
 type PlanDefinitionGoalTarget struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Measure           *CodeableConcept `json:"measure,omitempty"`
-	Due               *Duration        `json:"due,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Measure           *CodeableConcept `bson:"measure,omitempty" json:"measure,omitempty"`
+	Due               *Duration        `bson:"due,omitempty" json:"due,omitempty"`
 }
 type PlanDefinitionAction struct {
-	Id                  *string                             `json:"id,omitempty"`
-	Extension           []Extension                         `json:"extension,omitempty"`
-	ModifierExtension   []Extension                         `json:"modifierExtension,omitempty"`
-	Prefix              *string                             `json:"prefix,omitempty"`
-	Title               *string                             `json:"title,omitempty"`
-	Description         *string                             `json:"description,omitempty"`
-	TextEquivalent      *string                             `json:"textEquivalent,omitempty"`
-	Priority            *RequestPriority                    `json:"priority,omitempty"`
-	Code                []CodeableConcept                   `json:"code,omitempty"`
-	Reason              []CodeableConcept                   `json:"reason,omitempty"`
-	Documentation       []RelatedArtifact                   `json:"documentation,omitempty"`
-	GoalId              []string                            `json:"goalId,omitempty"`
-	Trigger             []TriggerDefinition                 `json:"trigger,omitempty"`
-	Condition           []PlanDefinitionActionCondition     `json:"condition,omitempty"`
-	Input               []DataRequirement                   `json:"input,omitempty"`
-	Output              []DataRequirement                   `json:"output,omitempty"`
-	RelatedAction       []PlanDefinitionActionRelatedAction `json:"relatedAction,omitempty"`
-	Participant         []PlanDefinitionActionParticipant   `json:"participant,omitempty"`
-	Type                *CodeableConcept                    `json:"type,omitempty"`
-	GroupingBehavior    *ActionGroupingBehavior             `json:"groupingBehavior,omitempty"`
-	SelectionBehavior   *ActionSelectionBehavior            `json:"selectionBehavior,omitempty"`
-	RequiredBehavior    *ActionRequiredBehavior             `json:"requiredBehavior,omitempty"`
-	PrecheckBehavior    *ActionPrecheckBehavior             `json:"precheckBehavior,omitempty"`
-	CardinalityBehavior *ActionCardinalityBehavior          `json:"cardinalityBehavior,omitempty"`
-	Transform           *string                             `json:"transform,omitempty"`
-	DynamicValue        []PlanDefinitionActionDynamicValue  `json:"dynamicValue,omitempty"`
-	Action              []PlanDefinitionAction              `json:"action,omitempty"`
+	Id                  *string                             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Prefix              *string                             `bson:"prefix,omitempty" json:"prefix,omitempty"`
+	Title               *string                             `bson:"title,omitempty" json:"title,omitempty"`
+	Description         *string                             `bson:"description,omitempty" json:"description,omitempty"`
+	TextEquivalent      *string                             `bson:"textEquivalent,omitempty" json:"textEquivalent,omitempty"`
+	Priority            *RequestPriority                    `bson:"priority,omitempty" json:"priority,omitempty"`
+	Code                []CodeableConcept                   `bson:"code,omitempty" json:"code,omitempty"`
+	Reason              []CodeableConcept                   `bson:"reason,omitempty" json:"reason,omitempty"`
+	Documentation       []RelatedArtifact                   `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	GoalId              []string                            `bson:"goalId,omitempty" json:"goalId,omitempty"`
+	Trigger             []TriggerDefinition                 `bson:"trigger,omitempty" json:"trigger,omitempty"`
+	Condition           []PlanDefinitionActionCondition     `bson:"condition,omitempty" json:"condition,omitempty"`
+	Input               []DataRequirement                   `bson:"input,omitempty" json:"input,omitempty"`
+	Output              []DataRequirement                   `bson:"output,omitempty" json:"output,omitempty"`
+	RelatedAction       []PlanDefinitionActionRelatedAction `bson:"relatedAction,omitempty" json:"relatedAction,omitempty"`
+	Participant         []PlanDefinitionActionParticipant   `bson:"participant,omitempty" json:"participant,omitempty"`
+	Type                *CodeableConcept                    `bson:"type,omitempty" json:"type,omitempty"`
+	GroupingBehavior    *ActionGroupingBehavior             `bson:"groupingBehavior,omitempty" json:"groupingBehavior,omitempty"`
+	SelectionBehavior   *ActionSelectionBehavior            `bson:"selectionBehavior,omitempty" json:"selectionBehavior,omitempty"`
+	RequiredBehavior    *ActionRequiredBehavior             `bson:"requiredBehavior,omitempty" json:"requiredBehavior,omitempty"`
+	PrecheckBehavior    *ActionPrecheckBehavior             `bson:"precheckBehavior,omitempty" json:"precheckBehavior,omitempty"`
+	CardinalityBehavior *ActionCardinalityBehavior          `bson:"cardinalityBehavior,omitempty" json:"cardinalityBehavior,omitempty"`
+	Transform           *string                             `bson:"transform,omitempty" json:"transform,omitempty"`
+	DynamicValue        []PlanDefinitionActionDynamicValue  `bson:"dynamicValue,omitempty" json:"dynamicValue,omitempty"`
+	Action              []PlanDefinitionAction              `bson:"action,omitempty" json:"action,omitempty"`
 }
 type PlanDefinitionActionCondition struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Kind              ActionConditionKind `json:"kind"`
-	Expression        *Expression         `json:"expression,omitempty"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Kind              ActionConditionKind `bson:"kind" json:"kind"`
+	Expression        *Expression         `bson:"expression,omitempty" json:"expression,omitempty"`
 }
 type PlanDefinitionActionRelatedAction struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	ActionId          string                 `json:"actionId"`
-	Relationship      ActionRelationshipType `json:"relationship"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ActionId          string                 `bson:"actionId" json:"actionId"`
+	Relationship      ActionRelationshipType `bson:"relationship" json:"relationship"`
 }
 type PlanDefinitionActionParticipant struct {
-	Id                *string               `json:"id,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Type              ActionParticipantType `json:"type"`
-	Role              *CodeableConcept      `json:"role,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ActionParticipantType `bson:"type" json:"type"`
+	Role              *CodeableConcept      `bson:"role,omitempty" json:"role,omitempty"`
 }
 type PlanDefinitionActionDynamicValue struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Path              *string     `json:"path,omitempty"`
-	Expression        *Expression `json:"expression,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Path              *string     `bson:"path,omitempty" json:"path,omitempty"`
+	Expression        *Expression `bson:"expression,omitempty" json:"expression,omitempty"`
 }
 type OtherPlanDefinition PlanDefinition
 

--- a/fhir-models/fhir/population.go
+++ b/fhir-models/fhir/population.go
@@ -19,10 +19,10 @@ package fhir
 
 // Population is documented here http://hl7.org/fhir/StructureDefinition/Population
 type Population struct {
-	Id                     *string          `json:"id,omitempty"`
-	Extension              []Extension      `json:"extension,omitempty"`
-	ModifierExtension      []Extension      `json:"modifierExtension,omitempty"`
-	Gender                 *CodeableConcept `json:"gender,omitempty"`
-	Race                   *CodeableConcept `json:"race,omitempty"`
-	PhysiologicalCondition *CodeableConcept `json:"physiologicalCondition,omitempty"`
+	Id                     *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension              []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Gender                 *CodeableConcept `bson:"gender,omitempty" json:"gender,omitempty"`
+	Race                   *CodeableConcept `bson:"race,omitempty" json:"race,omitempty"`
+	PhysiologicalCondition *CodeableConcept `bson:"physiologicalCondition,omitempty" json:"physiologicalCondition,omitempty"`
 }

--- a/fhir-models/fhir/practitioner.go
+++ b/fhir-models/fhir/practitioner.go
@@ -21,32 +21,32 @@ import "encoding/json"
 
 // Practitioner is documented here http://hl7.org/fhir/StructureDefinition/Practitioner
 type Practitioner struct {
-	Id                *string                     `json:"id,omitempty"`
-	Meta              *Meta                       `json:"meta,omitempty"`
-	ImplicitRules     *string                     `json:"implicitRules,omitempty"`
-	Language          *string                     `json:"language,omitempty"`
-	Text              *Narrative                  `json:"text,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                `json:"identifier,omitempty"`
-	Active            *bool                       `json:"active,omitempty"`
-	Name              []HumanName                 `json:"name,omitempty"`
-	Telecom           []ContactPoint              `json:"telecom,omitempty"`
-	Address           []Address                   `json:"address,omitempty"`
-	Gender            *AdministrativeGender       `json:"gender,omitempty"`
-	BirthDate         *string                     `json:"birthDate,omitempty"`
-	Photo             []Attachment                `json:"photo,omitempty"`
-	Qualification     []PractitionerQualification `json:"qualification,omitempty"`
-	Communication     []CodeableConcept           `json:"communication,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active            *bool                       `bson:"active,omitempty" json:"active,omitempty"`
+	Name              []HumanName                 `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom           []ContactPoint              `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Address           []Address                   `bson:"address,omitempty" json:"address,omitempty"`
+	Gender            *AdministrativeGender       `bson:"gender,omitempty" json:"gender,omitempty"`
+	BirthDate         *string                     `bson:"birthDate,omitempty" json:"birthDate,omitempty"`
+	Photo             []Attachment                `bson:"photo,omitempty" json:"photo,omitempty"`
+	Qualification     []PractitionerQualification `bson:"qualification,omitempty" json:"qualification,omitempty"`
+	Communication     []CodeableConcept           `bson:"communication,omitempty" json:"communication,omitempty"`
 }
 type PractitionerQualification struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier    `json:"identifier,omitempty"`
-	Code              CodeableConcept `json:"code"`
-	Period            *Period         `json:"period,omitempty"`
-	Issuer            *Reference      `json:"issuer,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Code              CodeableConcept `bson:"code" json:"code"`
+	Period            *Period         `bson:"period,omitempty" json:"period,omitempty"`
+	Issuer            *Reference      `bson:"issuer,omitempty" json:"issuer,omitempty"`
 }
 type OtherPractitioner Practitioner
 

--- a/fhir-models/fhir/practitionerRole.go
+++ b/fhir-models/fhir/practitionerRole.go
@@ -21,43 +21,43 @@ import "encoding/json"
 
 // PractitionerRole is documented here http://hl7.org/fhir/StructureDefinition/PractitionerRole
 type PractitionerRole struct {
-	Id                     *string                         `json:"id,omitempty"`
-	Meta                   *Meta                           `json:"meta,omitempty"`
-	ImplicitRules          *string                         `json:"implicitRules,omitempty"`
-	Language               *string                         `json:"language,omitempty"`
-	Text                   *Narrative                      `json:"text,omitempty"`
-	Extension              []Extension                     `json:"extension,omitempty"`
-	ModifierExtension      []Extension                     `json:"modifierExtension,omitempty"`
-	Identifier             []Identifier                    `json:"identifier,omitempty"`
-	Active                 *bool                           `json:"active,omitempty"`
-	Period                 *Period                         `json:"period,omitempty"`
-	Practitioner           *Reference                      `json:"practitioner,omitempty"`
-	Organization           *Reference                      `json:"organization,omitempty"`
-	Code                   []CodeableConcept               `json:"code,omitempty"`
-	Specialty              []CodeableConcept               `json:"specialty,omitempty"`
-	Location               []Reference                     `json:"location,omitempty"`
-	HealthcareService      []Reference                     `json:"healthcareService,omitempty"`
-	Telecom                []ContactPoint                  `json:"telecom,omitempty"`
-	AvailableTime          []PractitionerRoleAvailableTime `json:"availableTime,omitempty"`
-	NotAvailable           []PractitionerRoleNotAvailable  `json:"notAvailable,omitempty"`
-	AvailabilityExceptions *string                         `json:"availabilityExceptions,omitempty"`
-	Endpoint               []Reference                     `json:"endpoint,omitempty"`
+	Id                     *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                   *Meta                           `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules          *string                         `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language               *string                         `bson:"language,omitempty" json:"language,omitempty"`
+	Text                   *Narrative                      `bson:"text,omitempty" json:"text,omitempty"`
+	Extension              []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension      []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier             []Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active                 *bool                           `bson:"active,omitempty" json:"active,omitempty"`
+	Period                 *Period                         `bson:"period,omitempty" json:"period,omitempty"`
+	Practitioner           *Reference                      `bson:"practitioner,omitempty" json:"practitioner,omitempty"`
+	Organization           *Reference                      `bson:"organization,omitempty" json:"organization,omitempty"`
+	Code                   []CodeableConcept               `bson:"code,omitempty" json:"code,omitempty"`
+	Specialty              []CodeableConcept               `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	Location               []Reference                     `bson:"location,omitempty" json:"location,omitempty"`
+	HealthcareService      []Reference                     `bson:"healthcareService,omitempty" json:"healthcareService,omitempty"`
+	Telecom                []ContactPoint                  `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	AvailableTime          []PractitionerRoleAvailableTime `bson:"availableTime,omitempty" json:"availableTime,omitempty"`
+	NotAvailable           []PractitionerRoleNotAvailable  `bson:"notAvailable,omitempty" json:"notAvailable,omitempty"`
+	AvailabilityExceptions *string                         `bson:"availabilityExceptions,omitempty" json:"availabilityExceptions,omitempty"`
+	Endpoint               []Reference                     `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
 }
 type PractitionerRoleAvailableTime struct {
-	Id                 *string      `json:"id,omitempty"`
-	Extension          []Extension  `json:"extension,omitempty"`
-	ModifierExtension  []Extension  `json:"modifierExtension,omitempty"`
-	DaysOfWeek         []DaysOfWeek `json:"daysOfWeek,omitempty"`
-	AllDay             *bool        `json:"allDay,omitempty"`
-	AvailableStartTime *string      `json:"availableStartTime,omitempty"`
-	AvailableEndTime   *string      `json:"availableEndTime,omitempty"`
+	Id                 *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	DaysOfWeek         []DaysOfWeek `bson:"daysOfWeek,omitempty" json:"daysOfWeek,omitempty"`
+	AllDay             *bool        `bson:"allDay,omitempty" json:"allDay,omitempty"`
+	AvailableStartTime *string      `bson:"availableStartTime,omitempty" json:"availableStartTime,omitempty"`
+	AvailableEndTime   *string      `bson:"availableEndTime,omitempty" json:"availableEndTime,omitempty"`
 }
 type PractitionerRoleNotAvailable struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Description       string      `json:"description"`
-	During            *Period     `json:"during,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       string      `bson:"description" json:"description"`
+	During            *Period     `bson:"during,omitempty" json:"during,omitempty"`
 }
 type OtherPractitionerRole PractitionerRole
 

--- a/fhir-models/fhir/procedure.go
+++ b/fhir-models/fhir/procedure.go
@@ -21,55 +21,55 @@ import "encoding/json"
 
 // Procedure is documented here http://hl7.org/fhir/StructureDefinition/Procedure
 type Procedure struct {
-	Id                    *string                `json:"id,omitempty"`
-	Meta                  *Meta                  `json:"meta,omitempty"`
-	ImplicitRules         *string                `json:"implicitRules,omitempty"`
-	Language              *string                `json:"language,omitempty"`
-	Text                  *Narrative             `json:"text,omitempty"`
-	Extension             []Extension            `json:"extension,omitempty"`
-	ModifierExtension     []Extension            `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier           `json:"identifier,omitempty"`
-	InstantiatesCanonical []string               `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string               `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference            `json:"basedOn,omitempty"`
-	PartOf                []Reference            `json:"partOf,omitempty"`
-	Status                EventStatus            `json:"status"`
-	StatusReason          *CodeableConcept       `json:"statusReason,omitempty"`
-	Category              *CodeableConcept       `json:"category,omitempty"`
-	Code                  *CodeableConcept       `json:"code,omitempty"`
-	Subject               Reference              `json:"subject"`
-	Encounter             *Reference             `json:"encounter,omitempty"`
-	Recorder              *Reference             `json:"recorder,omitempty"`
-	Asserter              *Reference             `json:"asserter,omitempty"`
-	Performer             []ProcedurePerformer   `json:"performer,omitempty"`
-	Location              *Reference             `json:"location,omitempty"`
-	ReasonCode            []CodeableConcept      `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference            `json:"reasonReference,omitempty"`
-	BodySite              []CodeableConcept      `json:"bodySite,omitempty"`
-	Outcome               *CodeableConcept       `json:"outcome,omitempty"`
-	Report                []Reference            `json:"report,omitempty"`
-	Complication          []CodeableConcept      `json:"complication,omitempty"`
-	ComplicationDetail    []Reference            `json:"complicationDetail,omitempty"`
-	FollowUp              []CodeableConcept      `json:"followUp,omitempty"`
-	Note                  []Annotation           `json:"note,omitempty"`
-	FocalDevice           []ProcedureFocalDevice `json:"focalDevice,omitempty"`
-	UsedReference         []Reference            `json:"usedReference,omitempty"`
-	UsedCode              []CodeableConcept      `json:"usedCode,omitempty"`
+	Id                    *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier           `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string               `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string               `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference            `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf                []Reference            `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status                EventStatus            `bson:"status" json:"status"`
+	StatusReason          *CodeableConcept       `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	Category              *CodeableConcept       `bson:"category,omitempty" json:"category,omitempty"`
+	Code                  *CodeableConcept       `bson:"code,omitempty" json:"code,omitempty"`
+	Subject               Reference              `bson:"subject" json:"subject"`
+	Encounter             *Reference             `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Recorder              *Reference             `bson:"recorder,omitempty" json:"recorder,omitempty"`
+	Asserter              *Reference             `bson:"asserter,omitempty" json:"asserter,omitempty"`
+	Performer             []ProcedurePerformer   `bson:"performer,omitempty" json:"performer,omitempty"`
+	Location              *Reference             `bson:"location,omitempty" json:"location,omitempty"`
+	ReasonCode            []CodeableConcept      `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference            `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	BodySite              []CodeableConcept      `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Outcome               *CodeableConcept       `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	Report                []Reference            `bson:"report,omitempty" json:"report,omitempty"`
+	Complication          []CodeableConcept      `bson:"complication,omitempty" json:"complication,omitempty"`
+	ComplicationDetail    []Reference            `bson:"complicationDetail,omitempty" json:"complicationDetail,omitempty"`
+	FollowUp              []CodeableConcept      `bson:"followUp,omitempty" json:"followUp,omitempty"`
+	Note                  []Annotation           `bson:"note,omitempty" json:"note,omitempty"`
+	FocalDevice           []ProcedureFocalDevice `bson:"focalDevice,omitempty" json:"focalDevice,omitempty"`
+	UsedReference         []Reference            `bson:"usedReference,omitempty" json:"usedReference,omitempty"`
+	UsedCode              []CodeableConcept      `bson:"usedCode,omitempty" json:"usedCode,omitempty"`
 }
 type ProcedurePerformer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Function          *CodeableConcept `json:"function,omitempty"`
-	Actor             Reference        `json:"actor"`
-	OnBehalfOf        *Reference       `json:"onBehalfOf,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Function          *CodeableConcept `bson:"function,omitempty" json:"function,omitempty"`
+	Actor             Reference        `bson:"actor" json:"actor"`
+	OnBehalfOf        *Reference       `bson:"onBehalfOf,omitempty" json:"onBehalfOf,omitempty"`
 }
 type ProcedureFocalDevice struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Action            *CodeableConcept `json:"action,omitempty"`
-	Manipulated       Reference        `json:"manipulated"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Action            *CodeableConcept `bson:"action,omitempty" json:"action,omitempty"`
+	Manipulated       Reference        `bson:"manipulated" json:"manipulated"`
 }
 type OtherProcedure Procedure
 

--- a/fhir-models/fhir/prodCharacteristic.go
+++ b/fhir-models/fhir/prodCharacteristic.go
@@ -19,18 +19,18 @@ package fhir
 
 // ProdCharacteristic is documented here http://hl7.org/fhir/StructureDefinition/ProdCharacteristic
 type ProdCharacteristic struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Height            *Quantity        `json:"height,omitempty"`
-	Width             *Quantity        `json:"width,omitempty"`
-	Depth             *Quantity        `json:"depth,omitempty"`
-	Weight            *Quantity        `json:"weight,omitempty"`
-	NominalVolume     *Quantity        `json:"nominalVolume,omitempty"`
-	ExternalDiameter  *Quantity        `json:"externalDiameter,omitempty"`
-	Shape             *string          `json:"shape,omitempty"`
-	Color             []string         `json:"color,omitempty"`
-	Imprint           []string         `json:"imprint,omitempty"`
-	Image             []Attachment     `json:"image,omitempty"`
-	Scoring           *CodeableConcept `json:"scoring,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Height            *Quantity        `bson:"height,omitempty" json:"height,omitempty"`
+	Width             *Quantity        `bson:"width,omitempty" json:"width,omitempty"`
+	Depth             *Quantity        `bson:"depth,omitempty" json:"depth,omitempty"`
+	Weight            *Quantity        `bson:"weight,omitempty" json:"weight,omitempty"`
+	NominalVolume     *Quantity        `bson:"nominalVolume,omitempty" json:"nominalVolume,omitempty"`
+	ExternalDiameter  *Quantity        `bson:"externalDiameter,omitempty" json:"externalDiameter,omitempty"`
+	Shape             *string          `bson:"shape,omitempty" json:"shape,omitempty"`
+	Color             []string         `bson:"color,omitempty" json:"color,omitempty"`
+	Imprint           []string         `bson:"imprint,omitempty" json:"imprint,omitempty"`
+	Image             []Attachment     `bson:"image,omitempty" json:"image,omitempty"`
+	Scoring           *CodeableConcept `bson:"scoring,omitempty" json:"scoring,omitempty"`
 }

--- a/fhir-models/fhir/productShelfLife.go
+++ b/fhir-models/fhir/productShelfLife.go
@@ -19,11 +19,11 @@ package fhir
 
 // ProductShelfLife is documented here http://hl7.org/fhir/StructureDefinition/ProductShelfLife
 type ProductShelfLife struct {
-	Id                           *string           `json:"id,omitempty"`
-	Extension                    []Extension       `json:"extension,omitempty"`
-	ModifierExtension            []Extension       `json:"modifierExtension,omitempty"`
-	Identifier                   *Identifier       `json:"identifier,omitempty"`
-	Type                         CodeableConcept   `json:"type"`
-	Period                       Quantity          `json:"period"`
-	SpecialPrecautionsForStorage []CodeableConcept `json:"specialPrecautionsForStorage,omitempty"`
+	Id                           *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                    []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension            []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier                   *Identifier       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type                         CodeableConcept   `bson:"type" json:"type"`
+	Period                       Quantity          `bson:"period" json:"period"`
+	SpecialPrecautionsForStorage []CodeableConcept `bson:"specialPrecautionsForStorage,omitempty" json:"specialPrecautionsForStorage,omitempty"`
 }

--- a/fhir-models/fhir/provenance.go
+++ b/fhir-models/fhir/provenance.go
@@ -21,39 +21,39 @@ import "encoding/json"
 
 // Provenance is documented here http://hl7.org/fhir/StructureDefinition/Provenance
 type Provenance struct {
-	Id                *string            `json:"id,omitempty"`
-	Meta              *Meta              `json:"meta,omitempty"`
-	ImplicitRules     *string            `json:"implicitRules,omitempty"`
-	Language          *string            `json:"language,omitempty"`
-	Text              *Narrative         `json:"text,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Target            []Reference        `json:"target"`
-	Recorded          string             `json:"recorded"`
-	Policy            []string           `json:"policy,omitempty"`
-	Location          *Reference         `json:"location,omitempty"`
-	Reason            []CodeableConcept  `json:"reason,omitempty"`
-	Activity          *CodeableConcept   `json:"activity,omitempty"`
-	Agent             []ProvenanceAgent  `json:"agent"`
-	Entity            []ProvenanceEntity `json:"entity,omitempty"`
-	Signature         []Signature        `json:"signature,omitempty"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Target            []Reference        `bson:"target" json:"target"`
+	Recorded          string             `bson:"recorded" json:"recorded"`
+	Policy            []string           `bson:"policy,omitempty" json:"policy,omitempty"`
+	Location          *Reference         `bson:"location,omitempty" json:"location,omitempty"`
+	Reason            []CodeableConcept  `bson:"reason,omitempty" json:"reason,omitempty"`
+	Activity          *CodeableConcept   `bson:"activity,omitempty" json:"activity,omitempty"`
+	Agent             []ProvenanceAgent  `bson:"agent" json:"agent"`
+	Entity            []ProvenanceEntity `bson:"entity,omitempty" json:"entity,omitempty"`
+	Signature         []Signature        `bson:"signature,omitempty" json:"signature,omitempty"`
 }
 type ProvenanceAgent struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept  `json:"type,omitempty"`
-	Role              []CodeableConcept `json:"role,omitempty"`
-	Who               Reference         `json:"who"`
-	OnBehalfOf        *Reference        `json:"onBehalfOf,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	Role              []CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Who               Reference         `bson:"who" json:"who"`
+	OnBehalfOf        *Reference        `bson:"onBehalfOf,omitempty" json:"onBehalfOf,omitempty"`
 }
 type ProvenanceEntity struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Role              ProvenanceEntityRole `json:"role"`
-	What              Reference            `json:"what"`
-	Agent             []ProvenanceAgent    `json:"agent,omitempty"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Role              ProvenanceEntityRole `bson:"role" json:"role"`
+	What              Reference            `bson:"what" json:"what"`
+	Agent             []ProvenanceAgent    `bson:"agent,omitempty" json:"agent,omitempty"`
 }
 type OtherProvenance Provenance
 

--- a/fhir-models/fhir/quantity.go
+++ b/fhir-models/fhir/quantity.go
@@ -19,11 +19,11 @@ package fhir
 
 // Quantity is documented here http://hl7.org/fhir/StructureDefinition/Quantity
 type Quantity struct {
-	Id         *string             `json:"id,omitempty"`
-	Extension  []Extension         `json:"extension,omitempty"`
-	Value      *string             `json:"value,omitempty"`
-	Comparator *QuantityComparator `json:"comparator,omitempty"`
-	Unit       *string             `json:"unit,omitempty"`
-	System     *string             `json:"system,omitempty"`
-	Code       *string             `json:"code,omitempty"`
+	Id         *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension  []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	Value      *string             `bson:"value,omitempty" json:"value,omitempty"`
+	Comparator *QuantityComparator `bson:"comparator,omitempty" json:"comparator,omitempty"`
+	Unit       *string             `bson:"unit,omitempty" json:"unit,omitempty"`
+	System     *string             `bson:"system,omitempty" json:"system,omitempty"`
+	Code       *string             `bson:"code,omitempty" json:"code,omitempty"`
 }

--- a/fhir-models/fhir/questionnaire.go
+++ b/fhir-models/fhir/questionnaire.go
@@ -21,74 +21,74 @@ import "encoding/json"
 
 // Questionnaire is documented here http://hl7.org/fhir/StructureDefinition/Questionnaire
 type Questionnaire struct {
-	Id                *string             `json:"id,omitempty"`
-	Meta              *Meta               `json:"meta,omitempty"`
-	ImplicitRules     *string             `json:"implicitRules,omitempty"`
-	Language          *string             `json:"language,omitempty"`
-	Text              *Narrative          `json:"text,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Url               *string             `json:"url,omitempty"`
-	Identifier        []Identifier        `json:"identifier,omitempty"`
-	Version           *string             `json:"version,omitempty"`
-	Name              *string             `json:"name,omitempty"`
-	Title             *string             `json:"title,omitempty"`
-	DerivedFrom       []string            `json:"derivedFrom,omitempty"`
-	Status            PublicationStatus   `json:"status"`
-	Experimental      *bool               `json:"experimental,omitempty"`
-	SubjectType       []ResourceType      `json:"subjectType,omitempty"`
-	Date              *string             `json:"date,omitempty"`
-	Publisher         *string             `json:"publisher,omitempty"`
-	Contact           []ContactDetail     `json:"contact,omitempty"`
-	Description       *string             `json:"description,omitempty"`
-	UseContext        []UsageContext      `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept   `json:"jurisdiction,omitempty"`
-	Purpose           *string             `json:"purpose,omitempty"`
-	Copyright         *string             `json:"copyright,omitempty"`
-	ApprovalDate      *string             `json:"approvalDate,omitempty"`
-	LastReviewDate    *string             `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period             `json:"effectivePeriod,omitempty"`
-	Code              []Coding            `json:"code,omitempty"`
-	Item              []QuestionnaireItem `json:"item,omitempty"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string             `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier        `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string             `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string             `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string             `bson:"title,omitempty" json:"title,omitempty"`
+	DerivedFrom       []string            `bson:"derivedFrom,omitempty" json:"derivedFrom,omitempty"`
+	Status            PublicationStatus   `bson:"status" json:"status"`
+	Experimental      *bool               `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	SubjectType       []ResourceType      `bson:"subjectType,omitempty" json:"subjectType,omitempty"`
+	Date              *string             `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string             `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail     `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string             `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext      `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept   `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string             `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string             `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string             `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string             `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period             `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Code              []Coding            `bson:"code,omitempty" json:"code,omitempty"`
+	Item              []QuestionnaireItem `bson:"item,omitempty" json:"item,omitempty"`
 }
 type QuestionnaireItem struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	LinkId            string                          `json:"linkId"`
-	Definition        *string                         `json:"definition,omitempty"`
-	Code              []Coding                        `json:"code,omitempty"`
-	Prefix            *string                         `json:"prefix,omitempty"`
-	Text              *string                         `json:"text,omitempty"`
-	Type              QuestionnaireItemType           `json:"type"`
-	EnableWhen        []QuestionnaireItemEnableWhen   `json:"enableWhen,omitempty"`
-	EnableBehavior    *EnableWhenBehavior             `json:"enableBehavior,omitempty"`
-	Required          *bool                           `json:"required,omitempty"`
-	Repeats           *bool                           `json:"repeats,omitempty"`
-	ReadOnly          *bool                           `json:"readOnly,omitempty"`
-	MaxLength         *int                            `json:"maxLength,omitempty"`
-	AnswerValueSet    *string                         `json:"answerValueSet,omitempty"`
-	AnswerOption      []QuestionnaireItemAnswerOption `json:"answerOption,omitempty"`
-	Initial           []QuestionnaireItemInitial      `json:"initial,omitempty"`
-	Item              []QuestionnaireItem             `json:"item,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	LinkId            string                          `bson:"linkId" json:"linkId"`
+	Definition        *string                         `bson:"definition,omitempty" json:"definition,omitempty"`
+	Code              []Coding                        `bson:"code,omitempty" json:"code,omitempty"`
+	Prefix            *string                         `bson:"prefix,omitempty" json:"prefix,omitempty"`
+	Text              *string                         `bson:"text,omitempty" json:"text,omitempty"`
+	Type              QuestionnaireItemType           `bson:"type" json:"type"`
+	EnableWhen        []QuestionnaireItemEnableWhen   `bson:"enableWhen,omitempty" json:"enableWhen,omitempty"`
+	EnableBehavior    *EnableWhenBehavior             `bson:"enableBehavior,omitempty" json:"enableBehavior,omitempty"`
+	Required          *bool                           `bson:"required,omitempty" json:"required,omitempty"`
+	Repeats           *bool                           `bson:"repeats,omitempty" json:"repeats,omitempty"`
+	ReadOnly          *bool                           `bson:"readOnly,omitempty" json:"readOnly,omitempty"`
+	MaxLength         *int                            `bson:"maxLength,omitempty" json:"maxLength,omitempty"`
+	AnswerValueSet    *string                         `bson:"answerValueSet,omitempty" json:"answerValueSet,omitempty"`
+	AnswerOption      []QuestionnaireItemAnswerOption `bson:"answerOption,omitempty" json:"answerOption,omitempty"`
+	Initial           []QuestionnaireItemInitial      `bson:"initial,omitempty" json:"initial,omitempty"`
+	Item              []QuestionnaireItem             `bson:"item,omitempty" json:"item,omitempty"`
 }
 type QuestionnaireItemEnableWhen struct {
-	Id                *string                   `json:"id,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Question          string                    `json:"question"`
-	Operator          QuestionnaireItemOperator `json:"operator"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Question          string                    `bson:"question" json:"question"`
+	Operator          QuestionnaireItemOperator `bson:"operator" json:"operator"`
 }
 type QuestionnaireItemAnswerOption struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	InitialSelected   *bool       `json:"initialSelected,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	InitialSelected   *bool       `bson:"initialSelected,omitempty" json:"initialSelected,omitempty"`
 }
 type QuestionnaireItemInitial struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type OtherQuestionnaire Questionnaire
 

--- a/fhir-models/fhir/questionnaireResponse.go
+++ b/fhir-models/fhir/questionnaireResponse.go
@@ -21,40 +21,40 @@ import "encoding/json"
 
 // QuestionnaireResponse is documented here http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse
 type QuestionnaireResponse struct {
-	Id                *string                     `json:"id,omitempty"`
-	Meta              *Meta                       `json:"meta,omitempty"`
-	ImplicitRules     *string                     `json:"implicitRules,omitempty"`
-	Language          *string                     `json:"language,omitempty"`
-	Text              *Narrative                  `json:"text,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier                 `json:"identifier,omitempty"`
-	BasedOn           []Reference                 `json:"basedOn,omitempty"`
-	PartOf            []Reference                 `json:"partOf,omitempty"`
-	Questionnaire     *string                     `json:"questionnaire,omitempty"`
-	Status            QuestionnaireResponseStatus `json:"status"`
-	Subject           *Reference                  `json:"subject,omitempty"`
-	Encounter         *Reference                  `json:"encounter,omitempty"`
-	Authored          *string                     `json:"authored,omitempty"`
-	Author            *Reference                  `json:"author,omitempty"`
-	Source            *Reference                  `json:"source,omitempty"`
-	Item              []QuestionnaireResponseItem `json:"item,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference                 `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf            []Reference                 `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Questionnaire     *string                     `bson:"questionnaire,omitempty" json:"questionnaire,omitempty"`
+	Status            QuestionnaireResponseStatus `bson:"status" json:"status"`
+	Subject           *Reference                  `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter         *Reference                  `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Authored          *string                     `bson:"authored,omitempty" json:"authored,omitempty"`
+	Author            *Reference                  `bson:"author,omitempty" json:"author,omitempty"`
+	Source            *Reference                  `bson:"source,omitempty" json:"source,omitempty"`
+	Item              []QuestionnaireResponseItem `bson:"item,omitempty" json:"item,omitempty"`
 }
 type QuestionnaireResponseItem struct {
-	Id                *string                           `json:"id,omitempty"`
-	Extension         []Extension                       `json:"extension,omitempty"`
-	ModifierExtension []Extension                       `json:"modifierExtension,omitempty"`
-	LinkId            string                            `json:"linkId"`
-	Definition        *string                           `json:"definition,omitempty"`
-	Text              *string                           `json:"text,omitempty"`
-	Answer            []QuestionnaireResponseItemAnswer `json:"answer,omitempty"`
-	Item              []QuestionnaireResponseItem       `json:"item,omitempty"`
+	Id                *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	LinkId            string                            `bson:"linkId" json:"linkId"`
+	Definition        *string                           `bson:"definition,omitempty" json:"definition,omitempty"`
+	Text              *string                           `bson:"text,omitempty" json:"text,omitempty"`
+	Answer            []QuestionnaireResponseItemAnswer `bson:"answer,omitempty" json:"answer,omitempty"`
+	Item              []QuestionnaireResponseItem       `bson:"item,omitempty" json:"item,omitempty"`
 }
 type QuestionnaireResponseItemAnswer struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Item              []QuestionnaireResponseItem `json:"item,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Item              []QuestionnaireResponseItem `bson:"item,omitempty" json:"item,omitempty"`
 }
 type OtherQuestionnaireResponse QuestionnaireResponse
 

--- a/fhir-models/fhir/range.go
+++ b/fhir-models/fhir/range.go
@@ -19,8 +19,8 @@ package fhir
 
 // Range is documented here http://hl7.org/fhir/StructureDefinition/Range
 type Range struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Low       *Quantity   `json:"low,omitempty"`
-	High      *Quantity   `json:"high,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Low       *Quantity   `bson:"low,omitempty" json:"low,omitempty"`
+	High      *Quantity   `bson:"high,omitempty" json:"high,omitempty"`
 }

--- a/fhir-models/fhir/ratio.go
+++ b/fhir-models/fhir/ratio.go
@@ -19,8 +19,8 @@ package fhir
 
 // Ratio is documented here http://hl7.org/fhir/StructureDefinition/Ratio
 type Ratio struct {
-	Id          *string     `json:"id,omitempty"`
-	Extension   []Extension `json:"extension,omitempty"`
-	Numerator   *Quantity   `json:"numerator,omitempty"`
-	Denominator *Quantity   `json:"denominator,omitempty"`
+	Id          *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension   []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Numerator   *Quantity   `bson:"numerator,omitempty" json:"numerator,omitempty"`
+	Denominator *Quantity   `bson:"denominator,omitempty" json:"denominator,omitempty"`
 }

--- a/fhir-models/fhir/reference.go
+++ b/fhir-models/fhir/reference.go
@@ -19,10 +19,10 @@ package fhir
 
 // Reference is documented here http://hl7.org/fhir/StructureDefinition/Reference
 type Reference struct {
-	Id         *string     `json:"id,omitempty"`
-	Extension  []Extension `json:"extension,omitempty"`
-	Reference  *string     `json:"reference,omitempty"`
-	Type       *string     `json:"type,omitempty"`
-	Identifier *Identifier `json:"identifier,omitempty"`
-	Display    *string     `json:"display,omitempty"`
+	Id         *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension  []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Reference  *string     `bson:"reference,omitempty" json:"reference,omitempty"`
+	Type       *string     `bson:"type,omitempty" json:"type,omitempty"`
+	Identifier *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Display    *string     `bson:"display,omitempty" json:"display,omitempty"`
 }

--- a/fhir-models/fhir/relatedArtifact.go
+++ b/fhir-models/fhir/relatedArtifact.go
@@ -19,13 +19,13 @@ package fhir
 
 // RelatedArtifact is documented here http://hl7.org/fhir/StructureDefinition/RelatedArtifact
 type RelatedArtifact struct {
-	Id        *string             `json:"id,omitempty"`
-	Extension []Extension         `json:"extension,omitempty"`
-	Type      RelatedArtifactType `json:"type"`
-	Label     *string             `json:"label,omitempty"`
-	Display   *string             `json:"display,omitempty"`
-	Citation  *string             `json:"citation,omitempty"`
-	Url       *string             `json:"url,omitempty"`
-	Document  *Attachment         `json:"document,omitempty"`
-	Resource  *string             `json:"resource,omitempty"`
+	Id        *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type      RelatedArtifactType `bson:"type" json:"type"`
+	Label     *string             `bson:"label,omitempty" json:"label,omitempty"`
+	Display   *string             `bson:"display,omitempty" json:"display,omitempty"`
+	Citation  *string             `bson:"citation,omitempty" json:"citation,omitempty"`
+	Url       *string             `bson:"url,omitempty" json:"url,omitempty"`
+	Document  *Attachment         `bson:"document,omitempty" json:"document,omitempty"`
+	Resource  *string             `bson:"resource,omitempty" json:"resource,omitempty"`
 }

--- a/fhir-models/fhir/relatedPerson.go
+++ b/fhir-models/fhir/relatedPerson.go
@@ -21,32 +21,32 @@ import "encoding/json"
 
 // RelatedPerson is documented here http://hl7.org/fhir/StructureDefinition/RelatedPerson
 type RelatedPerson struct {
-	Id                *string                      `json:"id,omitempty"`
-	Meta              *Meta                        `json:"meta,omitempty"`
-	ImplicitRules     *string                      `json:"implicitRules,omitempty"`
-	Language          *string                      `json:"language,omitempty"`
-	Text              *Narrative                   `json:"text,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                 `json:"identifier,omitempty"`
-	Active            *bool                        `json:"active,omitempty"`
-	Patient           Reference                    `json:"patient"`
-	Relationship      []CodeableConcept            `json:"relationship,omitempty"`
-	Name              []HumanName                  `json:"name,omitempty"`
-	Telecom           []ContactPoint               `json:"telecom,omitempty"`
-	Gender            *AdministrativeGender        `json:"gender,omitempty"`
-	BirthDate         *string                      `json:"birthDate,omitempty"`
-	Address           []Address                    `json:"address,omitempty"`
-	Photo             []Attachment                 `json:"photo,omitempty"`
-	Period            *Period                      `json:"period,omitempty"`
-	Communication     []RelatedPersonCommunication `json:"communication,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                 `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active            *bool                        `bson:"active,omitempty" json:"active,omitempty"`
+	Patient           Reference                    `bson:"patient" json:"patient"`
+	Relationship      []CodeableConcept            `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	Name              []HumanName                  `bson:"name,omitempty" json:"name,omitempty"`
+	Telecom           []ContactPoint               `bson:"telecom,omitempty" json:"telecom,omitempty"`
+	Gender            *AdministrativeGender        `bson:"gender,omitempty" json:"gender,omitempty"`
+	BirthDate         *string                      `bson:"birthDate,omitempty" json:"birthDate,omitempty"`
+	Address           []Address                    `bson:"address,omitempty" json:"address,omitempty"`
+	Photo             []Attachment                 `bson:"photo,omitempty" json:"photo,omitempty"`
+	Period            *Period                      `bson:"period,omitempty" json:"period,omitempty"`
+	Communication     []RelatedPersonCommunication `bson:"communication,omitempty" json:"communication,omitempty"`
 }
 type RelatedPersonCommunication struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Language          CodeableConcept `json:"language"`
-	Preferred         *bool           `json:"preferred,omitempty"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Language          CodeableConcept `bson:"language" json:"language"`
+	Preferred         *bool           `bson:"preferred,omitempty" json:"preferred,omitempty"`
 }
 type OtherRelatedPerson RelatedPerson
 

--- a/fhir-models/fhir/requestGroup.go
+++ b/fhir-models/fhir/requestGroup.go
@@ -21,68 +21,68 @@ import "encoding/json"
 
 // RequestGroup is documented here http://hl7.org/fhir/StructureDefinition/RequestGroup
 type RequestGroup struct {
-	Id                    *string              `json:"id,omitempty"`
-	Meta                  *Meta                `json:"meta,omitempty"`
-	ImplicitRules         *string              `json:"implicitRules,omitempty"`
-	Language              *string              `json:"language,omitempty"`
-	Text                  *Narrative           `json:"text,omitempty"`
-	Extension             []Extension          `json:"extension,omitempty"`
-	ModifierExtension     []Extension          `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier         `json:"identifier,omitempty"`
-	InstantiatesCanonical []string             `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string             `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference          `json:"basedOn,omitempty"`
-	Replaces              []Reference          `json:"replaces,omitempty"`
-	GroupIdentifier       *Identifier          `json:"groupIdentifier,omitempty"`
-	Status                RequestStatus        `json:"status"`
-	Intent                RequestIntent        `json:"intent"`
-	Priority              *RequestPriority     `json:"priority,omitempty"`
-	Code                  *CodeableConcept     `json:"code,omitempty"`
-	Subject               *Reference           `json:"subject,omitempty"`
-	Encounter             *Reference           `json:"encounter,omitempty"`
-	AuthoredOn            *string              `json:"authoredOn,omitempty"`
-	Author                *Reference           `json:"author,omitempty"`
-	ReasonCode            []CodeableConcept    `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference          `json:"reasonReference,omitempty"`
-	Note                  []Annotation         `json:"note,omitempty"`
-	Action                []RequestGroupAction `json:"action,omitempty"`
+	Id                    *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string              `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string              `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative           `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier         `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string             `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string             `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference          `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Replaces              []Reference          `bson:"replaces,omitempty" json:"replaces,omitempty"`
+	GroupIdentifier       *Identifier          `bson:"groupIdentifier,omitempty" json:"groupIdentifier,omitempty"`
+	Status                RequestStatus        `bson:"status" json:"status"`
+	Intent                RequestIntent        `bson:"intent" json:"intent"`
+	Priority              *RequestPriority     `bson:"priority,omitempty" json:"priority,omitempty"`
+	Code                  *CodeableConcept     `bson:"code,omitempty" json:"code,omitempty"`
+	Subject               *Reference           `bson:"subject,omitempty" json:"subject,omitempty"`
+	Encounter             *Reference           `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	AuthoredOn            *string              `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	Author                *Reference           `bson:"author,omitempty" json:"author,omitempty"`
+	ReasonCode            []CodeableConcept    `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference          `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Note                  []Annotation         `bson:"note,omitempty" json:"note,omitempty"`
+	Action                []RequestGroupAction `bson:"action,omitempty" json:"action,omitempty"`
 }
 type RequestGroupAction struct {
-	Id                  *string                           `json:"id,omitempty"`
-	Extension           []Extension                       `json:"extension,omitempty"`
-	ModifierExtension   []Extension                       `json:"modifierExtension,omitempty"`
-	Prefix              *string                           `json:"prefix,omitempty"`
-	Title               *string                           `json:"title,omitempty"`
-	Description         *string                           `json:"description,omitempty"`
-	TextEquivalent      *string                           `json:"textEquivalent,omitempty"`
-	Priority            *RequestPriority                  `json:"priority,omitempty"`
-	Code                []CodeableConcept                 `json:"code,omitempty"`
-	Documentation       []RelatedArtifact                 `json:"documentation,omitempty"`
-	Condition           []RequestGroupActionCondition     `json:"condition,omitempty"`
-	RelatedAction       []RequestGroupActionRelatedAction `json:"relatedAction,omitempty"`
-	Participant         []Reference                       `json:"participant,omitempty"`
-	Type                *CodeableConcept                  `json:"type,omitempty"`
-	GroupingBehavior    *ActionGroupingBehavior           `json:"groupingBehavior,omitempty"`
-	SelectionBehavior   *ActionSelectionBehavior          `json:"selectionBehavior,omitempty"`
-	RequiredBehavior    *ActionRequiredBehavior           `json:"requiredBehavior,omitempty"`
-	PrecheckBehavior    *ActionPrecheckBehavior           `json:"precheckBehavior,omitempty"`
-	CardinalityBehavior *ActionCardinalityBehavior        `json:"cardinalityBehavior,omitempty"`
-	Resource            *Reference                        `json:"resource,omitempty"`
-	Action              []RequestGroupAction              `json:"action,omitempty"`
+	Id                  *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Prefix              *string                           `bson:"prefix,omitempty" json:"prefix,omitempty"`
+	Title               *string                           `bson:"title,omitempty" json:"title,omitempty"`
+	Description         *string                           `bson:"description,omitempty" json:"description,omitempty"`
+	TextEquivalent      *string                           `bson:"textEquivalent,omitempty" json:"textEquivalent,omitempty"`
+	Priority            *RequestPriority                  `bson:"priority,omitempty" json:"priority,omitempty"`
+	Code                []CodeableConcept                 `bson:"code,omitempty" json:"code,omitempty"`
+	Documentation       []RelatedArtifact                 `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Condition           []RequestGroupActionCondition     `bson:"condition,omitempty" json:"condition,omitempty"`
+	RelatedAction       []RequestGroupActionRelatedAction `bson:"relatedAction,omitempty" json:"relatedAction,omitempty"`
+	Participant         []Reference                       `bson:"participant,omitempty" json:"participant,omitempty"`
+	Type                *CodeableConcept                  `bson:"type,omitempty" json:"type,omitempty"`
+	GroupingBehavior    *ActionGroupingBehavior           `bson:"groupingBehavior,omitempty" json:"groupingBehavior,omitempty"`
+	SelectionBehavior   *ActionSelectionBehavior          `bson:"selectionBehavior,omitempty" json:"selectionBehavior,omitempty"`
+	RequiredBehavior    *ActionRequiredBehavior           `bson:"requiredBehavior,omitempty" json:"requiredBehavior,omitempty"`
+	PrecheckBehavior    *ActionPrecheckBehavior           `bson:"precheckBehavior,omitempty" json:"precheckBehavior,omitempty"`
+	CardinalityBehavior *ActionCardinalityBehavior        `bson:"cardinalityBehavior,omitempty" json:"cardinalityBehavior,omitempty"`
+	Resource            *Reference                        `bson:"resource,omitempty" json:"resource,omitempty"`
+	Action              []RequestGroupAction              `bson:"action,omitempty" json:"action,omitempty"`
 }
 type RequestGroupActionCondition struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Kind              ActionConditionKind `json:"kind"`
-	Expression        *Expression         `json:"expression,omitempty"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Kind              ActionConditionKind `bson:"kind" json:"kind"`
+	Expression        *Expression         `bson:"expression,omitempty" json:"expression,omitempty"`
 }
 type RequestGroupActionRelatedAction struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	ActionId          string                 `json:"actionId"`
-	Relationship      ActionRelationshipType `json:"relationship"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	ActionId          string                 `bson:"actionId" json:"actionId"`
+	Relationship      ActionRelationshipType `bson:"relationship" json:"relationship"`
 }
 type OtherRequestGroup RequestGroup
 

--- a/fhir-models/fhir/researchDefinition.go
+++ b/fhir-models/fhir/researchDefinition.go
@@ -21,46 +21,46 @@ import "encoding/json"
 
 // ResearchDefinition is documented here http://hl7.org/fhir/StructureDefinition/ResearchDefinition
 type ResearchDefinition struct {
-	Id                  *string           `json:"id,omitempty"`
-	Meta                *Meta             `json:"meta,omitempty"`
-	ImplicitRules       *string           `json:"implicitRules,omitempty"`
-	Language            *string           `json:"language,omitempty"`
-	Text                *Narrative        `json:"text,omitempty"`
-	Extension           []Extension       `json:"extension,omitempty"`
-	ModifierExtension   []Extension       `json:"modifierExtension,omitempty"`
-	Url                 *string           `json:"url,omitempty"`
-	Identifier          []Identifier      `json:"identifier,omitempty"`
-	Version             *string           `json:"version,omitempty"`
-	Name                *string           `json:"name,omitempty"`
-	Title               *string           `json:"title,omitempty"`
-	ShortTitle          *string           `json:"shortTitle,omitempty"`
-	Subtitle            *string           `json:"subtitle,omitempty"`
-	Status              PublicationStatus `json:"status"`
-	Experimental        *bool             `json:"experimental,omitempty"`
-	Date                *string           `json:"date,omitempty"`
-	Publisher           *string           `json:"publisher,omitempty"`
-	Contact             []ContactDetail   `json:"contact,omitempty"`
-	Description         *string           `json:"description,omitempty"`
-	Comment             []string          `json:"comment,omitempty"`
-	UseContext          []UsageContext    `json:"useContext,omitempty"`
-	Jurisdiction        []CodeableConcept `json:"jurisdiction,omitempty"`
-	Purpose             *string           `json:"purpose,omitempty"`
-	Usage               *string           `json:"usage,omitempty"`
-	Copyright           *string           `json:"copyright,omitempty"`
-	ApprovalDate        *string           `json:"approvalDate,omitempty"`
-	LastReviewDate      *string           `json:"lastReviewDate,omitempty"`
-	EffectivePeriod     *Period           `json:"effectivePeriod,omitempty"`
-	Topic               []CodeableConcept `json:"topic,omitempty"`
-	Author              []ContactDetail   `json:"author,omitempty"`
-	Editor              []ContactDetail   `json:"editor,omitempty"`
-	Reviewer            []ContactDetail   `json:"reviewer,omitempty"`
-	Endorser            []ContactDetail   `json:"endorser,omitempty"`
-	RelatedArtifact     []RelatedArtifact `json:"relatedArtifact,omitempty"`
-	Library             []string          `json:"library,omitempty"`
-	Population          Reference         `json:"population"`
-	Exposure            *Reference        `json:"exposure,omitempty"`
-	ExposureAlternative *Reference        `json:"exposureAlternative,omitempty"`
-	Outcome             *Reference        `json:"outcome,omitempty"`
+	Id                  *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url                 *string           `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier          []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version             *string           `bson:"version,omitempty" json:"version,omitempty"`
+	Name                *string           `bson:"name,omitempty" json:"name,omitempty"`
+	Title               *string           `bson:"title,omitempty" json:"title,omitempty"`
+	ShortTitle          *string           `bson:"shortTitle,omitempty" json:"shortTitle,omitempty"`
+	Subtitle            *string           `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status              PublicationStatus `bson:"status" json:"status"`
+	Experimental        *bool             `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date                *string           `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher           *string           `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact             []ContactDetail   `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description         *string           `bson:"description,omitempty" json:"description,omitempty"`
+	Comment             []string          `bson:"comment,omitempty" json:"comment,omitempty"`
+	UseContext          []UsageContext    `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction        []CodeableConcept `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose             *string           `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage               *string           `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright           *string           `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate        *string           `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate      *string           `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod     *Period           `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic               []CodeableConcept `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author              []ContactDetail   `bson:"author,omitempty" json:"author,omitempty"`
+	Editor              []ContactDetail   `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer            []ContactDetail   `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser            []ContactDetail   `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact     []RelatedArtifact `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Library             []string          `bson:"library,omitempty" json:"library,omitempty"`
+	Population          Reference         `bson:"population" json:"population"`
+	Exposure            *Reference        `bson:"exposure,omitempty" json:"exposure,omitempty"`
+	ExposureAlternative *Reference        `bson:"exposureAlternative,omitempty" json:"exposureAlternative,omitempty"`
+	Outcome             *Reference        `bson:"outcome,omitempty" json:"outcome,omitempty"`
 }
 type OtherResearchDefinition ResearchDefinition
 

--- a/fhir-models/fhir/researchElementDefinition.go
+++ b/fhir-models/fhir/researchElementDefinition.go
@@ -21,59 +21,59 @@ import "encoding/json"
 
 // ResearchElementDefinition is documented here http://hl7.org/fhir/StructureDefinition/ResearchElementDefinition
 type ResearchElementDefinition struct {
-	Id                *string                                   `json:"id,omitempty"`
-	Meta              *Meta                                     `json:"meta,omitempty"`
-	ImplicitRules     *string                                   `json:"implicitRules,omitempty"`
-	Language          *string                                   `json:"language,omitempty"`
-	Text              *Narrative                                `json:"text,omitempty"`
-	Extension         []Extension                               `json:"extension,omitempty"`
-	ModifierExtension []Extension                               `json:"modifierExtension,omitempty"`
-	Url               *string                                   `json:"url,omitempty"`
-	Identifier        []Identifier                              `json:"identifier,omitempty"`
-	Version           *string                                   `json:"version,omitempty"`
-	Name              *string                                   `json:"name,omitempty"`
-	Title             *string                                   `json:"title,omitempty"`
-	ShortTitle        *string                                   `json:"shortTitle,omitempty"`
-	Subtitle          *string                                   `json:"subtitle,omitempty"`
-	Status            PublicationStatus                         `json:"status"`
-	Experimental      *bool                                     `json:"experimental,omitempty"`
-	Date              *string                                   `json:"date,omitempty"`
-	Publisher         *string                                   `json:"publisher,omitempty"`
-	Contact           []ContactDetail                           `json:"contact,omitempty"`
-	Description       *string                                   `json:"description,omitempty"`
-	Comment           []string                                  `json:"comment,omitempty"`
-	UseContext        []UsageContext                            `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                         `json:"jurisdiction,omitempty"`
-	Purpose           *string                                   `json:"purpose,omitempty"`
-	Usage             *string                                   `json:"usage,omitempty"`
-	Copyright         *string                                   `json:"copyright,omitempty"`
-	ApprovalDate      *string                                   `json:"approvalDate,omitempty"`
-	LastReviewDate    *string                                   `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period                                   `json:"effectivePeriod,omitempty"`
-	Topic             []CodeableConcept                         `json:"topic,omitempty"`
-	Author            []ContactDetail                           `json:"author,omitempty"`
-	Editor            []ContactDetail                           `json:"editor,omitempty"`
-	Reviewer          []ContactDetail                           `json:"reviewer,omitempty"`
-	Endorser          []ContactDetail                           `json:"endorser,omitempty"`
-	RelatedArtifact   []RelatedArtifact                         `json:"relatedArtifact,omitempty"`
-	Library           []string                                  `json:"library,omitempty"`
-	Type              ResearchElementType                       `json:"type"`
-	VariableType      *EvidenceVariableType                     `json:"variableType,omitempty"`
-	Characteristic    []ResearchElementDefinitionCharacteristic `json:"characteristic"`
+	Id                *string                                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                                   `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier                              `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                                   `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                                   `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                                   `bson:"title,omitempty" json:"title,omitempty"`
+	ShortTitle        *string                                   `bson:"shortTitle,omitempty" json:"shortTitle,omitempty"`
+	Subtitle          *string                                   `bson:"subtitle,omitempty" json:"subtitle,omitempty"`
+	Status            PublicationStatus                         `bson:"status" json:"status"`
+	Experimental      *bool                                     `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                                   `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                                   `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                           `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                                   `bson:"description,omitempty" json:"description,omitempty"`
+	Comment           []string                                  `bson:"comment,omitempty" json:"comment,omitempty"`
+	UseContext        []UsageContext                            `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                         `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                                   `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Usage             *string                                   `bson:"usage,omitempty" json:"usage,omitempty"`
+	Copyright         *string                                   `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string                                   `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string                                   `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period                                   `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic             []CodeableConcept                         `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author            []ContactDetail                           `bson:"author,omitempty" json:"author,omitempty"`
+	Editor            []ContactDetail                           `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer          []ContactDetail                           `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser          []ContactDetail                           `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact   []RelatedArtifact                         `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Library           []string                                  `bson:"library,omitempty" json:"library,omitempty"`
+	Type              ResearchElementType                       `bson:"type" json:"type"`
+	VariableType      *EvidenceVariableType                     `bson:"variableType,omitempty" json:"variableType,omitempty"`
+	Characteristic    []ResearchElementDefinitionCharacteristic `bson:"characteristic" json:"characteristic"`
 }
 type ResearchElementDefinitionCharacteristic struct {
-	Id                                *string          `json:"id,omitempty"`
-	Extension                         []Extension      `json:"extension,omitempty"`
-	ModifierExtension                 []Extension      `json:"modifierExtension,omitempty"`
-	UsageContext                      []UsageContext   `json:"usageContext,omitempty"`
-	Exclude                           *bool            `json:"exclude,omitempty"`
-	UnitOfMeasure                     *CodeableConcept `json:"unitOfMeasure,omitempty"`
-	StudyEffectiveDescription         *string          `json:"studyEffectiveDescription,omitempty"`
-	StudyEffectiveTimeFromStart       *Duration        `json:"studyEffectiveTimeFromStart,omitempty"`
-	StudyEffectiveGroupMeasure        *GroupMeasure    `json:"studyEffectiveGroupMeasure,omitempty"`
-	ParticipantEffectiveDescription   *string          `json:"participantEffectiveDescription,omitempty"`
-	ParticipantEffectiveTimeFromStart *Duration        `json:"participantEffectiveTimeFromStart,omitempty"`
-	ParticipantEffectiveGroupMeasure  *GroupMeasure    `json:"participantEffectiveGroupMeasure,omitempty"`
+	Id                                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension                 []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	UsageContext                      []UsageContext   `bson:"usageContext,omitempty" json:"usageContext,omitempty"`
+	Exclude                           *bool            `bson:"exclude,omitempty" json:"exclude,omitempty"`
+	UnitOfMeasure                     *CodeableConcept `bson:"unitOfMeasure,omitempty" json:"unitOfMeasure,omitempty"`
+	StudyEffectiveDescription         *string          `bson:"studyEffectiveDescription,omitempty" json:"studyEffectiveDescription,omitempty"`
+	StudyEffectiveTimeFromStart       *Duration        `bson:"studyEffectiveTimeFromStart,omitempty" json:"studyEffectiveTimeFromStart,omitempty"`
+	StudyEffectiveGroupMeasure        *GroupMeasure    `bson:"studyEffectiveGroupMeasure,omitempty" json:"studyEffectiveGroupMeasure,omitempty"`
+	ParticipantEffectiveDescription   *string          `bson:"participantEffectiveDescription,omitempty" json:"participantEffectiveDescription,omitempty"`
+	ParticipantEffectiveTimeFromStart *Duration        `bson:"participantEffectiveTimeFromStart,omitempty" json:"participantEffectiveTimeFromStart,omitempty"`
+	ParticipantEffectiveGroupMeasure  *GroupMeasure    `bson:"participantEffectiveGroupMeasure,omitempty" json:"participantEffectiveGroupMeasure,omitempty"`
 }
 type OtherResearchElementDefinition ResearchElementDefinition
 

--- a/fhir-models/fhir/researchStudy.go
+++ b/fhir-models/fhir/researchStudy.go
@@ -21,52 +21,52 @@ import "encoding/json"
 
 // ResearchStudy is documented here http://hl7.org/fhir/StructureDefinition/ResearchStudy
 type ResearchStudy struct {
-	Id                    *string                  `json:"id,omitempty"`
-	Meta                  *Meta                    `json:"meta,omitempty"`
-	ImplicitRules         *string                  `json:"implicitRules,omitempty"`
-	Language              *string                  `json:"language,omitempty"`
-	Text                  *Narrative               `json:"text,omitempty"`
-	Extension             []Extension              `json:"extension,omitempty"`
-	ModifierExtension     []Extension              `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier             `json:"identifier,omitempty"`
-	Title                 *string                  `json:"title,omitempty"`
-	Protocol              []Reference              `json:"protocol,omitempty"`
-	PartOf                []Reference              `json:"partOf,omitempty"`
-	Status                ResearchStudyStatus      `json:"status"`
-	PrimaryPurposeType    *CodeableConcept         `json:"primaryPurposeType,omitempty"`
-	Phase                 *CodeableConcept         `json:"phase,omitempty"`
-	Category              []CodeableConcept        `json:"category,omitempty"`
-	Focus                 []CodeableConcept        `json:"focus,omitempty"`
-	Condition             []CodeableConcept        `json:"condition,omitempty"`
-	Contact               []ContactDetail          `json:"contact,omitempty"`
-	RelatedArtifact       []RelatedArtifact        `json:"relatedArtifact,omitempty"`
-	Keyword               []CodeableConcept        `json:"keyword,omitempty"`
-	Location              []CodeableConcept        `json:"location,omitempty"`
-	Description           *string                  `json:"description,omitempty"`
-	Enrollment            []Reference              `json:"enrollment,omitempty"`
-	Period                *Period                  `json:"period,omitempty"`
-	Sponsor               *Reference               `json:"sponsor,omitempty"`
-	PrincipalInvestigator *Reference               `json:"principalInvestigator,omitempty"`
-	Site                  []Reference              `json:"site,omitempty"`
-	ReasonStopped         *CodeableConcept         `json:"reasonStopped,omitempty"`
-	Note                  []Annotation             `json:"note,omitempty"`
-	Arm                   []ResearchStudyArm       `json:"arm,omitempty"`
-	Objective             []ResearchStudyObjective `json:"objective,omitempty"`
+	Id                    *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Title                 *string                  `bson:"title,omitempty" json:"title,omitempty"`
+	Protocol              []Reference              `bson:"protocol,omitempty" json:"protocol,omitempty"`
+	PartOf                []Reference              `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status                ResearchStudyStatus      `bson:"status" json:"status"`
+	PrimaryPurposeType    *CodeableConcept         `bson:"primaryPurposeType,omitempty" json:"primaryPurposeType,omitempty"`
+	Phase                 *CodeableConcept         `bson:"phase,omitempty" json:"phase,omitempty"`
+	Category              []CodeableConcept        `bson:"category,omitempty" json:"category,omitempty"`
+	Focus                 []CodeableConcept        `bson:"focus,omitempty" json:"focus,omitempty"`
+	Condition             []CodeableConcept        `bson:"condition,omitempty" json:"condition,omitempty"`
+	Contact               []ContactDetail          `bson:"contact,omitempty" json:"contact,omitempty"`
+	RelatedArtifact       []RelatedArtifact        `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	Keyword               []CodeableConcept        `bson:"keyword,omitempty" json:"keyword,omitempty"`
+	Location              []CodeableConcept        `bson:"location,omitempty" json:"location,omitempty"`
+	Description           *string                  `bson:"description,omitempty" json:"description,omitempty"`
+	Enrollment            []Reference              `bson:"enrollment,omitempty" json:"enrollment,omitempty"`
+	Period                *Period                  `bson:"period,omitempty" json:"period,omitempty"`
+	Sponsor               *Reference               `bson:"sponsor,omitempty" json:"sponsor,omitempty"`
+	PrincipalInvestigator *Reference               `bson:"principalInvestigator,omitempty" json:"principalInvestigator,omitempty"`
+	Site                  []Reference              `bson:"site,omitempty" json:"site,omitempty"`
+	ReasonStopped         *CodeableConcept         `bson:"reasonStopped,omitempty" json:"reasonStopped,omitempty"`
+	Note                  []Annotation             `bson:"note,omitempty" json:"note,omitempty"`
+	Arm                   []ResearchStudyArm       `bson:"arm,omitempty" json:"arm,omitempty"`
+	Objective             []ResearchStudyObjective `bson:"objective,omitempty" json:"objective,omitempty"`
 }
 type ResearchStudyArm struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Name              string           `json:"name"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Description       *string          `json:"description,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string           `bson:"name" json:"name"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
 }
 type ResearchStudyObjective struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Name              *string          `json:"name,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              *string          `bson:"name,omitempty" json:"name,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
 }
 type OtherResearchStudy ResearchStudy
 

--- a/fhir-models/fhir/researchSubject.go
+++ b/fhir-models/fhir/researchSubject.go
@@ -21,21 +21,21 @@ import "encoding/json"
 
 // ResearchSubject is documented here http://hl7.org/fhir/StructureDefinition/ResearchSubject
 type ResearchSubject struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier          `json:"identifier,omitempty"`
-	Status            ResearchSubjectStatus `json:"status"`
-	Period            *Period               `json:"period,omitempty"`
-	Study             Reference             `json:"study"`
-	Individual        Reference             `json:"individual"`
-	AssignedArm       *string               `json:"assignedArm,omitempty"`
-	ActualArm         *string               `json:"actualArm,omitempty"`
-	Consent           *Reference            `json:"consent,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            ResearchSubjectStatus `bson:"status" json:"status"`
+	Period            *Period               `bson:"period,omitempty" json:"period,omitempty"`
+	Study             Reference             `bson:"study" json:"study"`
+	Individual        Reference             `bson:"individual" json:"individual"`
+	AssignedArm       *string               `bson:"assignedArm,omitempty" json:"assignedArm,omitempty"`
+	ActualArm         *string               `bson:"actualArm,omitempty" json:"actualArm,omitempty"`
+	Consent           *Reference            `bson:"consent,omitempty" json:"consent,omitempty"`
 }
 type OtherResearchSubject ResearchSubject
 

--- a/fhir-models/fhir/resource.go
+++ b/fhir-models/fhir/resource.go
@@ -21,10 +21,10 @@ import "encoding/json"
 
 // Resource is documented here http://hl7.org/fhir/StructureDefinition/Resource
 type Resource struct {
-	Id            *string `json:"id,omitempty"`
-	Meta          *Meta   `json:"meta,omitempty"`
-	ImplicitRules *string `json:"implicitRules,omitempty"`
-	Language      *string `json:"language,omitempty"`
+	Id            *string `bson:"id,omitempty" json:"id,omitempty"`
+	Meta          *Meta   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules *string `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language      *string `bson:"language,omitempty" json:"language,omitempty"`
 }
 type OtherResource Resource
 

--- a/fhir-models/fhir/riskAssessment.go
+++ b/fhir-models/fhir/riskAssessment.go
@@ -21,38 +21,38 @@ import "encoding/json"
 
 // RiskAssessment is documented here http://hl7.org/fhir/StructureDefinition/RiskAssessment
 type RiskAssessment struct {
-	Id                *string                    `json:"id,omitempty"`
-	Meta              *Meta                      `json:"meta,omitempty"`
-	ImplicitRules     *string                    `json:"implicitRules,omitempty"`
-	Language          *string                    `json:"language,omitempty"`
-	Text              *Narrative                 `json:"text,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier               `json:"identifier,omitempty"`
-	BasedOn           *Reference                 `json:"basedOn,omitempty"`
-	Parent            *Reference                 `json:"parent,omitempty"`
-	Status            ObservationStatus          `json:"status"`
-	Method            *CodeableConcept           `json:"method,omitempty"`
-	Code              *CodeableConcept           `json:"code,omitempty"`
-	Subject           Reference                  `json:"subject"`
-	Encounter         *Reference                 `json:"encounter,omitempty"`
-	Condition         *Reference                 `json:"condition,omitempty"`
-	Performer         *Reference                 `json:"performer,omitempty"`
-	ReasonCode        []CodeableConcept          `json:"reasonCode,omitempty"`
-	ReasonReference   []Reference                `json:"reasonReference,omitempty"`
-	Basis             []Reference                `json:"basis,omitempty"`
-	Prediction        []RiskAssessmentPrediction `json:"prediction,omitempty"`
-	Mitigation        *string                    `json:"mitigation,omitempty"`
-	Note              []Annotation               `json:"note,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier               `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           *Reference                 `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Parent            *Reference                 `bson:"parent,omitempty" json:"parent,omitempty"`
+	Status            ObservationStatus          `bson:"status" json:"status"`
+	Method            *CodeableConcept           `bson:"method,omitempty" json:"method,omitempty"`
+	Code              *CodeableConcept           `bson:"code,omitempty" json:"code,omitempty"`
+	Subject           Reference                  `bson:"subject" json:"subject"`
+	Encounter         *Reference                 `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	Condition         *Reference                 `bson:"condition,omitempty" json:"condition,omitempty"`
+	Performer         *Reference                 `bson:"performer,omitempty" json:"performer,omitempty"`
+	ReasonCode        []CodeableConcept          `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference   []Reference                `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Basis             []Reference                `bson:"basis,omitempty" json:"basis,omitempty"`
+	Prediction        []RiskAssessmentPrediction `bson:"prediction,omitempty" json:"prediction,omitempty"`
+	Mitigation        *string                    `bson:"mitigation,omitempty" json:"mitigation,omitempty"`
+	Note              []Annotation               `bson:"note,omitempty" json:"note,omitempty"`
 }
 type RiskAssessmentPrediction struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Outcome           *CodeableConcept `json:"outcome,omitempty"`
-	QualitativeRisk   *CodeableConcept `json:"qualitativeRisk,omitempty"`
-	RelativeRisk      *string          `json:"relativeRisk,omitempty"`
-	Rationale         *string          `json:"rationale,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Outcome           *CodeableConcept `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	QualitativeRisk   *CodeableConcept `bson:"qualitativeRisk,omitempty" json:"qualitativeRisk,omitempty"`
+	RelativeRisk      *string          `bson:"relativeRisk,omitempty" json:"relativeRisk,omitempty"`
+	Rationale         *string          `bson:"rationale,omitempty" json:"rationale,omitempty"`
 }
 type OtherRiskAssessment RiskAssessment
 

--- a/fhir-models/fhir/riskEvidenceSynthesis.go
+++ b/fhir-models/fhir/riskEvidenceSynthesis.go
@@ -21,89 +21,89 @@ import "encoding/json"
 
 // RiskEvidenceSynthesis is documented here http://hl7.org/fhir/StructureDefinition/RiskEvidenceSynthesis
 type RiskEvidenceSynthesis struct {
-	Id                *string                            `json:"id,omitempty"`
-	Meta              *Meta                              `json:"meta,omitempty"`
-	ImplicitRules     *string                            `json:"implicitRules,omitempty"`
-	Language          *string                            `json:"language,omitempty"`
-	Text              *Narrative                         `json:"text,omitempty"`
-	Extension         []Extension                        `json:"extension,omitempty"`
-	ModifierExtension []Extension                        `json:"modifierExtension,omitempty"`
-	Url               *string                            `json:"url,omitempty"`
-	Identifier        []Identifier                       `json:"identifier,omitempty"`
-	Version           *string                            `json:"version,omitempty"`
-	Name              *string                            `json:"name,omitempty"`
-	Title             *string                            `json:"title,omitempty"`
-	Status            PublicationStatus                  `json:"status"`
-	Date              *string                            `json:"date,omitempty"`
-	Publisher         *string                            `json:"publisher,omitempty"`
-	Contact           []ContactDetail                    `json:"contact,omitempty"`
-	Description       *string                            `json:"description,omitempty"`
-	Note              []Annotation                       `json:"note,omitempty"`
-	UseContext        []UsageContext                     `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                  `json:"jurisdiction,omitempty"`
-	Copyright         *string                            `json:"copyright,omitempty"`
-	ApprovalDate      *string                            `json:"approvalDate,omitempty"`
-	LastReviewDate    *string                            `json:"lastReviewDate,omitempty"`
-	EffectivePeriod   *Period                            `json:"effectivePeriod,omitempty"`
-	Topic             []CodeableConcept                  `json:"topic,omitempty"`
-	Author            []ContactDetail                    `json:"author,omitempty"`
-	Editor            []ContactDetail                    `json:"editor,omitempty"`
-	Reviewer          []ContactDetail                    `json:"reviewer,omitempty"`
-	Endorser          []ContactDetail                    `json:"endorser,omitempty"`
-	RelatedArtifact   []RelatedArtifact                  `json:"relatedArtifact,omitempty"`
-	SynthesisType     *CodeableConcept                   `json:"synthesisType,omitempty"`
-	StudyType         *CodeableConcept                   `json:"studyType,omitempty"`
-	Population        Reference                          `json:"population"`
-	Exposure          *Reference                         `json:"exposure,omitempty"`
-	Outcome           Reference                          `json:"outcome"`
-	SampleSize        *RiskEvidenceSynthesisSampleSize   `json:"sampleSize,omitempty"`
-	RiskEstimate      *RiskEvidenceSynthesisRiskEstimate `json:"riskEstimate,omitempty"`
-	Certainty         []RiskEvidenceSynthesisCertainty   `json:"certainty,omitempty"`
+	Id                *string                            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                            `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier                       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                            `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                            `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                            `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus                  `bson:"status" json:"status"`
+	Date              *string                            `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                            `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                            `bson:"description,omitempty" json:"description,omitempty"`
+	Note              []Annotation                       `bson:"note,omitempty" json:"note,omitempty"`
+	UseContext        []UsageContext                     `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                  `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Copyright         *string                            `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	ApprovalDate      *string                            `bson:"approvalDate,omitempty" json:"approvalDate,omitempty"`
+	LastReviewDate    *string                            `bson:"lastReviewDate,omitempty" json:"lastReviewDate,omitempty"`
+	EffectivePeriod   *Period                            `bson:"effectivePeriod,omitempty" json:"effectivePeriod,omitempty"`
+	Topic             []CodeableConcept                  `bson:"topic,omitempty" json:"topic,omitempty"`
+	Author            []ContactDetail                    `bson:"author,omitempty" json:"author,omitempty"`
+	Editor            []ContactDetail                    `bson:"editor,omitempty" json:"editor,omitempty"`
+	Reviewer          []ContactDetail                    `bson:"reviewer,omitempty" json:"reviewer,omitempty"`
+	Endorser          []ContactDetail                    `bson:"endorser,omitempty" json:"endorser,omitempty"`
+	RelatedArtifact   []RelatedArtifact                  `bson:"relatedArtifact,omitempty" json:"relatedArtifact,omitempty"`
+	SynthesisType     *CodeableConcept                   `bson:"synthesisType,omitempty" json:"synthesisType,omitempty"`
+	StudyType         *CodeableConcept                   `bson:"studyType,omitempty" json:"studyType,omitempty"`
+	Population        Reference                          `bson:"population" json:"population"`
+	Exposure          *Reference                         `bson:"exposure,omitempty" json:"exposure,omitempty"`
+	Outcome           Reference                          `bson:"outcome" json:"outcome"`
+	SampleSize        *RiskEvidenceSynthesisSampleSize   `bson:"sampleSize,omitempty" json:"sampleSize,omitempty"`
+	RiskEstimate      *RiskEvidenceSynthesisRiskEstimate `bson:"riskEstimate,omitempty" json:"riskEstimate,omitempty"`
+	Certainty         []RiskEvidenceSynthesisCertainty   `bson:"certainty,omitempty" json:"certainty,omitempty"`
 }
 type RiskEvidenceSynthesisSampleSize struct {
-	Id                   *string     `json:"id,omitempty"`
-	Extension            []Extension `json:"extension,omitempty"`
-	ModifierExtension    []Extension `json:"modifierExtension,omitempty"`
-	Description          *string     `json:"description,omitempty"`
-	NumberOfStudies      *int        `json:"numberOfStudies,omitempty"`
-	NumberOfParticipants *int        `json:"numberOfParticipants,omitempty"`
+	Id                   *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension            []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description          *string     `bson:"description,omitempty" json:"description,omitempty"`
+	NumberOfStudies      *int        `bson:"numberOfStudies,omitempty" json:"numberOfStudies,omitempty"`
+	NumberOfParticipants *int        `bson:"numberOfParticipants,omitempty" json:"numberOfParticipants,omitempty"`
 }
 type RiskEvidenceSynthesisRiskEstimate struct {
-	Id                *string                                              `json:"id,omitempty"`
-	Extension         []Extension                                          `json:"extension,omitempty"`
-	ModifierExtension []Extension                                          `json:"modifierExtension,omitempty"`
-	Description       *string                                              `json:"description,omitempty"`
-	Type              *CodeableConcept                                     `json:"type,omitempty"`
-	Value             *string                                              `json:"value,omitempty"`
-	UnitOfMeasure     *CodeableConcept                                     `json:"unitOfMeasure,omitempty"`
-	DenominatorCount  *int                                                 `json:"denominatorCount,omitempty"`
-	NumeratorCount    *int                                                 `json:"numeratorCount,omitempty"`
-	PrecisionEstimate []RiskEvidenceSynthesisRiskEstimatePrecisionEstimate `json:"precisionEstimate,omitempty"`
+	Id                *string                                              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string                                              `bson:"description,omitempty" json:"description,omitempty"`
+	Type              *CodeableConcept                                     `bson:"type,omitempty" json:"type,omitempty"`
+	Value             *string                                              `bson:"value,omitempty" json:"value,omitempty"`
+	UnitOfMeasure     *CodeableConcept                                     `bson:"unitOfMeasure,omitempty" json:"unitOfMeasure,omitempty"`
+	DenominatorCount  *int                                                 `bson:"denominatorCount,omitempty" json:"denominatorCount,omitempty"`
+	NumeratorCount    *int                                                 `bson:"numeratorCount,omitempty" json:"numeratorCount,omitempty"`
+	PrecisionEstimate []RiskEvidenceSynthesisRiskEstimatePrecisionEstimate `bson:"precisionEstimate,omitempty" json:"precisionEstimate,omitempty"`
 }
 type RiskEvidenceSynthesisRiskEstimatePrecisionEstimate struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Level             *string          `json:"level,omitempty"`
-	From              *string          `json:"from,omitempty"`
-	To                *string          `json:"to,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Level             *string          `bson:"level,omitempty" json:"level,omitempty"`
+	From              *string          `bson:"from,omitempty" json:"from,omitempty"`
+	To                *string          `bson:"to,omitempty" json:"to,omitempty"`
 }
 type RiskEvidenceSynthesisCertainty struct {
-	Id                    *string                                               `json:"id,omitempty"`
-	Extension             []Extension                                           `json:"extension,omitempty"`
-	ModifierExtension     []Extension                                           `json:"modifierExtension,omitempty"`
-	Rating                []CodeableConcept                                     `json:"rating,omitempty"`
-	Note                  []Annotation                                          `json:"note,omitempty"`
-	CertaintySubcomponent []RiskEvidenceSynthesisCertaintyCertaintySubcomponent `json:"certaintySubcomponent,omitempty"`
+	Id                    *string                                               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension             []Extension                                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Rating                []CodeableConcept                                     `bson:"rating,omitempty" json:"rating,omitempty"`
+	Note                  []Annotation                                          `bson:"note,omitempty" json:"note,omitempty"`
+	CertaintySubcomponent []RiskEvidenceSynthesisCertaintyCertaintySubcomponent `bson:"certaintySubcomponent,omitempty" json:"certaintySubcomponent,omitempty"`
 }
 type RiskEvidenceSynthesisCertaintyCertaintySubcomponent struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept  `json:"type,omitempty"`
-	Rating            []CodeableConcept `json:"rating,omitempty"`
-	Note              []Annotation      `json:"note,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept  `bson:"type,omitempty" json:"type,omitempty"`
+	Rating            []CodeableConcept `bson:"rating,omitempty" json:"rating,omitempty"`
+	Note              []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
 }
 type OtherRiskEvidenceSynthesis RiskEvidenceSynthesis
 

--- a/fhir-models/fhir/schedule.go
+++ b/fhir-models/fhir/schedule.go
@@ -21,21 +21,21 @@ import "encoding/json"
 
 // Schedule is documented here http://hl7.org/fhir/StructureDefinition/Schedule
 type Schedule struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier      `json:"identifier,omitempty"`
-	Active            *bool             `json:"active,omitempty"`
-	ServiceCategory   []CodeableConcept `json:"serviceCategory,omitempty"`
-	ServiceType       []CodeableConcept `json:"serviceType,omitempty"`
-	Specialty         []CodeableConcept `json:"specialty,omitempty"`
-	Actor             []Reference       `json:"actor"`
-	PlanningHorizon   *Period           `json:"planningHorizon,omitempty"`
-	Comment           *string           `json:"comment,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Active            *bool             `bson:"active,omitempty" json:"active,omitempty"`
+	ServiceCategory   []CodeableConcept `bson:"serviceCategory,omitempty" json:"serviceCategory,omitempty"`
+	ServiceType       []CodeableConcept `bson:"serviceType,omitempty" json:"serviceType,omitempty"`
+	Specialty         []CodeableConcept `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	Actor             []Reference       `bson:"actor" json:"actor"`
+	PlanningHorizon   *Period           `bson:"planningHorizon,omitempty" json:"planningHorizon,omitempty"`
+	Comment           *string           `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type OtherSchedule Schedule
 

--- a/fhir-models/fhir/searchParameter.go
+++ b/fhir-models/fhir/searchParameter.go
@@ -21,46 +21,46 @@ import "encoding/json"
 
 // SearchParameter is documented here http://hl7.org/fhir/StructureDefinition/SearchParameter
 type SearchParameter struct {
-	Id                *string                    `json:"id,omitempty"`
-	Meta              *Meta                      `json:"meta,omitempty"`
-	ImplicitRules     *string                    `json:"implicitRules,omitempty"`
-	Language          *string                    `json:"language,omitempty"`
-	Text              *Narrative                 `json:"text,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Url               string                     `json:"url"`
-	Version           *string                    `json:"version,omitempty"`
-	Name              string                     `json:"name"`
-	DerivedFrom       *string                    `json:"derivedFrom,omitempty"`
-	Status            PublicationStatus          `json:"status"`
-	Experimental      *bool                      `json:"experimental,omitempty"`
-	Date              *string                    `json:"date,omitempty"`
-	Publisher         *string                    `json:"publisher,omitempty"`
-	Contact           []ContactDetail            `json:"contact,omitempty"`
-	Description       string                     `json:"description"`
-	UseContext        []UsageContext             `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept          `json:"jurisdiction,omitempty"`
-	Purpose           *string                    `json:"purpose,omitempty"`
-	Code              string                     `json:"code"`
-	Base              []ResourceType             `json:"base"`
-	Type              SearchParamType            `json:"type"`
-	Expression        *string                    `json:"expression,omitempty"`
-	Xpath             *string                    `json:"xpath,omitempty"`
-	XpathUsage        *XPathUsageType            `json:"xpathUsage,omitempty"`
-	Target            []ResourceType             `json:"target,omitempty"`
-	MultipleOr        *bool                      `json:"multipleOr,omitempty"`
-	MultipleAnd       *bool                      `json:"multipleAnd,omitempty"`
-	Comparator        []SearchComparator         `json:"comparator,omitempty"`
-	Modifier          []SearchModifierCode       `json:"modifier,omitempty"`
-	Chain             []string                   `json:"chain,omitempty"`
-	Component         []SearchParameterComponent `json:"component,omitempty"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                      `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                    `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                    `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                 `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                     `bson:"url" json:"url"`
+	Version           *string                    `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                     `bson:"name" json:"name"`
+	DerivedFrom       *string                    `bson:"derivedFrom,omitempty" json:"derivedFrom,omitempty"`
+	Status            PublicationStatus          `bson:"status" json:"status"`
+	Experimental      *bool                      `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                    `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                    `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail            `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       string                     `bson:"description" json:"description"`
+	UseContext        []UsageContext             `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept          `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                    `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Code              string                     `bson:"code" json:"code"`
+	Base              []ResourceType             `bson:"base" json:"base"`
+	Type              SearchParamType            `bson:"type" json:"type"`
+	Expression        *string                    `bson:"expression,omitempty" json:"expression,omitempty"`
+	Xpath             *string                    `bson:"xpath,omitempty" json:"xpath,omitempty"`
+	XpathUsage        *XPathUsageType            `bson:"xpathUsage,omitempty" json:"xpathUsage,omitempty"`
+	Target            []ResourceType             `bson:"target,omitempty" json:"target,omitempty"`
+	MultipleOr        *bool                      `bson:"multipleOr,omitempty" json:"multipleOr,omitempty"`
+	MultipleAnd       *bool                      `bson:"multipleAnd,omitempty" json:"multipleAnd,omitempty"`
+	Comparator        []SearchComparator         `bson:"comparator,omitempty" json:"comparator,omitempty"`
+	Modifier          []SearchModifierCode       `bson:"modifier,omitempty" json:"modifier,omitempty"`
+	Chain             []string                   `bson:"chain,omitempty" json:"chain,omitempty"`
+	Component         []SearchParameterComponent `bson:"component,omitempty" json:"component,omitempty"`
 }
 type SearchParameterComponent struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Definition        string      `json:"definition"`
-	Expression        string      `json:"expression"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Definition        string      `bson:"definition" json:"definition"`
+	Expression        string      `bson:"expression" json:"expression"`
 }
 type OtherSearchParameter SearchParameter
 

--- a/fhir-models/fhir/serviceRequest.go
+++ b/fhir-models/fhir/serviceRequest.go
@@ -21,43 +21,43 @@ import "encoding/json"
 
 // ServiceRequest is documented here http://hl7.org/fhir/StructureDefinition/ServiceRequest
 type ServiceRequest struct {
-	Id                    *string           `json:"id,omitempty"`
-	Meta                  *Meta             `json:"meta,omitempty"`
-	ImplicitRules         *string           `json:"implicitRules,omitempty"`
-	Language              *string           `json:"language,omitempty"`
-	Text                  *Narrative        `json:"text,omitempty"`
-	Extension             []Extension       `json:"extension,omitempty"`
-	ModifierExtension     []Extension       `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier      `json:"identifier,omitempty"`
-	InstantiatesCanonical []string          `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       []string          `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference       `json:"basedOn,omitempty"`
-	Replaces              []Reference       `json:"replaces,omitempty"`
-	Requisition           *Identifier       `json:"requisition,omitempty"`
-	Status                RequestStatus     `json:"status"`
-	Intent                RequestIntent     `json:"intent"`
-	Category              []CodeableConcept `json:"category,omitempty"`
-	Priority              *RequestPriority  `json:"priority,omitempty"`
-	DoNotPerform          *bool             `json:"doNotPerform,omitempty"`
-	Code                  *CodeableConcept  `json:"code,omitempty"`
-	OrderDetail           []CodeableConcept `json:"orderDetail,omitempty"`
-	Subject               Reference         `json:"subject"`
-	Encounter             *Reference        `json:"encounter,omitempty"`
-	AuthoredOn            *string           `json:"authoredOn,omitempty"`
-	Requester             *Reference        `json:"requester,omitempty"`
-	PerformerType         *CodeableConcept  `json:"performerType,omitempty"`
-	Performer             []Reference       `json:"performer,omitempty"`
-	LocationCode          []CodeableConcept `json:"locationCode,omitempty"`
-	LocationReference     []Reference       `json:"locationReference,omitempty"`
-	ReasonCode            []CodeableConcept `json:"reasonCode,omitempty"`
-	ReasonReference       []Reference       `json:"reasonReference,omitempty"`
-	Insurance             []Reference       `json:"insurance,omitempty"`
-	SupportingInfo        []Reference       `json:"supportingInfo,omitempty"`
-	Specimen              []Reference       `json:"specimen,omitempty"`
-	BodySite              []CodeableConcept `json:"bodySite,omitempty"`
-	Note                  []Annotation      `json:"note,omitempty"`
-	PatientInstruction    *string           `json:"patientInstruction,omitempty"`
-	RelevantHistory       []Reference       `json:"relevantHistory,omitempty"`
+	Id                    *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical []string          `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       []string          `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference       `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	Replaces              []Reference       `bson:"replaces,omitempty" json:"replaces,omitempty"`
+	Requisition           *Identifier       `bson:"requisition,omitempty" json:"requisition,omitempty"`
+	Status                RequestStatus     `bson:"status" json:"status"`
+	Intent                RequestIntent     `bson:"intent" json:"intent"`
+	Category              []CodeableConcept `bson:"category,omitempty" json:"category,omitempty"`
+	Priority              *RequestPriority  `bson:"priority,omitempty" json:"priority,omitempty"`
+	DoNotPerform          *bool             `bson:"doNotPerform,omitempty" json:"doNotPerform,omitempty"`
+	Code                  *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
+	OrderDetail           []CodeableConcept `bson:"orderDetail,omitempty" json:"orderDetail,omitempty"`
+	Subject               Reference         `bson:"subject" json:"subject"`
+	Encounter             *Reference        `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	AuthoredOn            *string           `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	Requester             *Reference        `bson:"requester,omitempty" json:"requester,omitempty"`
+	PerformerType         *CodeableConcept  `bson:"performerType,omitempty" json:"performerType,omitempty"`
+	Performer             []Reference       `bson:"performer,omitempty" json:"performer,omitempty"`
+	LocationCode          []CodeableConcept `bson:"locationCode,omitempty" json:"locationCode,omitempty"`
+	LocationReference     []Reference       `bson:"locationReference,omitempty" json:"locationReference,omitempty"`
+	ReasonCode            []CodeableConcept `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       []Reference       `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Insurance             []Reference       `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	SupportingInfo        []Reference       `bson:"supportingInfo,omitempty" json:"supportingInfo,omitempty"`
+	Specimen              []Reference       `bson:"specimen,omitempty" json:"specimen,omitempty"`
+	BodySite              []CodeableConcept `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
+	Note                  []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
+	PatientInstruction    *string           `bson:"patientInstruction,omitempty" json:"patientInstruction,omitempty"`
+	RelevantHistory       []Reference       `bson:"relevantHistory,omitempty" json:"relevantHistory,omitempty"`
 }
 type OtherServiceRequest ServiceRequest
 

--- a/fhir-models/fhir/signature.go
+++ b/fhir-models/fhir/signature.go
@@ -19,13 +19,13 @@ package fhir
 
 // Signature is documented here http://hl7.org/fhir/StructureDefinition/Signature
 type Signature struct {
-	Id           *string     `json:"id,omitempty"`
-	Extension    []Extension `json:"extension,omitempty"`
-	Type         []Coding    `json:"type"`
-	When         string      `json:"when"`
-	Who          Reference   `json:"who"`
-	OnBehalfOf   *Reference  `json:"onBehalfOf,omitempty"`
-	TargetFormat *string     `json:"targetFormat,omitempty"`
-	SigFormat    *string     `json:"sigFormat,omitempty"`
-	Data         *string     `json:"data,omitempty"`
+	Id           *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type         []Coding    `bson:"type" json:"type"`
+	When         string      `bson:"when" json:"when"`
+	Who          Reference   `bson:"who" json:"who"`
+	OnBehalfOf   *Reference  `bson:"onBehalfOf,omitempty" json:"onBehalfOf,omitempty"`
+	TargetFormat *string     `bson:"targetFormat,omitempty" json:"targetFormat,omitempty"`
+	SigFormat    *string     `bson:"sigFormat,omitempty" json:"sigFormat,omitempty"`
+	Data         *string     `bson:"data,omitempty" json:"data,omitempty"`
 }

--- a/fhir-models/fhir/slot.go
+++ b/fhir-models/fhir/slot.go
@@ -21,24 +21,24 @@ import "encoding/json"
 
 // Slot is documented here http://hl7.org/fhir/StructureDefinition/Slot
 type Slot struct {
-	Id                *string           `json:"id,omitempty"`
-	Meta              *Meta             `json:"meta,omitempty"`
-	ImplicitRules     *string           `json:"implicitRules,omitempty"`
-	Language          *string           `json:"language,omitempty"`
-	Text              *Narrative        `json:"text,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier      `json:"identifier,omitempty"`
-	ServiceCategory   []CodeableConcept `json:"serviceCategory,omitempty"`
-	ServiceType       []CodeableConcept `json:"serviceType,omitempty"`
-	Specialty         []CodeableConcept `json:"specialty,omitempty"`
-	AppointmentType   *CodeableConcept  `json:"appointmentType,omitempty"`
-	Schedule          Reference         `json:"schedule"`
-	Status            SlotStatus        `json:"status"`
-	Start             string            `json:"start"`
-	End               string            `json:"end"`
-	Overbooked        *bool             `json:"overbooked,omitempty"`
-	Comment           *string           `json:"comment,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	ServiceCategory   []CodeableConcept `bson:"serviceCategory,omitempty" json:"serviceCategory,omitempty"`
+	ServiceType       []CodeableConcept `bson:"serviceType,omitempty" json:"serviceType,omitempty"`
+	Specialty         []CodeableConcept `bson:"specialty,omitempty" json:"specialty,omitempty"`
+	AppointmentType   *CodeableConcept  `bson:"appointmentType,omitempty" json:"appointmentType,omitempty"`
+	Schedule          Reference         `bson:"schedule" json:"schedule"`
+	Status            SlotStatus        `bson:"status" json:"status"`
+	Start             string            `bson:"start" json:"start"`
+	End               string            `bson:"end" json:"end"`
+	Overbooked        *bool             `bson:"overbooked,omitempty" json:"overbooked,omitempty"`
+	Comment           *string           `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type OtherSlot Slot
 

--- a/fhir-models/fhir/specimen.go
+++ b/fhir-models/fhir/specimen.go
@@ -21,54 +21,54 @@ import "encoding/json"
 
 // Specimen is documented here http://hl7.org/fhir/StructureDefinition/Specimen
 type Specimen struct {
-	Id                  *string              `json:"id,omitempty"`
-	Meta                *Meta                `json:"meta,omitempty"`
-	ImplicitRules       *string              `json:"implicitRules,omitempty"`
-	Language            *string              `json:"language,omitempty"`
-	Text                *Narrative           `json:"text,omitempty"`
-	Extension           []Extension          `json:"extension,omitempty"`
-	ModifierExtension   []Extension          `json:"modifierExtension,omitempty"`
-	Identifier          []Identifier         `json:"identifier,omitempty"`
-	AccessionIdentifier *Identifier          `json:"accessionIdentifier,omitempty"`
-	Status              *SpecimenStatus      `json:"status,omitempty"`
-	Type                *CodeableConcept     `json:"type,omitempty"`
-	Subject             *Reference           `json:"subject,omitempty"`
-	ReceivedTime        *string              `json:"receivedTime,omitempty"`
-	Parent              []Reference          `json:"parent,omitempty"`
-	Request             []Reference          `json:"request,omitempty"`
-	Collection          *SpecimenCollection  `json:"collection,omitempty"`
-	Processing          []SpecimenProcessing `json:"processing,omitempty"`
-	Container           []SpecimenContainer  `json:"container,omitempty"`
-	Condition           []CodeableConcept    `json:"condition,omitempty"`
-	Note                []Annotation         `json:"note,omitempty"`
+	Id                  *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string              `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string              `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative           `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier          []Identifier         `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	AccessionIdentifier *Identifier          `bson:"accessionIdentifier,omitempty" json:"accessionIdentifier,omitempty"`
+	Status              *SpecimenStatus      `bson:"status,omitempty" json:"status,omitempty"`
+	Type                *CodeableConcept     `bson:"type,omitempty" json:"type,omitempty"`
+	Subject             *Reference           `bson:"subject,omitempty" json:"subject,omitempty"`
+	ReceivedTime        *string              `bson:"receivedTime,omitempty" json:"receivedTime,omitempty"`
+	Parent              []Reference          `bson:"parent,omitempty" json:"parent,omitempty"`
+	Request             []Reference          `bson:"request,omitempty" json:"request,omitempty"`
+	Collection          *SpecimenCollection  `bson:"collection,omitempty" json:"collection,omitempty"`
+	Processing          []SpecimenProcessing `bson:"processing,omitempty" json:"processing,omitempty"`
+	Container           []SpecimenContainer  `bson:"container,omitempty" json:"container,omitempty"`
+	Condition           []CodeableConcept    `bson:"condition,omitempty" json:"condition,omitempty"`
+	Note                []Annotation         `bson:"note,omitempty" json:"note,omitempty"`
 }
 type SpecimenCollection struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Collector         *Reference       `json:"collector,omitempty"`
-	Duration          *Duration        `json:"duration,omitempty"`
-	Quantity          *Quantity        `json:"quantity,omitempty"`
-	Method            *CodeableConcept `json:"method,omitempty"`
-	BodySite          *CodeableConcept `json:"bodySite,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Collector         *Reference       `bson:"collector,omitempty" json:"collector,omitempty"`
+	Duration          *Duration        `bson:"duration,omitempty" json:"duration,omitempty"`
+	Quantity          *Quantity        `bson:"quantity,omitempty" json:"quantity,omitempty"`
+	Method            *CodeableConcept `bson:"method,omitempty" json:"method,omitempty"`
+	BodySite          *CodeableConcept `bson:"bodySite,omitempty" json:"bodySite,omitempty"`
 }
 type SpecimenProcessing struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Description       *string          `json:"description,omitempty"`
-	Procedure         *CodeableConcept `json:"procedure,omitempty"`
-	Additive          []Reference      `json:"additive,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Procedure         *CodeableConcept `bson:"procedure,omitempty" json:"procedure,omitempty"`
+	Additive          []Reference      `bson:"additive,omitempty" json:"additive,omitempty"`
 }
 type SpecimenContainer struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier     `json:"identifier,omitempty"`
-	Description       *string          `json:"description,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Capacity          *Quantity        `json:"capacity,omitempty"`
-	SpecimenQuantity  *Quantity        `json:"specimenQuantity,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Description       *string          `bson:"description,omitempty" json:"description,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Capacity          *Quantity        `bson:"capacity,omitempty" json:"capacity,omitempty"`
+	SpecimenQuantity  *Quantity        `bson:"specimenQuantity,omitempty" json:"specimenQuantity,omitempty"`
 }
 type OtherSpecimen Specimen
 

--- a/fhir-models/fhir/specimenDefinition.go
+++ b/fhir-models/fhir/specimenDefinition.go
@@ -21,58 +21,58 @@ import "encoding/json"
 
 // SpecimenDefinition is documented here http://hl7.org/fhir/StructureDefinition/SpecimenDefinition
 type SpecimenDefinition struct {
-	Id                 *string                        `json:"id,omitempty"`
-	Meta               *Meta                          `json:"meta,omitempty"`
-	ImplicitRules      *string                        `json:"implicitRules,omitempty"`
-	Language           *string                        `json:"language,omitempty"`
-	Text               *Narrative                     `json:"text,omitempty"`
-	Extension          []Extension                    `json:"extension,omitempty"`
-	ModifierExtension  []Extension                    `json:"modifierExtension,omitempty"`
-	Identifier         *Identifier                    `json:"identifier,omitempty"`
-	TypeCollected      *CodeableConcept               `json:"typeCollected,omitempty"`
-	PatientPreparation []CodeableConcept              `json:"patientPreparation,omitempty"`
-	TimeAspect         *string                        `json:"timeAspect,omitempty"`
-	Collection         []CodeableConcept              `json:"collection,omitempty"`
-	TypeTested         []SpecimenDefinitionTypeTested `json:"typeTested,omitempty"`
+	Id                 *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Meta               *Meta                          `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules      *string                        `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language           *string                        `bson:"language,omitempty" json:"language,omitempty"`
+	Text               *Narrative                     `bson:"text,omitempty" json:"text,omitempty"`
+	Extension          []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier         *Identifier                    `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	TypeCollected      *CodeableConcept               `bson:"typeCollected,omitempty" json:"typeCollected,omitempty"`
+	PatientPreparation []CodeableConcept              `bson:"patientPreparation,omitempty" json:"patientPreparation,omitempty"`
+	TimeAspect         *string                        `bson:"timeAspect,omitempty" json:"timeAspect,omitempty"`
+	Collection         []CodeableConcept              `bson:"collection,omitempty" json:"collection,omitempty"`
+	TypeTested         []SpecimenDefinitionTypeTested `bson:"typeTested,omitempty" json:"typeTested,omitempty"`
 }
 type SpecimenDefinitionTypeTested struct {
-	Id                 *string                                `json:"id,omitempty"`
-	Extension          []Extension                            `json:"extension,omitempty"`
-	ModifierExtension  []Extension                            `json:"modifierExtension,omitempty"`
-	IsDerived          *bool                                  `json:"isDerived,omitempty"`
-	Type               *CodeableConcept                       `json:"type,omitempty"`
-	Preference         SpecimenContainedPreference            `json:"preference"`
-	Container          *SpecimenDefinitionTypeTestedContainer `json:"container,omitempty"`
-	Requirement        *string                                `json:"requirement,omitempty"`
-	RetentionTime      *Duration                              `json:"retentionTime,omitempty"`
-	RejectionCriterion []CodeableConcept                      `json:"rejectionCriterion,omitempty"`
-	Handling           []SpecimenDefinitionTypeTestedHandling `json:"handling,omitempty"`
+	Id                 *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	IsDerived          *bool                                  `bson:"isDerived,omitempty" json:"isDerived,omitempty"`
+	Type               *CodeableConcept                       `bson:"type,omitempty" json:"type,omitempty"`
+	Preference         SpecimenContainedPreference            `bson:"preference" json:"preference"`
+	Container          *SpecimenDefinitionTypeTestedContainer `bson:"container,omitempty" json:"container,omitempty"`
+	Requirement        *string                                `bson:"requirement,omitempty" json:"requirement,omitempty"`
+	RetentionTime      *Duration                              `bson:"retentionTime,omitempty" json:"retentionTime,omitempty"`
+	RejectionCriterion []CodeableConcept                      `bson:"rejectionCriterion,omitempty" json:"rejectionCriterion,omitempty"`
+	Handling           []SpecimenDefinitionTypeTestedHandling `bson:"handling,omitempty" json:"handling,omitempty"`
 }
 type SpecimenDefinitionTypeTestedContainer struct {
-	Id                *string                                         `json:"id,omitempty"`
-	Extension         []Extension                                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                                     `json:"modifierExtension,omitempty"`
-	Material          *CodeableConcept                                `json:"material,omitempty"`
-	Type              *CodeableConcept                                `json:"type,omitempty"`
-	Cap               *CodeableConcept                                `json:"cap,omitempty"`
-	Description       *string                                         `json:"description,omitempty"`
-	Capacity          *Quantity                                       `json:"capacity,omitempty"`
-	Additive          []SpecimenDefinitionTypeTestedContainerAdditive `json:"additive,omitempty"`
-	Preparation       *string                                         `json:"preparation,omitempty"`
+	Id                *string                                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Material          *CodeableConcept                                `bson:"material,omitempty" json:"material,omitempty"`
+	Type              *CodeableConcept                                `bson:"type,omitempty" json:"type,omitempty"`
+	Cap               *CodeableConcept                                `bson:"cap,omitempty" json:"cap,omitempty"`
+	Description       *string                                         `bson:"description,omitempty" json:"description,omitempty"`
+	Capacity          *Quantity                                       `bson:"capacity,omitempty" json:"capacity,omitempty"`
+	Additive          []SpecimenDefinitionTypeTestedContainerAdditive `bson:"additive,omitempty" json:"additive,omitempty"`
+	Preparation       *string                                         `bson:"preparation,omitempty" json:"preparation,omitempty"`
 }
 type SpecimenDefinitionTypeTestedContainerAdditive struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type SpecimenDefinitionTypeTestedHandling struct {
-	Id                   *string          `json:"id,omitempty"`
-	Extension            []Extension      `json:"extension,omitempty"`
-	ModifierExtension    []Extension      `json:"modifierExtension,omitempty"`
-	TemperatureQualifier *CodeableConcept `json:"temperatureQualifier,omitempty"`
-	TemperatureRange     *Range           `json:"temperatureRange,omitempty"`
-	MaxDuration          *Duration        `json:"maxDuration,omitempty"`
-	Instruction          *string          `json:"instruction,omitempty"`
+	Id                   *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension            []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	TemperatureQualifier *CodeableConcept `bson:"temperatureQualifier,omitempty" json:"temperatureQualifier,omitempty"`
+	TemperatureRange     *Range           `bson:"temperatureRange,omitempty" json:"temperatureRange,omitempty"`
+	MaxDuration          *Duration        `bson:"maxDuration,omitempty" json:"maxDuration,omitempty"`
+	Instruction          *string          `bson:"instruction,omitempty" json:"instruction,omitempty"`
 }
 type OtherSpecimenDefinition SpecimenDefinition
 

--- a/fhir-models/fhir/structureDefinition.go
+++ b/fhir-models/fhir/structureDefinition.go
@@ -21,68 +21,68 @@ import "encoding/json"
 
 // StructureDefinition is documented here http://hl7.org/fhir/StructureDefinition/StructureDefinition
 type StructureDefinition struct {
-	Id                *string                          `json:"id,omitempty"`
-	Meta              *Meta                            `json:"meta,omitempty"`
-	ImplicitRules     *string                          `json:"implicitRules,omitempty"`
-	Language          *string                          `json:"language,omitempty"`
-	Text              *Narrative                       `json:"text,omitempty"`
-	Extension         []Extension                      `json:"extension,omitempty"`
-	ModifierExtension []Extension                      `json:"modifierExtension,omitempty"`
-	Url               string                           `json:"url"`
-	Identifier        []Identifier                     `json:"identifier,omitempty"`
-	Version           *string                          `json:"version,omitempty"`
-	Name              string                           `json:"name"`
-	Title             *string                          `json:"title,omitempty"`
-	Status            PublicationStatus                `json:"status"`
-	Experimental      *bool                            `json:"experimental,omitempty"`
-	Date              *string                          `json:"date,omitempty"`
-	Publisher         *string                          `json:"publisher,omitempty"`
-	Contact           []ContactDetail                  `json:"contact,omitempty"`
-	Description       *string                          `json:"description,omitempty"`
-	UseContext        []UsageContext                   `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                `json:"jurisdiction,omitempty"`
-	Purpose           *string                          `json:"purpose,omitempty"`
-	Copyright         *string                          `json:"copyright,omitempty"`
-	Keyword           []Coding                         `json:"keyword,omitempty"`
-	FhirVersion       *FHIRVersion                     `json:"fhirVersion,omitempty"`
-	Mapping           []StructureDefinitionMapping     `json:"mapping,omitempty"`
-	Kind              StructureDefinitionKind          `json:"kind"`
-	Abstract          bool                             `json:"abstract"`
-	Context           []StructureDefinitionContext     `json:"context,omitempty"`
-	ContextInvariant  []string                         `json:"contextInvariant,omitempty"`
-	Type              string                           `json:"type"`
-	BaseDefinition    *string                          `json:"baseDefinition,omitempty"`
-	Derivation        *TypeDerivationRule              `json:"derivation,omitempty"`
-	Snapshot          *StructureDefinitionSnapshot     `json:"snapshot,omitempty"`
-	Differential      *StructureDefinitionDifferential `json:"differential,omitempty"`
+	Id                *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                            `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                          `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                          `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                       `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                           `bson:"url" json:"url"`
+	Identifier        []Identifier                     `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                          `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                           `bson:"name" json:"name"`
+	Title             *string                          `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus                `bson:"status" json:"status"`
+	Experimental      *bool                            `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                          `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                          `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                  `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                          `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                   `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                          `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                          `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Keyword           []Coding                         `bson:"keyword,omitempty" json:"keyword,omitempty"`
+	FhirVersion       *FHIRVersion                     `bson:"fhirVersion,omitempty" json:"fhirVersion,omitempty"`
+	Mapping           []StructureDefinitionMapping     `bson:"mapping,omitempty" json:"mapping,omitempty"`
+	Kind              StructureDefinitionKind          `bson:"kind" json:"kind"`
+	Abstract          bool                             `bson:"abstract" json:"abstract"`
+	Context           []StructureDefinitionContext     `bson:"context,omitempty" json:"context,omitempty"`
+	ContextInvariant  []string                         `bson:"contextInvariant,omitempty" json:"contextInvariant,omitempty"`
+	Type              string                           `bson:"type" json:"type"`
+	BaseDefinition    *string                          `bson:"baseDefinition,omitempty" json:"baseDefinition,omitempty"`
+	Derivation        *TypeDerivationRule              `bson:"derivation,omitempty" json:"derivation,omitempty"`
+	Snapshot          *StructureDefinitionSnapshot     `bson:"snapshot,omitempty" json:"snapshot,omitempty"`
+	Differential      *StructureDefinitionDifferential `bson:"differential,omitempty" json:"differential,omitempty"`
 }
 type StructureDefinitionMapping struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Identity          string      `json:"identity"`
-	Uri               *string     `json:"uri,omitempty"`
-	Name              *string     `json:"name,omitempty"`
-	Comment           *string     `json:"comment,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identity          string      `bson:"identity" json:"identity"`
+	Uri               *string     `bson:"uri,omitempty" json:"uri,omitempty"`
+	Name              *string     `bson:"name,omitempty" json:"name,omitempty"`
+	Comment           *string     `bson:"comment,omitempty" json:"comment,omitempty"`
 }
 type StructureDefinitionContext struct {
-	Id                *string              `json:"id,omitempty"`
-	Extension         []Extension          `json:"extension,omitempty"`
-	ModifierExtension []Extension          `json:"modifierExtension,omitempty"`
-	Type              ExtensionContextType `json:"type"`
-	Expression        string               `json:"expression"`
+	Id                *string              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              ExtensionContextType `bson:"type" json:"type"`
+	Expression        string               `bson:"expression" json:"expression"`
 }
 type StructureDefinitionSnapshot struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Element           []ElementDefinition `json:"element"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Element           []ElementDefinition `bson:"element" json:"element"`
 }
 type StructureDefinitionDifferential struct {
-	Id                *string             `json:"id,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Element           []ElementDefinition `json:"element"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Element           []ElementDefinition `bson:"element" json:"element"`
 }
 type OtherStructureDefinition StructureDefinition
 

--- a/fhir-models/fhir/structureMap.go
+++ b/fhir-models/fhir/structureMap.go
@@ -21,111 +21,111 @@ import "encoding/json"
 
 // StructureMap is documented here http://hl7.org/fhir/StructureDefinition/StructureMap
 type StructureMap struct {
-	Id                *string                 `json:"id,omitempty"`
-	Meta              *Meta                   `json:"meta,omitempty"`
-	ImplicitRules     *string                 `json:"implicitRules,omitempty"`
-	Language          *string                 `json:"language,omitempty"`
-	Text              *Narrative              `json:"text,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Url               string                  `json:"url"`
-	Identifier        []Identifier            `json:"identifier,omitempty"`
-	Version           *string                 `json:"version,omitempty"`
-	Name              string                  `json:"name"`
-	Title             *string                 `json:"title,omitempty"`
-	Status            PublicationStatus       `json:"status"`
-	Experimental      *bool                   `json:"experimental,omitempty"`
-	Date              *string                 `json:"date,omitempty"`
-	Publisher         *string                 `json:"publisher,omitempty"`
-	Contact           []ContactDetail         `json:"contact,omitempty"`
-	Description       *string                 `json:"description,omitempty"`
-	UseContext        []UsageContext          `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept       `json:"jurisdiction,omitempty"`
-	Purpose           *string                 `json:"purpose,omitempty"`
-	Copyright         *string                 `json:"copyright,omitempty"`
-	Structure         []StructureMapStructure `json:"structure,omitempty"`
-	Import            []string                `json:"import,omitempty"`
-	Group             []StructureMapGroup     `json:"group"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                  `bson:"url" json:"url"`
+	Identifier        []Identifier            `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                 `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                  `bson:"name" json:"name"`
+	Title             *string                 `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus       `bson:"status" json:"status"`
+	Experimental      *bool                   `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                 `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                 `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail         `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                 `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext          `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept       `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                 `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                 `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Structure         []StructureMapStructure `bson:"structure,omitempty" json:"structure,omitempty"`
+	Import            []string                `bson:"import,omitempty" json:"import,omitempty"`
+	Group             []StructureMapGroup     `bson:"group" json:"group"`
 }
 type StructureMapStructure struct {
-	Id                *string               `json:"id,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Url               string                `json:"url"`
-	Mode              StructureMapModelMode `json:"mode"`
-	Alias             *string               `json:"alias,omitempty"`
-	Documentation     *string               `json:"documentation,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                `bson:"url" json:"url"`
+	Mode              StructureMapModelMode `bson:"mode" json:"mode"`
+	Alias             *string               `bson:"alias,omitempty" json:"alias,omitempty"`
+	Documentation     *string               `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type StructureMapGroup struct {
-	Id                *string                   `json:"id,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Name              string                    `json:"name"`
-	Extends           *string                   `json:"extends,omitempty"`
-	TypeMode          StructureMapGroupTypeMode `json:"typeMode"`
-	Documentation     *string                   `json:"documentation,omitempty"`
-	Input             []StructureMapGroupInput  `json:"input"`
-	Rule              []StructureMapGroupRule   `json:"rule"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                    `bson:"name" json:"name"`
+	Extends           *string                   `bson:"extends,omitempty" json:"extends,omitempty"`
+	TypeMode          StructureMapGroupTypeMode `bson:"typeMode" json:"typeMode"`
+	Documentation     *string                   `bson:"documentation,omitempty" json:"documentation,omitempty"`
+	Input             []StructureMapGroupInput  `bson:"input" json:"input"`
+	Rule              []StructureMapGroupRule   `bson:"rule" json:"rule"`
 }
 type StructureMapGroupInput struct {
-	Id                *string               `json:"id,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Name              string                `json:"name"`
-	Type              *string               `json:"type,omitempty"`
-	Mode              StructureMapInputMode `json:"mode"`
-	Documentation     *string               `json:"documentation,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                `bson:"name" json:"name"`
+	Type              *string               `bson:"type,omitempty" json:"type,omitempty"`
+	Mode              StructureMapInputMode `bson:"mode" json:"mode"`
+	Documentation     *string               `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type StructureMapGroupRule struct {
-	Id                *string                          `json:"id,omitempty"`
-	Extension         []Extension                      `json:"extension,omitempty"`
-	ModifierExtension []Extension                      `json:"modifierExtension,omitempty"`
-	Name              string                           `json:"name"`
-	Source            []StructureMapGroupRuleSource    `json:"source"`
-	Target            []StructureMapGroupRuleTarget    `json:"target,omitempty"`
-	Rule              []StructureMapGroupRule          `json:"rule,omitempty"`
-	Dependent         []StructureMapGroupRuleDependent `json:"dependent,omitempty"`
-	Documentation     *string                          `json:"documentation,omitempty"`
+	Id                *string                          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                           `bson:"name" json:"name"`
+	Source            []StructureMapGroupRuleSource    `bson:"source" json:"source"`
+	Target            []StructureMapGroupRuleTarget    `bson:"target,omitempty" json:"target,omitempty"`
+	Rule              []StructureMapGroupRule          `bson:"rule,omitempty" json:"rule,omitempty"`
+	Dependent         []StructureMapGroupRuleDependent `bson:"dependent,omitempty" json:"dependent,omitempty"`
+	Documentation     *string                          `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type StructureMapGroupRuleSource struct {
-	Id                *string                     `json:"id,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Context           string                      `json:"context"`
-	Min               *int                        `json:"min,omitempty"`
-	Max               *string                     `json:"max,omitempty"`
-	Type              *string                     `json:"type,omitempty"`
-	Element           *string                     `json:"element,omitempty"`
-	ListMode          *StructureMapSourceListMode `json:"listMode,omitempty"`
-	Variable          *string                     `json:"variable,omitempty"`
-	Condition         *string                     `json:"condition,omitempty"`
-	Check             *string                     `json:"check,omitempty"`
-	LogMessage        *string                     `json:"logMessage,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Context           string                      `bson:"context" json:"context"`
+	Min               *int                        `bson:"min,omitempty" json:"min,omitempty"`
+	Max               *string                     `bson:"max,omitempty" json:"max,omitempty"`
+	Type              *string                     `bson:"type,omitempty" json:"type,omitempty"`
+	Element           *string                     `bson:"element,omitempty" json:"element,omitempty"`
+	ListMode          *StructureMapSourceListMode `bson:"listMode,omitempty" json:"listMode,omitempty"`
+	Variable          *string                     `bson:"variable,omitempty" json:"variable,omitempty"`
+	Condition         *string                     `bson:"condition,omitempty" json:"condition,omitempty"`
+	Check             *string                     `bson:"check,omitempty" json:"check,omitempty"`
+	LogMessage        *string                     `bson:"logMessage,omitempty" json:"logMessage,omitempty"`
 }
 type StructureMapGroupRuleTarget struct {
-	Id                *string                                `json:"id,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Context           *string                                `json:"context,omitempty"`
-	ContextType       *StructureMapContextType               `json:"contextType,omitempty"`
-	Element           *string                                `json:"element,omitempty"`
-	Variable          *string                                `json:"variable,omitempty"`
-	ListMode          []StructureMapTargetListMode           `json:"listMode,omitempty"`
-	ListRuleId        *string                                `json:"listRuleId,omitempty"`
-	Transform         *StructureMapTransform                 `json:"transform,omitempty"`
-	Parameter         []StructureMapGroupRuleTargetParameter `json:"parameter,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Context           *string                                `bson:"context,omitempty" json:"context,omitempty"`
+	ContextType       *StructureMapContextType               `bson:"contextType,omitempty" json:"contextType,omitempty"`
+	Element           *string                                `bson:"element,omitempty" json:"element,omitempty"`
+	Variable          *string                                `bson:"variable,omitempty" json:"variable,omitempty"`
+	ListMode          []StructureMapTargetListMode           `bson:"listMode,omitempty" json:"listMode,omitempty"`
+	ListRuleId        *string                                `bson:"listRuleId,omitempty" json:"listRuleId,omitempty"`
+	Transform         *StructureMapTransform                 `bson:"transform,omitempty" json:"transform,omitempty"`
+	Parameter         []StructureMapGroupRuleTargetParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
 }
 type StructureMapGroupRuleTargetParameter struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
 }
 type StructureMapGroupRuleDependent struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Variable          []string    `json:"variable"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Variable          []string    `bson:"variable" json:"variable"`
 }
 type OtherStructureMap StructureMap
 

--- a/fhir-models/fhir/subscription.go
+++ b/fhir-models/fhir/subscription.go
@@ -21,29 +21,29 @@ import "encoding/json"
 
 // Subscription is documented here http://hl7.org/fhir/StructureDefinition/Subscription
 type Subscription struct {
-	Id                *string             `json:"id,omitempty"`
-	Meta              *Meta               `json:"meta,omitempty"`
-	ImplicitRules     *string             `json:"implicitRules,omitempty"`
-	Language          *string             `json:"language,omitempty"`
-	Text              *Narrative          `json:"text,omitempty"`
-	Extension         []Extension         `json:"extension,omitempty"`
-	ModifierExtension []Extension         `json:"modifierExtension,omitempty"`
-	Status            SubscriptionStatus  `json:"status"`
-	Contact           []ContactPoint      `json:"contact,omitempty"`
-	End               *string             `json:"end,omitempty"`
-	Reason            string              `json:"reason"`
-	Criteria          string              `json:"criteria"`
-	Error             *string             `json:"error,omitempty"`
-	Channel           SubscriptionChannel `json:"channel"`
+	Id                *string             `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta               `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string             `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string             `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative          `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension         `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension         `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Status            SubscriptionStatus  `bson:"status" json:"status"`
+	Contact           []ContactPoint      `bson:"contact,omitempty" json:"contact,omitempty"`
+	End               *string             `bson:"end,omitempty" json:"end,omitempty"`
+	Reason            string              `bson:"reason" json:"reason"`
+	Criteria          string              `bson:"criteria" json:"criteria"`
+	Error             *string             `bson:"error,omitempty" json:"error,omitempty"`
+	Channel           SubscriptionChannel `bson:"channel" json:"channel"`
 }
 type SubscriptionChannel struct {
-	Id                *string                 `json:"id,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Type              SubscriptionChannelType `json:"type"`
-	Endpoint          *string                 `json:"endpoint,omitempty"`
-	Payload           *string                 `json:"payload,omitempty"`
-	Header            []string                `json:"header,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              SubscriptionChannelType `bson:"type" json:"type"`
+	Endpoint          *string                 `bson:"endpoint,omitempty" json:"endpoint,omitempty"`
+	Payload           *string                 `bson:"payload,omitempty" json:"payload,omitempty"`
+	Header            []string                `bson:"header,omitempty" json:"header,omitempty"`
 }
 type OtherSubscription Subscription
 

--- a/fhir-models/fhir/substance.go
+++ b/fhir-models/fhir/substance.go
@@ -21,34 +21,34 @@ import "encoding/json"
 
 // Substance is documented here http://hl7.org/fhir/StructureDefinition/Substance
 type Substance struct {
-	Id                *string               `json:"id,omitempty"`
-	Meta              *Meta                 `json:"meta,omitempty"`
-	ImplicitRules     *string               `json:"implicitRules,omitempty"`
-	Language          *string               `json:"language,omitempty"`
-	Text              *Narrative            `json:"text,omitempty"`
-	Extension         []Extension           `json:"extension,omitempty"`
-	ModifierExtension []Extension           `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier          `json:"identifier,omitempty"`
-	Status            *FHIRSubstanceStatus  `json:"status,omitempty"`
-	Category          []CodeableConcept     `json:"category,omitempty"`
-	Code              CodeableConcept       `json:"code"`
-	Description       *string               `json:"description,omitempty"`
-	Instance          []SubstanceInstance   `json:"instance,omitempty"`
-	Ingredient        []SubstanceIngredient `json:"ingredient,omitempty"`
+	Id                *string               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            *FHIRSubstanceStatus  `bson:"status,omitempty" json:"status,omitempty"`
+	Category          []CodeableConcept     `bson:"category,omitempty" json:"category,omitempty"`
+	Code              CodeableConcept       `bson:"code" json:"code"`
+	Description       *string               `bson:"description,omitempty" json:"description,omitempty"`
+	Instance          []SubstanceInstance   `bson:"instance,omitempty" json:"instance,omitempty"`
+	Ingredient        []SubstanceIngredient `bson:"ingredient,omitempty" json:"ingredient,omitempty"`
 }
 type SubstanceInstance struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier `json:"identifier,omitempty"`
-	Expiry            *string     `json:"expiry,omitempty"`
-	Quantity          *Quantity   `json:"quantity,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Expiry            *string     `bson:"expiry,omitempty" json:"expiry,omitempty"`
+	Quantity          *Quantity   `bson:"quantity,omitempty" json:"quantity,omitempty"`
 }
 type SubstanceIngredient struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Quantity          *Ratio      `json:"quantity,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Quantity          *Ratio      `bson:"quantity,omitempty" json:"quantity,omitempty"`
 }
 type OtherSubstance Substance
 

--- a/fhir-models/fhir/substanceAmount.go
+++ b/fhir-models/fhir/substanceAmount.go
@@ -19,16 +19,16 @@ package fhir
 
 // SubstanceAmount is documented here http://hl7.org/fhir/StructureDefinition/SubstanceAmount
 type SubstanceAmount struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	AmountType        *CodeableConcept               `json:"amountType,omitempty"`
-	AmountText        *string                        `json:"amountText,omitempty"`
-	ReferenceRange    *SubstanceAmountReferenceRange `json:"referenceRange,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	AmountType        *CodeableConcept               `bson:"amountType,omitempty" json:"amountType,omitempty"`
+	AmountText        *string                        `bson:"amountText,omitempty" json:"amountText,omitempty"`
+	ReferenceRange    *SubstanceAmountReferenceRange `bson:"referenceRange,omitempty" json:"referenceRange,omitempty"`
 }
 type SubstanceAmountReferenceRange struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	LowLimit  *Quantity   `json:"lowLimit,omitempty"`
-	HighLimit *Quantity   `json:"highLimit,omitempty"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	LowLimit  *Quantity   `bson:"lowLimit,omitempty" json:"lowLimit,omitempty"`
+	HighLimit *Quantity   `bson:"highLimit,omitempty" json:"highLimit,omitempty"`
 }

--- a/fhir-models/fhir/substanceNucleicAcid.go
+++ b/fhir-models/fhir/substanceNucleicAcid.go
@@ -21,48 +21,48 @@ import "encoding/json"
 
 // SubstanceNucleicAcid is documented here http://hl7.org/fhir/StructureDefinition/SubstanceNucleicAcid
 type SubstanceNucleicAcid struct {
-	Id                  *string                       `json:"id,omitempty"`
-	Meta                *Meta                         `json:"meta,omitempty"`
-	ImplicitRules       *string                       `json:"implicitRules,omitempty"`
-	Language            *string                       `json:"language,omitempty"`
-	Text                *Narrative                    `json:"text,omitempty"`
-	Extension           []Extension                   `json:"extension,omitempty"`
-	ModifierExtension   []Extension                   `json:"modifierExtension,omitempty"`
-	SequenceType        *CodeableConcept              `json:"sequenceType,omitempty"`
-	NumberOfSubunits    *int                          `json:"numberOfSubunits,omitempty"`
-	AreaOfHybridisation *string                       `json:"areaOfHybridisation,omitempty"`
-	OligoNucleotideType *CodeableConcept              `json:"oligoNucleotideType,omitempty"`
-	Subunit             []SubstanceNucleicAcidSubunit `json:"subunit,omitempty"`
+	Id                  *string                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                *Meta                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules       *string                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language            *string                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text                *Narrative                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension           []Extension                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SequenceType        *CodeableConcept              `bson:"sequenceType,omitempty" json:"sequenceType,omitempty"`
+	NumberOfSubunits    *int                          `bson:"numberOfSubunits,omitempty" json:"numberOfSubunits,omitempty"`
+	AreaOfHybridisation *string                       `bson:"areaOfHybridisation,omitempty" json:"areaOfHybridisation,omitempty"`
+	OligoNucleotideType *CodeableConcept              `bson:"oligoNucleotideType,omitempty" json:"oligoNucleotideType,omitempty"`
+	Subunit             []SubstanceNucleicAcidSubunit `bson:"subunit,omitempty" json:"subunit,omitempty"`
 }
 type SubstanceNucleicAcidSubunit struct {
-	Id                 *string                              `json:"id,omitempty"`
-	Extension          []Extension                          `json:"extension,omitempty"`
-	ModifierExtension  []Extension                          `json:"modifierExtension,omitempty"`
-	Subunit            *int                                 `json:"subunit,omitempty"`
-	Sequence           *string                              `json:"sequence,omitempty"`
-	Length             *int                                 `json:"length,omitempty"`
-	SequenceAttachment *Attachment                          `json:"sequenceAttachment,omitempty"`
-	FivePrime          *CodeableConcept                     `json:"fivePrime,omitempty"`
-	ThreePrime         *CodeableConcept                     `json:"threePrime,omitempty"`
-	Linkage            []SubstanceNucleicAcidSubunitLinkage `json:"linkage,omitempty"`
-	Sugar              []SubstanceNucleicAcidSubunitSugar   `json:"sugar,omitempty"`
+	Id                 *string                              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension                          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension                          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Subunit            *int                                 `bson:"subunit,omitempty" json:"subunit,omitempty"`
+	Sequence           *string                              `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Length             *int                                 `bson:"length,omitempty" json:"length,omitempty"`
+	SequenceAttachment *Attachment                          `bson:"sequenceAttachment,omitempty" json:"sequenceAttachment,omitempty"`
+	FivePrime          *CodeableConcept                     `bson:"fivePrime,omitempty" json:"fivePrime,omitempty"`
+	ThreePrime         *CodeableConcept                     `bson:"threePrime,omitempty" json:"threePrime,omitempty"`
+	Linkage            []SubstanceNucleicAcidSubunitLinkage `bson:"linkage,omitempty" json:"linkage,omitempty"`
+	Sugar              []SubstanceNucleicAcidSubunitSugar   `bson:"sugar,omitempty" json:"sugar,omitempty"`
 }
 type SubstanceNucleicAcidSubunitLinkage struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Connectivity      *string     `json:"connectivity,omitempty"`
-	Identifier        *Identifier `json:"identifier,omitempty"`
-	Name              *string     `json:"name,omitempty"`
-	ResidueSite       *string     `json:"residueSite,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Connectivity      *string     `bson:"connectivity,omitempty" json:"connectivity,omitempty"`
+	Identifier        *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Name              *string     `bson:"name,omitempty" json:"name,omitempty"`
+	ResidueSite       *string     `bson:"residueSite,omitempty" json:"residueSite,omitempty"`
 }
 type SubstanceNucleicAcidSubunitSugar struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier `json:"identifier,omitempty"`
-	Name              *string     `json:"name,omitempty"`
-	ResidueSite       *string     `json:"residueSite,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Name              *string     `bson:"name,omitempty" json:"name,omitempty"`
+	ResidueSite       *string     `bson:"residueSite,omitempty" json:"residueSite,omitempty"`
 }
 type OtherSubstanceNucleicAcid SubstanceNucleicAcid
 

--- a/fhir-models/fhir/substancePolymer.go
+++ b/fhir-models/fhir/substancePolymer.go
@@ -21,69 +21,69 @@ import "encoding/json"
 
 // SubstancePolymer is documented here http://hl7.org/fhir/StructureDefinition/SubstancePolymer
 type SubstancePolymer struct {
-	Id                    *string                      `json:"id,omitempty"`
-	Meta                  *Meta                        `json:"meta,omitempty"`
-	ImplicitRules         *string                      `json:"implicitRules,omitempty"`
-	Language              *string                      `json:"language,omitempty"`
-	Text                  *Narrative                   `json:"text,omitempty"`
-	Extension             []Extension                  `json:"extension,omitempty"`
-	ModifierExtension     []Extension                  `json:"modifierExtension,omitempty"`
-	Class                 *CodeableConcept             `json:"class,omitempty"`
-	Geometry              *CodeableConcept             `json:"geometry,omitempty"`
-	CopolymerConnectivity []CodeableConcept            `json:"copolymerConnectivity,omitempty"`
-	Modification          []string                     `json:"modification,omitempty"`
-	MonomerSet            []SubstancePolymerMonomerSet `json:"monomerSet,omitempty"`
-	Repeat                []SubstancePolymerRepeat     `json:"repeat,omitempty"`
+	Id                    *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Class                 *CodeableConcept             `bson:"class,omitempty" json:"class,omitempty"`
+	Geometry              *CodeableConcept             `bson:"geometry,omitempty" json:"geometry,omitempty"`
+	CopolymerConnectivity []CodeableConcept            `bson:"copolymerConnectivity,omitempty" json:"copolymerConnectivity,omitempty"`
+	Modification          []string                     `bson:"modification,omitempty" json:"modification,omitempty"`
+	MonomerSet            []SubstancePolymerMonomerSet `bson:"monomerSet,omitempty" json:"monomerSet,omitempty"`
+	Repeat                []SubstancePolymerRepeat     `bson:"repeat,omitempty" json:"repeat,omitempty"`
 }
 type SubstancePolymerMonomerSet struct {
-	Id                *string                                      `json:"id,omitempty"`
-	Extension         []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                                  `json:"modifierExtension,omitempty"`
-	RatioType         *CodeableConcept                             `json:"ratioType,omitempty"`
-	StartingMaterial  []SubstancePolymerMonomerSetStartingMaterial `json:"startingMaterial,omitempty"`
+	Id                *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	RatioType         *CodeableConcept                             `bson:"ratioType,omitempty" json:"ratioType,omitempty"`
+	StartingMaterial  []SubstancePolymerMonomerSetStartingMaterial `bson:"startingMaterial,omitempty" json:"startingMaterial,omitempty"`
 }
 type SubstancePolymerMonomerSetStartingMaterial struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Material          *CodeableConcept `json:"material,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	IsDefining        *bool            `json:"isDefining,omitempty"`
-	Amount            *SubstanceAmount `json:"amount,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Material          *CodeableConcept `bson:"material,omitempty" json:"material,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	IsDefining        *bool            `bson:"isDefining,omitempty" json:"isDefining,omitempty"`
+	Amount            *SubstanceAmount `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type SubstancePolymerRepeat struct {
-	Id                      *string                            `json:"id,omitempty"`
-	Extension               []Extension                        `json:"extension,omitempty"`
-	ModifierExtension       []Extension                        `json:"modifierExtension,omitempty"`
-	NumberOfUnits           *int                               `json:"numberOfUnits,omitempty"`
-	AverageMolecularFormula *string                            `json:"averageMolecularFormula,omitempty"`
-	RepeatUnitAmountType    *CodeableConcept                   `json:"repeatUnitAmountType,omitempty"`
-	RepeatUnit              []SubstancePolymerRepeatRepeatUnit `json:"repeatUnit,omitempty"`
+	Id                      *string                            `bson:"id,omitempty" json:"id,omitempty"`
+	Extension               []Extension                        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension                        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	NumberOfUnits           *int                               `bson:"numberOfUnits,omitempty" json:"numberOfUnits,omitempty"`
+	AverageMolecularFormula *string                            `bson:"averageMolecularFormula,omitempty" json:"averageMolecularFormula,omitempty"`
+	RepeatUnitAmountType    *CodeableConcept                   `bson:"repeatUnitAmountType,omitempty" json:"repeatUnitAmountType,omitempty"`
+	RepeatUnit              []SubstancePolymerRepeatRepeatUnit `bson:"repeatUnit,omitempty" json:"repeatUnit,omitempty"`
 }
 type SubstancePolymerRepeatRepeatUnit struct {
-	Id                          *string                                                    `json:"id,omitempty"`
-	Extension                   []Extension                                                `json:"extension,omitempty"`
-	ModifierExtension           []Extension                                                `json:"modifierExtension,omitempty"`
-	OrientationOfPolymerisation *CodeableConcept                                           `json:"orientationOfPolymerisation,omitempty"`
-	RepeatUnit                  *string                                                    `json:"repeatUnit,omitempty"`
-	Amount                      *SubstanceAmount                                           `json:"amount,omitempty"`
-	DegreeOfPolymerisation      []SubstancePolymerRepeatRepeatUnitDegreeOfPolymerisation   `json:"degreeOfPolymerisation,omitempty"`
-	StructuralRepresentation    []SubstancePolymerRepeatRepeatUnitStructuralRepresentation `json:"structuralRepresentation,omitempty"`
+	Id                          *string                                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                   []Extension                                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension           []Extension                                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	OrientationOfPolymerisation *CodeableConcept                                           `bson:"orientationOfPolymerisation,omitempty" json:"orientationOfPolymerisation,omitempty"`
+	RepeatUnit                  *string                                                    `bson:"repeatUnit,omitempty" json:"repeatUnit,omitempty"`
+	Amount                      *SubstanceAmount                                           `bson:"amount,omitempty" json:"amount,omitempty"`
+	DegreeOfPolymerisation      []SubstancePolymerRepeatRepeatUnitDegreeOfPolymerisation   `bson:"degreeOfPolymerisation,omitempty" json:"degreeOfPolymerisation,omitempty"`
+	StructuralRepresentation    []SubstancePolymerRepeatRepeatUnitStructuralRepresentation `bson:"structuralRepresentation,omitempty" json:"structuralRepresentation,omitempty"`
 }
 type SubstancePolymerRepeatRepeatUnitDegreeOfPolymerisation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Degree            *CodeableConcept `json:"degree,omitempty"`
-	Amount            *SubstanceAmount `json:"amount,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Degree            *CodeableConcept `bson:"degree,omitempty" json:"degree,omitempty"`
+	Amount            *SubstanceAmount `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type SubstancePolymerRepeatRepeatUnitStructuralRepresentation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Representation    *string          `json:"representation,omitempty"`
-	Attachment        *Attachment      `json:"attachment,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Representation    *string          `bson:"representation,omitempty" json:"representation,omitempty"`
+	Attachment        *Attachment      `bson:"attachment,omitempty" json:"attachment,omitempty"`
 }
 type OtherSubstancePolymer SubstancePolymer
 

--- a/fhir-models/fhir/substanceProtein.go
+++ b/fhir-models/fhir/substanceProtein.go
@@ -21,30 +21,30 @@ import "encoding/json"
 
 // SubstanceProtein is documented here http://hl7.org/fhir/StructureDefinition/SubstanceProtein
 type SubstanceProtein struct {
-	Id                *string                   `json:"id,omitempty"`
-	Meta              *Meta                     `json:"meta,omitempty"`
-	ImplicitRules     *string                   `json:"implicitRules,omitempty"`
-	Language          *string                   `json:"language,omitempty"`
-	Text              *Narrative                `json:"text,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	SequenceType      *CodeableConcept          `json:"sequenceType,omitempty"`
-	NumberOfSubunits  *int                      `json:"numberOfSubunits,omitempty"`
-	DisulfideLinkage  []string                  `json:"disulfideLinkage,omitempty"`
-	Subunit           []SubstanceProteinSubunit `json:"subunit,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                     `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                   `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                   `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SequenceType      *CodeableConcept          `bson:"sequenceType,omitempty" json:"sequenceType,omitempty"`
+	NumberOfSubunits  *int                      `bson:"numberOfSubunits,omitempty" json:"numberOfSubunits,omitempty"`
+	DisulfideLinkage  []string                  `bson:"disulfideLinkage,omitempty" json:"disulfideLinkage,omitempty"`
+	Subunit           []SubstanceProteinSubunit `bson:"subunit,omitempty" json:"subunit,omitempty"`
 }
 type SubstanceProteinSubunit struct {
-	Id                      *string     `json:"id,omitempty"`
-	Extension               []Extension `json:"extension,omitempty"`
-	ModifierExtension       []Extension `json:"modifierExtension,omitempty"`
-	Subunit                 *int        `json:"subunit,omitempty"`
-	Sequence                *string     `json:"sequence,omitempty"`
-	Length                  *int        `json:"length,omitempty"`
-	SequenceAttachment      *Attachment `json:"sequenceAttachment,omitempty"`
-	NTerminalModificationId *Identifier `json:"nTerminalModificationId,omitempty"`
-	NTerminalModification   *string     `json:"nTerminalModification,omitempty"`
-	CTerminalModificationId *Identifier `json:"cTerminalModificationId,omitempty"`
-	CTerminalModification   *string     `json:"cTerminalModification,omitempty"`
+	Id                      *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension               []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension       []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Subunit                 *int        `bson:"subunit,omitempty" json:"subunit,omitempty"`
+	Sequence                *string     `bson:"sequence,omitempty" json:"sequence,omitempty"`
+	Length                  *int        `bson:"length,omitempty" json:"length,omitempty"`
+	SequenceAttachment      *Attachment `bson:"sequenceAttachment,omitempty" json:"sequenceAttachment,omitempty"`
+	NTerminalModificationId *Identifier `bson:"nTerminalModificationId,omitempty" json:"nTerminalModificationId,omitempty"`
+	NTerminalModification   *string     `bson:"nTerminalModification,omitempty" json:"nTerminalModification,omitempty"`
+	CTerminalModificationId *Identifier `bson:"cTerminalModificationId,omitempty" json:"cTerminalModificationId,omitempty"`
+	CTerminalModification   *string     `bson:"cTerminalModification,omitempty" json:"cTerminalModification,omitempty"`
 }
 type OtherSubstanceProtein SubstanceProtein
 

--- a/fhir-models/fhir/substanceReferenceInformation.go
+++ b/fhir-models/fhir/substanceReferenceInformation.go
@@ -21,55 +21,55 @@ import "encoding/json"
 
 // SubstanceReferenceInformation is documented here http://hl7.org/fhir/StructureDefinition/SubstanceReferenceInformation
 type SubstanceReferenceInformation struct {
-	Id                *string                                       `json:"id,omitempty"`
-	Meta              *Meta                                         `json:"meta,omitempty"`
-	ImplicitRules     *string                                       `json:"implicitRules,omitempty"`
-	Language          *string                                       `json:"language,omitempty"`
-	Text              *Narrative                                    `json:"text,omitempty"`
-	Extension         []Extension                                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                                   `json:"modifierExtension,omitempty"`
-	Comment           *string                                       `json:"comment,omitempty"`
-	Gene              []SubstanceReferenceInformationGene           `json:"gene,omitempty"`
-	GeneElement       []SubstanceReferenceInformationGeneElement    `json:"geneElement,omitempty"`
-	Classification    []SubstanceReferenceInformationClassification `json:"classification,omitempty"`
-	Target            []SubstanceReferenceInformationTarget         `json:"target,omitempty"`
+	Id                *string                                       `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                         `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                       `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                       `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                                    `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Comment           *string                                       `bson:"comment,omitempty" json:"comment,omitempty"`
+	Gene              []SubstanceReferenceInformationGene           `bson:"gene,omitempty" json:"gene,omitempty"`
+	GeneElement       []SubstanceReferenceInformationGeneElement    `bson:"geneElement,omitempty" json:"geneElement,omitempty"`
+	Classification    []SubstanceReferenceInformationClassification `bson:"classification,omitempty" json:"classification,omitempty"`
+	Target            []SubstanceReferenceInformationTarget         `bson:"target,omitempty" json:"target,omitempty"`
 }
 type SubstanceReferenceInformationGene struct {
-	Id                 *string          `json:"id,omitempty"`
-	Extension          []Extension      `json:"extension,omitempty"`
-	ModifierExtension  []Extension      `json:"modifierExtension,omitempty"`
-	GeneSequenceOrigin *CodeableConcept `json:"geneSequenceOrigin,omitempty"`
-	Gene               *CodeableConcept `json:"gene,omitempty"`
-	Source             []Reference      `json:"source,omitempty"`
+	Id                 *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension          []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension  []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	GeneSequenceOrigin *CodeableConcept `bson:"geneSequenceOrigin,omitempty" json:"geneSequenceOrigin,omitempty"`
+	Gene               *CodeableConcept `bson:"gene,omitempty" json:"gene,omitempty"`
+	Source             []Reference      `bson:"source,omitempty" json:"source,omitempty"`
 }
 type SubstanceReferenceInformationGeneElement struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Element           *Identifier      `json:"element,omitempty"`
-	Source            []Reference      `json:"source,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Element           *Identifier      `bson:"element,omitempty" json:"element,omitempty"`
+	Source            []Reference      `bson:"source,omitempty" json:"source,omitempty"`
 }
 type SubstanceReferenceInformationClassification struct {
-	Id                *string           `json:"id,omitempty"`
-	Extension         []Extension       `json:"extension,omitempty"`
-	ModifierExtension []Extension       `json:"modifierExtension,omitempty"`
-	Domain            *CodeableConcept  `json:"domain,omitempty"`
-	Classification    *CodeableConcept  `json:"classification,omitempty"`
-	Subtype           []CodeableConcept `json:"subtype,omitempty"`
-	Source            []Reference       `json:"source,omitempty"`
+	Id                *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Domain            *CodeableConcept  `bson:"domain,omitempty" json:"domain,omitempty"`
+	Classification    *CodeableConcept  `bson:"classification,omitempty" json:"classification,omitempty"`
+	Subtype           []CodeableConcept `bson:"subtype,omitempty" json:"subtype,omitempty"`
+	Source            []Reference       `bson:"source,omitempty" json:"source,omitempty"`
 }
 type SubstanceReferenceInformationTarget struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Target            *Identifier      `json:"target,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Interaction       *CodeableConcept `json:"interaction,omitempty"`
-	Organism          *CodeableConcept `json:"organism,omitempty"`
-	OrganismType      *CodeableConcept `json:"organismType,omitempty"`
-	AmountType        *CodeableConcept `json:"amountType,omitempty"`
-	Source            []Reference      `json:"source,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Target            *Identifier      `bson:"target,omitempty" json:"target,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Interaction       *CodeableConcept `bson:"interaction,omitempty" json:"interaction,omitempty"`
+	Organism          *CodeableConcept `bson:"organism,omitempty" json:"organism,omitempty"`
+	OrganismType      *CodeableConcept `bson:"organismType,omitempty" json:"organismType,omitempty"`
+	AmountType        *CodeableConcept `bson:"amountType,omitempty" json:"amountType,omitempty"`
+	Source            []Reference      `bson:"source,omitempty" json:"source,omitempty"`
 }
 type OtherSubstanceReferenceInformation SubstanceReferenceInformation
 

--- a/fhir-models/fhir/substanceSourceMaterial.go
+++ b/fhir-models/fhir/substanceSourceMaterial.go
@@ -21,79 +21,79 @@ import "encoding/json"
 
 // SubstanceSourceMaterial is documented here http://hl7.org/fhir/StructureDefinition/SubstanceSourceMaterial
 type SubstanceSourceMaterial struct {
-	Id                   *string                                      `json:"id,omitempty"`
-	Meta                 *Meta                                        `json:"meta,omitempty"`
-	ImplicitRules        *string                                      `json:"implicitRules,omitempty"`
-	Language             *string                                      `json:"language,omitempty"`
-	Text                 *Narrative                                   `json:"text,omitempty"`
-	Extension            []Extension                                  `json:"extension,omitempty"`
-	ModifierExtension    []Extension                                  `json:"modifierExtension,omitempty"`
-	SourceMaterialClass  *CodeableConcept                             `json:"sourceMaterialClass,omitempty"`
-	SourceMaterialType   *CodeableConcept                             `json:"sourceMaterialType,omitempty"`
-	SourceMaterialState  *CodeableConcept                             `json:"sourceMaterialState,omitempty"`
-	OrganismId           *Identifier                                  `json:"organismId,omitempty"`
-	OrganismName         *string                                      `json:"organismName,omitempty"`
-	ParentSubstanceId    []Identifier                                 `json:"parentSubstanceId,omitempty"`
-	ParentSubstanceName  []string                                     `json:"parentSubstanceName,omitempty"`
-	CountryOfOrigin      []CodeableConcept                            `json:"countryOfOrigin,omitempty"`
-	GeographicalLocation []string                                     `json:"geographicalLocation,omitempty"`
-	DevelopmentStage     *CodeableConcept                             `json:"developmentStage,omitempty"`
-	FractionDescription  []SubstanceSourceMaterialFractionDescription `json:"fractionDescription,omitempty"`
-	Organism             *SubstanceSourceMaterialOrganism             `json:"organism,omitempty"`
-	PartDescription      []SubstanceSourceMaterialPartDescription     `json:"partDescription,omitempty"`
+	Id                   *string                                      `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                                        `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string                                      `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string                                      `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative                                   `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension                                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension                                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	SourceMaterialClass  *CodeableConcept                             `bson:"sourceMaterialClass,omitempty" json:"sourceMaterialClass,omitempty"`
+	SourceMaterialType   *CodeableConcept                             `bson:"sourceMaterialType,omitempty" json:"sourceMaterialType,omitempty"`
+	SourceMaterialState  *CodeableConcept                             `bson:"sourceMaterialState,omitempty" json:"sourceMaterialState,omitempty"`
+	OrganismId           *Identifier                                  `bson:"organismId,omitempty" json:"organismId,omitempty"`
+	OrganismName         *string                                      `bson:"organismName,omitempty" json:"organismName,omitempty"`
+	ParentSubstanceId    []Identifier                                 `bson:"parentSubstanceId,omitempty" json:"parentSubstanceId,omitempty"`
+	ParentSubstanceName  []string                                     `bson:"parentSubstanceName,omitempty" json:"parentSubstanceName,omitempty"`
+	CountryOfOrigin      []CodeableConcept                            `bson:"countryOfOrigin,omitempty" json:"countryOfOrigin,omitempty"`
+	GeographicalLocation []string                                     `bson:"geographicalLocation,omitempty" json:"geographicalLocation,omitempty"`
+	DevelopmentStage     *CodeableConcept                             `bson:"developmentStage,omitempty" json:"developmentStage,omitempty"`
+	FractionDescription  []SubstanceSourceMaterialFractionDescription `bson:"fractionDescription,omitempty" json:"fractionDescription,omitempty"`
+	Organism             *SubstanceSourceMaterialOrganism             `bson:"organism,omitempty" json:"organism,omitempty"`
+	PartDescription      []SubstanceSourceMaterialPartDescription     `bson:"partDescription,omitempty" json:"partDescription,omitempty"`
 }
 type SubstanceSourceMaterialFractionDescription struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Fraction          *string          `json:"fraction,omitempty"`
-	MaterialType      *CodeableConcept `json:"materialType,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Fraction          *string          `bson:"fraction,omitempty" json:"fraction,omitempty"`
+	MaterialType      *CodeableConcept `bson:"materialType,omitempty" json:"materialType,omitempty"`
 }
 type SubstanceSourceMaterialOrganism struct {
-	Id                       *string                                         `json:"id,omitempty"`
-	Extension                []Extension                                     `json:"extension,omitempty"`
-	ModifierExtension        []Extension                                     `json:"modifierExtension,omitempty"`
-	Family                   *CodeableConcept                                `json:"family,omitempty"`
-	Genus                    *CodeableConcept                                `json:"genus,omitempty"`
-	Species                  *CodeableConcept                                `json:"species,omitempty"`
-	IntraspecificType        *CodeableConcept                                `json:"intraspecificType,omitempty"`
-	IntraspecificDescription *string                                         `json:"intraspecificDescription,omitempty"`
-	Author                   []SubstanceSourceMaterialOrganismAuthor         `json:"author,omitempty"`
-	Hybrid                   *SubstanceSourceMaterialOrganismHybrid          `json:"hybrid,omitempty"`
-	OrganismGeneral          *SubstanceSourceMaterialOrganismOrganismGeneral `json:"organismGeneral,omitempty"`
+	Id                       *string                                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                []Extension                                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension        []Extension                                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Family                   *CodeableConcept                                `bson:"family,omitempty" json:"family,omitempty"`
+	Genus                    *CodeableConcept                                `bson:"genus,omitempty" json:"genus,omitempty"`
+	Species                  *CodeableConcept                                `bson:"species,omitempty" json:"species,omitempty"`
+	IntraspecificType        *CodeableConcept                                `bson:"intraspecificType,omitempty" json:"intraspecificType,omitempty"`
+	IntraspecificDescription *string                                         `bson:"intraspecificDescription,omitempty" json:"intraspecificDescription,omitempty"`
+	Author                   []SubstanceSourceMaterialOrganismAuthor         `bson:"author,omitempty" json:"author,omitempty"`
+	Hybrid                   *SubstanceSourceMaterialOrganismHybrid          `bson:"hybrid,omitempty" json:"hybrid,omitempty"`
+	OrganismGeneral          *SubstanceSourceMaterialOrganismOrganismGeneral `bson:"organismGeneral,omitempty" json:"organismGeneral,omitempty"`
 }
 type SubstanceSourceMaterialOrganismAuthor struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	AuthorType        *CodeableConcept `json:"authorType,omitempty"`
-	AuthorDescription *string          `json:"authorDescription,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	AuthorType        *CodeableConcept `bson:"authorType,omitempty" json:"authorType,omitempty"`
+	AuthorDescription *string          `bson:"authorDescription,omitempty" json:"authorDescription,omitempty"`
 }
 type SubstanceSourceMaterialOrganismHybrid struct {
-	Id                   *string          `json:"id,omitempty"`
-	Extension            []Extension      `json:"extension,omitempty"`
-	ModifierExtension    []Extension      `json:"modifierExtension,omitempty"`
-	MaternalOrganismId   *string          `json:"maternalOrganismId,omitempty"`
-	MaternalOrganismName *string          `json:"maternalOrganismName,omitempty"`
-	PaternalOrganismId   *string          `json:"paternalOrganismId,omitempty"`
-	PaternalOrganismName *string          `json:"paternalOrganismName,omitempty"`
-	HybridType           *CodeableConcept `json:"hybridType,omitempty"`
+	Id                   *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension            []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	MaternalOrganismId   *string          `bson:"maternalOrganismId,omitempty" json:"maternalOrganismId,omitempty"`
+	MaternalOrganismName *string          `bson:"maternalOrganismName,omitempty" json:"maternalOrganismName,omitempty"`
+	PaternalOrganismId   *string          `bson:"paternalOrganismId,omitempty" json:"paternalOrganismId,omitempty"`
+	PaternalOrganismName *string          `bson:"paternalOrganismName,omitempty" json:"paternalOrganismName,omitempty"`
+	HybridType           *CodeableConcept `bson:"hybridType,omitempty" json:"hybridType,omitempty"`
 }
 type SubstanceSourceMaterialOrganismOrganismGeneral struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Kingdom           *CodeableConcept `json:"kingdom,omitempty"`
-	Phylum            *CodeableConcept `json:"phylum,omitempty"`
-	Class             *CodeableConcept `json:"class,omitempty"`
-	Order             *CodeableConcept `json:"order,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Kingdom           *CodeableConcept `bson:"kingdom,omitempty" json:"kingdom,omitempty"`
+	Phylum            *CodeableConcept `bson:"phylum,omitempty" json:"phylum,omitempty"`
+	Class             *CodeableConcept `bson:"class,omitempty" json:"class,omitempty"`
+	Order             *CodeableConcept `bson:"order,omitempty" json:"order,omitempty"`
 }
 type SubstanceSourceMaterialPartDescription struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Part              *CodeableConcept `json:"part,omitempty"`
-	PartLocation      *CodeableConcept `json:"partLocation,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Part              *CodeableConcept `bson:"part,omitempty" json:"part,omitempty"`
+	PartLocation      *CodeableConcept `bson:"partLocation,omitempty" json:"partLocation,omitempty"`
 }
 type OtherSubstanceSourceMaterial SubstanceSourceMaterial
 

--- a/fhir-models/fhir/substanceSpecification.go
+++ b/fhir-models/fhir/substanceSpecification.go
@@ -21,134 +21,134 @@ import "encoding/json"
 
 // SubstanceSpecification is documented here http://hl7.org/fhir/StructureDefinition/SubstanceSpecification
 type SubstanceSpecification struct {
-	Id                   *string                                                 `json:"id,omitempty"`
-	Meta                 *Meta                                                   `json:"meta,omitempty"`
-	ImplicitRules        *string                                                 `json:"implicitRules,omitempty"`
-	Language             *string                                                 `json:"language,omitempty"`
-	Text                 *Narrative                                              `json:"text,omitempty"`
-	Extension            []Extension                                             `json:"extension,omitempty"`
-	ModifierExtension    []Extension                                             `json:"modifierExtension,omitempty"`
-	Identifier           *Identifier                                             `json:"identifier,omitempty"`
-	Type                 *CodeableConcept                                        `json:"type,omitempty"`
-	Status               *CodeableConcept                                        `json:"status,omitempty"`
-	Domain               *CodeableConcept                                        `json:"domain,omitempty"`
-	Description          *string                                                 `json:"description,omitempty"`
-	Source               []Reference                                             `json:"source,omitempty"`
-	Comment              *string                                                 `json:"comment,omitempty"`
-	Moiety               []SubstanceSpecificationMoiety                          `json:"moiety,omitempty"`
-	Property             []SubstanceSpecificationProperty                        `json:"property,omitempty"`
-	ReferenceInformation *Reference                                              `json:"referenceInformation,omitempty"`
-	Structure            *SubstanceSpecificationStructure                        `json:"structure,omitempty"`
-	Code                 []SubstanceSpecificationCode                            `json:"code,omitempty"`
-	Name                 []SubstanceSpecificationName                            `json:"name,omitempty"`
-	MolecularWeight      []SubstanceSpecificationStructureIsotopeMolecularWeight `json:"molecularWeight,omitempty"`
-	Relationship         []SubstanceSpecificationRelationship                    `json:"relationship,omitempty"`
-	NucleicAcid          *Reference                                              `json:"nucleicAcid,omitempty"`
-	Polymer              *Reference                                              `json:"polymer,omitempty"`
-	Protein              *Reference                                              `json:"protein,omitempty"`
-	SourceMaterial       *Reference                                              `json:"sourceMaterial,omitempty"`
+	Id                   *string                                                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                 *Meta                                                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules        *string                                                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language             *string                                                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text                 *Narrative                                              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension            []Extension                                             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension                                             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier           *Identifier                                             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Type                 *CodeableConcept                                        `bson:"type,omitempty" json:"type,omitempty"`
+	Status               *CodeableConcept                                        `bson:"status,omitempty" json:"status,omitempty"`
+	Domain               *CodeableConcept                                        `bson:"domain,omitempty" json:"domain,omitempty"`
+	Description          *string                                                 `bson:"description,omitempty" json:"description,omitempty"`
+	Source               []Reference                                             `bson:"source,omitempty" json:"source,omitempty"`
+	Comment              *string                                                 `bson:"comment,omitempty" json:"comment,omitempty"`
+	Moiety               []SubstanceSpecificationMoiety                          `bson:"moiety,omitempty" json:"moiety,omitempty"`
+	Property             []SubstanceSpecificationProperty                        `bson:"property,omitempty" json:"property,omitempty"`
+	ReferenceInformation *Reference                                              `bson:"referenceInformation,omitempty" json:"referenceInformation,omitempty"`
+	Structure            *SubstanceSpecificationStructure                        `bson:"structure,omitempty" json:"structure,omitempty"`
+	Code                 []SubstanceSpecificationCode                            `bson:"code,omitempty" json:"code,omitempty"`
+	Name                 []SubstanceSpecificationName                            `bson:"name,omitempty" json:"name,omitempty"`
+	MolecularWeight      []SubstanceSpecificationStructureIsotopeMolecularWeight `bson:"molecularWeight,omitempty" json:"molecularWeight,omitempty"`
+	Relationship         []SubstanceSpecificationRelationship                    `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	NucleicAcid          *Reference                                              `bson:"nucleicAcid,omitempty" json:"nucleicAcid,omitempty"`
+	Polymer              *Reference                                              `bson:"polymer,omitempty" json:"polymer,omitempty"`
+	Protein              *Reference                                              `bson:"protein,omitempty" json:"protein,omitempty"`
+	SourceMaterial       *Reference                                              `bson:"sourceMaterial,omitempty" json:"sourceMaterial,omitempty"`
 }
 type SubstanceSpecificationMoiety struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Role              *CodeableConcept `json:"role,omitempty"`
-	Identifier        *Identifier      `json:"identifier,omitempty"`
-	Name              *string          `json:"name,omitempty"`
-	Stereochemistry   *CodeableConcept `json:"stereochemistry,omitempty"`
-	OpticalActivity   *CodeableConcept `json:"opticalActivity,omitempty"`
-	MolecularFormula  *string          `json:"molecularFormula,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Role              *CodeableConcept `bson:"role,omitempty" json:"role,omitempty"`
+	Identifier        *Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Name              *string          `bson:"name,omitempty" json:"name,omitempty"`
+	Stereochemistry   *CodeableConcept `bson:"stereochemistry,omitempty" json:"stereochemistry,omitempty"`
+	OpticalActivity   *CodeableConcept `bson:"opticalActivity,omitempty" json:"opticalActivity,omitempty"`
+	MolecularFormula  *string          `bson:"molecularFormula,omitempty" json:"molecularFormula,omitempty"`
 }
 type SubstanceSpecificationProperty struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Category          *CodeableConcept `json:"category,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Parameters        *string          `json:"parameters,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Category          *CodeableConcept `bson:"category,omitempty" json:"category,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Parameters        *string          `bson:"parameters,omitempty" json:"parameters,omitempty"`
 }
 type SubstanceSpecificationStructure struct {
-	Id                       *string                                                `json:"id,omitempty"`
-	Extension                []Extension                                            `json:"extension,omitempty"`
-	ModifierExtension        []Extension                                            `json:"modifierExtension,omitempty"`
-	Stereochemistry          *CodeableConcept                                       `json:"stereochemistry,omitempty"`
-	OpticalActivity          *CodeableConcept                                       `json:"opticalActivity,omitempty"`
-	MolecularFormula         *string                                                `json:"molecularFormula,omitempty"`
-	MolecularFormulaByMoiety *string                                                `json:"molecularFormulaByMoiety,omitempty"`
-	Isotope                  []SubstanceSpecificationStructureIsotope               `json:"isotope,omitempty"`
-	MolecularWeight          *SubstanceSpecificationStructureIsotopeMolecularWeight `json:"molecularWeight,omitempty"`
-	Source                   []Reference                                            `json:"source,omitempty"`
-	Representation           []SubstanceSpecificationStructureRepresentation        `json:"representation,omitempty"`
+	Id                       *string                                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                []Extension                                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension        []Extension                                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Stereochemistry          *CodeableConcept                                       `bson:"stereochemistry,omitempty" json:"stereochemistry,omitempty"`
+	OpticalActivity          *CodeableConcept                                       `bson:"opticalActivity,omitempty" json:"opticalActivity,omitempty"`
+	MolecularFormula         *string                                                `bson:"molecularFormula,omitempty" json:"molecularFormula,omitempty"`
+	MolecularFormulaByMoiety *string                                                `bson:"molecularFormulaByMoiety,omitempty" json:"molecularFormulaByMoiety,omitempty"`
+	Isotope                  []SubstanceSpecificationStructureIsotope               `bson:"isotope,omitempty" json:"isotope,omitempty"`
+	MolecularWeight          *SubstanceSpecificationStructureIsotopeMolecularWeight `bson:"molecularWeight,omitempty" json:"molecularWeight,omitempty"`
+	Source                   []Reference                                            `bson:"source,omitempty" json:"source,omitempty"`
+	Representation           []SubstanceSpecificationStructureRepresentation        `bson:"representation,omitempty" json:"representation,omitempty"`
 }
 type SubstanceSpecificationStructureIsotope struct {
-	Id                *string                                                `json:"id,omitempty"`
-	Extension         []Extension                                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                                            `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier                                            `json:"identifier,omitempty"`
-	Name              *CodeableConcept                                       `json:"name,omitempty"`
-	Substitution      *CodeableConcept                                       `json:"substitution,omitempty"`
-	HalfLife          *Quantity                                              `json:"halfLife,omitempty"`
-	MolecularWeight   *SubstanceSpecificationStructureIsotopeMolecularWeight `json:"molecularWeight,omitempty"`
+	Id                *string                                                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier                                            `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Name              *CodeableConcept                                       `bson:"name,omitempty" json:"name,omitempty"`
+	Substitution      *CodeableConcept                                       `bson:"substitution,omitempty" json:"substitution,omitempty"`
+	HalfLife          *Quantity                                              `bson:"halfLife,omitempty" json:"halfLife,omitempty"`
+	MolecularWeight   *SubstanceSpecificationStructureIsotopeMolecularWeight `bson:"molecularWeight,omitempty" json:"molecularWeight,omitempty"`
 }
 type SubstanceSpecificationStructureIsotopeMolecularWeight struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Method            *CodeableConcept `json:"method,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Amount            *Quantity        `json:"amount,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Method            *CodeableConcept `bson:"method,omitempty" json:"method,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Amount            *Quantity        `bson:"amount,omitempty" json:"amount,omitempty"`
 }
 type SubstanceSpecificationStructureRepresentation struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Type              *CodeableConcept `json:"type,omitempty"`
-	Representation    *string          `json:"representation,omitempty"`
-	Attachment        *Attachment      `json:"attachment,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	Representation    *string          `bson:"representation,omitempty" json:"representation,omitempty"`
+	Attachment        *Attachment      `bson:"attachment,omitempty" json:"attachment,omitempty"`
 }
 type SubstanceSpecificationCode struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
-	Status            *CodeableConcept `json:"status,omitempty"`
-	StatusDate        *string          `json:"statusDate,omitempty"`
-	Comment           *string          `json:"comment,omitempty"`
-	Source            []Reference      `json:"source,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
+	Status            *CodeableConcept `bson:"status,omitempty" json:"status,omitempty"`
+	StatusDate        *string          `bson:"statusDate,omitempty" json:"statusDate,omitempty"`
+	Comment           *string          `bson:"comment,omitempty" json:"comment,omitempty"`
+	Source            []Reference      `bson:"source,omitempty" json:"source,omitempty"`
 }
 type SubstanceSpecificationName struct {
-	Id                *string                              `json:"id,omitempty"`
-	Extension         []Extension                          `json:"extension,omitempty"`
-	ModifierExtension []Extension                          `json:"modifierExtension,omitempty"`
-	Name              string                               `json:"name"`
-	Type              *CodeableConcept                     `json:"type,omitempty"`
-	Status            *CodeableConcept                     `json:"status,omitempty"`
-	Preferred         *bool                                `json:"preferred,omitempty"`
-	Language          []CodeableConcept                    `json:"language,omitempty"`
-	Domain            []CodeableConcept                    `json:"domain,omitempty"`
-	Jurisdiction      []CodeableConcept                    `json:"jurisdiction,omitempty"`
-	Synonym           []SubstanceSpecificationName         `json:"synonym,omitempty"`
-	Translation       []SubstanceSpecificationName         `json:"translation,omitempty"`
-	Official          []SubstanceSpecificationNameOfficial `json:"official,omitempty"`
-	Source            []Reference                          `json:"source,omitempty"`
+	Id                *string                              `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                          `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                          `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string                               `bson:"name" json:"name"`
+	Type              *CodeableConcept                     `bson:"type,omitempty" json:"type,omitempty"`
+	Status            *CodeableConcept                     `bson:"status,omitempty" json:"status,omitempty"`
+	Preferred         *bool                                `bson:"preferred,omitempty" json:"preferred,omitempty"`
+	Language          []CodeableConcept                    `bson:"language,omitempty" json:"language,omitempty"`
+	Domain            []CodeableConcept                    `bson:"domain,omitempty" json:"domain,omitempty"`
+	Jurisdiction      []CodeableConcept                    `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Synonym           []SubstanceSpecificationName         `bson:"synonym,omitempty" json:"synonym,omitempty"`
+	Translation       []SubstanceSpecificationName         `bson:"translation,omitempty" json:"translation,omitempty"`
+	Official          []SubstanceSpecificationNameOfficial `bson:"official,omitempty" json:"official,omitempty"`
+	Source            []Reference                          `bson:"source,omitempty" json:"source,omitempty"`
 }
 type SubstanceSpecificationNameOfficial struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Authority         *CodeableConcept `json:"authority,omitempty"`
-	Status            *CodeableConcept `json:"status,omitempty"`
-	Date              *string          `json:"date,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Authority         *CodeableConcept `bson:"authority,omitempty" json:"authority,omitempty"`
+	Status            *CodeableConcept `bson:"status,omitempty" json:"status,omitempty"`
+	Date              *string          `bson:"date,omitempty" json:"date,omitempty"`
 }
 type SubstanceSpecificationRelationship struct {
-	Id                  *string          `json:"id,omitempty"`
-	Extension           []Extension      `json:"extension,omitempty"`
-	ModifierExtension   []Extension      `json:"modifierExtension,omitempty"`
-	Relationship        *CodeableConcept `json:"relationship,omitempty"`
-	IsDefining          *bool            `json:"isDefining,omitempty"`
-	AmountRatioLowLimit *Ratio           `json:"amountRatioLowLimit,omitempty"`
-	AmountType          *CodeableConcept `json:"amountType,omitempty"`
-	Source              []Reference      `json:"source,omitempty"`
+	Id                  *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Relationship        *CodeableConcept `bson:"relationship,omitempty" json:"relationship,omitempty"`
+	IsDefining          *bool            `bson:"isDefining,omitempty" json:"isDefining,omitempty"`
+	AmountRatioLowLimit *Ratio           `bson:"amountRatioLowLimit,omitempty" json:"amountRatioLowLimit,omitempty"`
+	AmountType          *CodeableConcept `bson:"amountType,omitempty" json:"amountType,omitempty"`
+	Source              []Reference      `bson:"source,omitempty" json:"source,omitempty"`
 }
 type OtherSubstanceSpecification SubstanceSpecification
 

--- a/fhir-models/fhir/supplyDelivery.go
+++ b/fhir-models/fhir/supplyDelivery.go
@@ -21,29 +21,29 @@ import "encoding/json"
 
 // SupplyDelivery is documented here http://hl7.org/fhir/StructureDefinition/SupplyDelivery
 type SupplyDelivery struct {
-	Id                *string                     `json:"id,omitempty"`
-	Meta              *Meta                       `json:"meta,omitempty"`
-	ImplicitRules     *string                     `json:"implicitRules,omitempty"`
-	Language          *string                     `json:"language,omitempty"`
-	Text              *Narrative                  `json:"text,omitempty"`
-	Extension         []Extension                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                 `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                `json:"identifier,omitempty"`
-	BasedOn           []Reference                 `json:"basedOn,omitempty"`
-	PartOf            []Reference                 `json:"partOf,omitempty"`
-	Status            *SupplyDeliveryStatus       `json:"status,omitempty"`
-	Patient           *Reference                  `json:"patient,omitempty"`
-	Type              *CodeableConcept            `json:"type,omitempty"`
-	SuppliedItem      *SupplyDeliverySuppliedItem `json:"suppliedItem,omitempty"`
-	Supplier          *Reference                  `json:"supplier,omitempty"`
-	Destination       *Reference                  `json:"destination,omitempty"`
-	Receiver          []Reference                 `json:"receiver,omitempty"`
+	Id                *string                     `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                       `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                     `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                     `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                  `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	BasedOn           []Reference                 `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	PartOf            []Reference                 `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status            *SupplyDeliveryStatus       `bson:"status,omitempty" json:"status,omitempty"`
+	Patient           *Reference                  `bson:"patient,omitempty" json:"patient,omitempty"`
+	Type              *CodeableConcept            `bson:"type,omitempty" json:"type,omitempty"`
+	SuppliedItem      *SupplyDeliverySuppliedItem `bson:"suppliedItem,omitempty" json:"suppliedItem,omitempty"`
+	Supplier          *Reference                  `bson:"supplier,omitempty" json:"supplier,omitempty"`
+	Destination       *Reference                  `bson:"destination,omitempty" json:"destination,omitempty"`
+	Receiver          []Reference                 `bson:"receiver,omitempty" json:"receiver,omitempty"`
 }
 type SupplyDeliverySuppliedItem struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Quantity          *Quantity   `json:"quantity,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Quantity          *Quantity   `bson:"quantity,omitempty" json:"quantity,omitempty"`
 }
 type OtherSupplyDelivery SupplyDelivery
 

--- a/fhir-models/fhir/supplyRequest.go
+++ b/fhir-models/fhir/supplyRequest.go
@@ -21,32 +21,32 @@ import "encoding/json"
 
 // SupplyRequest is documented here http://hl7.org/fhir/StructureDefinition/SupplyRequest
 type SupplyRequest struct {
-	Id                *string                  `json:"id,omitempty"`
-	Meta              *Meta                    `json:"meta,omitempty"`
-	ImplicitRules     *string                  `json:"implicitRules,omitempty"`
-	Language          *string                  `json:"language,omitempty"`
-	Text              *Narrative               `json:"text,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier             `json:"identifier,omitempty"`
-	Status            *SupplyRequestStatus     `json:"status,omitempty"`
-	Category          *CodeableConcept         `json:"category,omitempty"`
-	Priority          *RequestPriority         `json:"priority,omitempty"`
-	Quantity          Quantity                 `json:"quantity"`
-	Parameter         []SupplyRequestParameter `json:"parameter,omitempty"`
-	AuthoredOn        *string                  `json:"authoredOn,omitempty"`
-	Requester         *Reference               `json:"requester,omitempty"`
-	Supplier          []Reference              `json:"supplier,omitempty"`
-	ReasonCode        []CodeableConcept        `json:"reasonCode,omitempty"`
-	ReasonReference   []Reference              `json:"reasonReference,omitempty"`
-	DeliverFrom       *Reference               `json:"deliverFrom,omitempty"`
-	DeliverTo         *Reference               `json:"deliverTo,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                    `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                  `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                  `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative               `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            *SupplyRequestStatus     `bson:"status,omitempty" json:"status,omitempty"`
+	Category          *CodeableConcept         `bson:"category,omitempty" json:"category,omitempty"`
+	Priority          *RequestPriority         `bson:"priority,omitempty" json:"priority,omitempty"`
+	Quantity          Quantity                 `bson:"quantity" json:"quantity"`
+	Parameter         []SupplyRequestParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	AuthoredOn        *string                  `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	Requester         *Reference               `bson:"requester,omitempty" json:"requester,omitempty"`
+	Supplier          []Reference              `bson:"supplier,omitempty" json:"supplier,omitempty"`
+	ReasonCode        []CodeableConcept        `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference   []Reference              `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	DeliverFrom       *Reference               `bson:"deliverFrom,omitempty" json:"deliverFrom,omitempty"`
+	DeliverTo         *Reference               `bson:"deliverTo,omitempty" json:"deliverTo,omitempty"`
 }
 type SupplyRequestParameter struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 }
 type OtherSupplyRequest SupplyRequest
 

--- a/fhir-models/fhir/task.go
+++ b/fhir-models/fhir/task.go
@@ -21,64 +21,64 @@ import "encoding/json"
 
 // Task is documented here http://hl7.org/fhir/StructureDefinition/Task
 type Task struct {
-	Id                    *string           `json:"id,omitempty"`
-	Meta                  *Meta             `json:"meta,omitempty"`
-	ImplicitRules         *string           `json:"implicitRules,omitempty"`
-	Language              *string           `json:"language,omitempty"`
-	Text                  *Narrative        `json:"text,omitempty"`
-	Extension             []Extension       `json:"extension,omitempty"`
-	ModifierExtension     []Extension       `json:"modifierExtension,omitempty"`
-	Identifier            []Identifier      `json:"identifier,omitempty"`
-	InstantiatesCanonical *string           `json:"instantiatesCanonical,omitempty"`
-	InstantiatesUri       *string           `json:"instantiatesUri,omitempty"`
-	BasedOn               []Reference       `json:"basedOn,omitempty"`
-	GroupIdentifier       *Identifier       `json:"groupIdentifier,omitempty"`
-	PartOf                []Reference       `json:"partOf,omitempty"`
-	Status                TaskStatus        `json:"status"`
-	StatusReason          *CodeableConcept  `json:"statusReason,omitempty"`
-	BusinessStatus        *CodeableConcept  `json:"businessStatus,omitempty"`
-	Intent                string            `json:"intent"`
-	Priority              *RequestPriority  `json:"priority,omitempty"`
-	Code                  *CodeableConcept  `json:"code,omitempty"`
-	Description           *string           `json:"description,omitempty"`
-	Focus                 *Reference        `json:"focus,omitempty"`
-	For                   *Reference        `json:"for,omitempty"`
-	Encounter             *Reference        `json:"encounter,omitempty"`
-	ExecutionPeriod       *Period           `json:"executionPeriod,omitempty"`
-	AuthoredOn            *string           `json:"authoredOn,omitempty"`
-	LastModified          *string           `json:"lastModified,omitempty"`
-	Requester             *Reference        `json:"requester,omitempty"`
-	PerformerType         []CodeableConcept `json:"performerType,omitempty"`
-	Owner                 *Reference        `json:"owner,omitempty"`
-	Location              *Reference        `json:"location,omitempty"`
-	ReasonCode            *CodeableConcept  `json:"reasonCode,omitempty"`
-	ReasonReference       *Reference        `json:"reasonReference,omitempty"`
-	Insurance             []Reference       `json:"insurance,omitempty"`
-	Note                  []Annotation      `json:"note,omitempty"`
-	RelevantHistory       []Reference       `json:"relevantHistory,omitempty"`
-	Restriction           *TaskRestriction  `json:"restriction,omitempty"`
-	Input                 []TaskInput       `json:"input,omitempty"`
-	Output                []TaskOutput      `json:"output,omitempty"`
+	Id                    *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta                  *Meta             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules         *string           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language              *string           `bson:"language,omitempty" json:"language,omitempty"`
+	Text                  *Narrative        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension             []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension     []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier            []Identifier      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	InstantiatesCanonical *string           `bson:"instantiatesCanonical,omitempty" json:"instantiatesCanonical,omitempty"`
+	InstantiatesUri       *string           `bson:"instantiatesUri,omitempty" json:"instantiatesUri,omitempty"`
+	BasedOn               []Reference       `bson:"basedOn,omitempty" json:"basedOn,omitempty"`
+	GroupIdentifier       *Identifier       `bson:"groupIdentifier,omitempty" json:"groupIdentifier,omitempty"`
+	PartOf                []Reference       `bson:"partOf,omitempty" json:"partOf,omitempty"`
+	Status                TaskStatus        `bson:"status" json:"status"`
+	StatusReason          *CodeableConcept  `bson:"statusReason,omitempty" json:"statusReason,omitempty"`
+	BusinessStatus        *CodeableConcept  `bson:"businessStatus,omitempty" json:"businessStatus,omitempty"`
+	Intent                string            `bson:"intent" json:"intent"`
+	Priority              *RequestPriority  `bson:"priority,omitempty" json:"priority,omitempty"`
+	Code                  *CodeableConcept  `bson:"code,omitempty" json:"code,omitempty"`
+	Description           *string           `bson:"description,omitempty" json:"description,omitempty"`
+	Focus                 *Reference        `bson:"focus,omitempty" json:"focus,omitempty"`
+	For                   *Reference        `bson:"for,omitempty" json:"for,omitempty"`
+	Encounter             *Reference        `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	ExecutionPeriod       *Period           `bson:"executionPeriod,omitempty" json:"executionPeriod,omitempty"`
+	AuthoredOn            *string           `bson:"authoredOn,omitempty" json:"authoredOn,omitempty"`
+	LastModified          *string           `bson:"lastModified,omitempty" json:"lastModified,omitempty"`
+	Requester             *Reference        `bson:"requester,omitempty" json:"requester,omitempty"`
+	PerformerType         []CodeableConcept `bson:"performerType,omitempty" json:"performerType,omitempty"`
+	Owner                 *Reference        `bson:"owner,omitempty" json:"owner,omitempty"`
+	Location              *Reference        `bson:"location,omitempty" json:"location,omitempty"`
+	ReasonCode            *CodeableConcept  `bson:"reasonCode,omitempty" json:"reasonCode,omitempty"`
+	ReasonReference       *Reference        `bson:"reasonReference,omitempty" json:"reasonReference,omitempty"`
+	Insurance             []Reference       `bson:"insurance,omitempty" json:"insurance,omitempty"`
+	Note                  []Annotation      `bson:"note,omitempty" json:"note,omitempty"`
+	RelevantHistory       []Reference       `bson:"relevantHistory,omitempty" json:"relevantHistory,omitempty"`
+	Restriction           *TaskRestriction  `bson:"restriction,omitempty" json:"restriction,omitempty"`
+	Input                 []TaskInput       `bson:"input,omitempty" json:"input,omitempty"`
+	Output                []TaskOutput      `bson:"output,omitempty" json:"output,omitempty"`
 }
 type TaskRestriction struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Repetitions       *int        `json:"repetitions,omitempty"`
-	Period            *Period     `json:"period,omitempty"`
-	Recipient         []Reference `json:"recipient,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Repetitions       *int        `bson:"repetitions,omitempty" json:"repetitions,omitempty"`
+	Period            *Period     `bson:"period,omitempty" json:"period,omitempty"`
+	Recipient         []Reference `bson:"recipient,omitempty" json:"recipient,omitempty"`
 }
 type TaskInput struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
 }
 type TaskOutput struct {
-	Id                *string         `json:"id,omitempty"`
-	Extension         []Extension     `json:"extension,omitempty"`
-	ModifierExtension []Extension     `json:"modifierExtension,omitempty"`
-	Type              CodeableConcept `json:"type"`
+	Id                *string         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              CodeableConcept `bson:"type" json:"type"`
 }
 type OtherTask Task
 

--- a/fhir-models/fhir/terminologyCapabilities.go
+++ b/fhir-models/fhir/terminologyCapabilities.go
@@ -21,112 +21,112 @@ import "encoding/json"
 
 // TerminologyCapabilities is documented here http://hl7.org/fhir/StructureDefinition/TerminologyCapabilities
 type TerminologyCapabilities struct {
-	Id                *string                                `json:"id,omitempty"`
-	Meta              *Meta                                  `json:"meta,omitempty"`
-	ImplicitRules     *string                                `json:"implicitRules,omitempty"`
-	Language          *string                                `json:"language,omitempty"`
-	Text              *Narrative                             `json:"text,omitempty"`
-	Extension         []Extension                            `json:"extension,omitempty"`
-	ModifierExtension []Extension                            `json:"modifierExtension,omitempty"`
-	Url               *string                                `json:"url,omitempty"`
-	Version           *string                                `json:"version,omitempty"`
-	Name              *string                                `json:"name,omitempty"`
-	Title             *string                                `json:"title,omitempty"`
-	Status            PublicationStatus                      `json:"status"`
-	Experimental      *bool                                  `json:"experimental,omitempty"`
-	Date              string                                 `json:"date"`
-	Publisher         *string                                `json:"publisher,omitempty"`
-	Contact           []ContactDetail                        `json:"contact,omitempty"`
-	Description       *string                                `json:"description,omitempty"`
-	UseContext        []UsageContext                         `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept                      `json:"jurisdiction,omitempty"`
-	Purpose           *string                                `json:"purpose,omitempty"`
-	Copyright         *string                                `json:"copyright,omitempty"`
-	Kind              CapabilityStatementKind                `json:"kind"`
-	Software          *TerminologyCapabilitiesSoftware       `json:"software,omitempty"`
-	Implementation    *TerminologyCapabilitiesImplementation `json:"implementation,omitempty"`
-	LockedDate        *bool                                  `json:"lockedDate,omitempty"`
-	CodeSystem        []TerminologyCapabilitiesCodeSystem    `json:"codeSystem,omitempty"`
-	Expansion         *TerminologyCapabilitiesExpansion      `json:"expansion,omitempty"`
-	CodeSearch        *CodeSearchSupport                     `json:"codeSearch,omitempty"`
-	ValidateCode      *TerminologyCapabilitiesValidateCode   `json:"validateCode,omitempty"`
-	Translation       *TerminologyCapabilitiesTranslation    `json:"translation,omitempty"`
-	Closure           *TerminologyCapabilitiesClosure        `json:"closure,omitempty"`
+	Id                *string                                `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                  `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                                `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                                `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                             `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string                                `bson:"url,omitempty" json:"url,omitempty"`
+	Version           *string                                `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string                                `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string                                `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus                      `bson:"status" json:"status"`
+	Experimental      *bool                                  `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              string                                 `bson:"date" json:"date"`
+	Publisher         *string                                `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail                        `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                                `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext                         `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept                      `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                                `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                                `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Kind              CapabilityStatementKind                `bson:"kind" json:"kind"`
+	Software          *TerminologyCapabilitiesSoftware       `bson:"software,omitempty" json:"software,omitempty"`
+	Implementation    *TerminologyCapabilitiesImplementation `bson:"implementation,omitempty" json:"implementation,omitempty"`
+	LockedDate        *bool                                  `bson:"lockedDate,omitempty" json:"lockedDate,omitempty"`
+	CodeSystem        []TerminologyCapabilitiesCodeSystem    `bson:"codeSystem,omitempty" json:"codeSystem,omitempty"`
+	Expansion         *TerminologyCapabilitiesExpansion      `bson:"expansion,omitempty" json:"expansion,omitempty"`
+	CodeSearch        *CodeSearchSupport                     `bson:"codeSearch,omitempty" json:"codeSearch,omitempty"`
+	ValidateCode      *TerminologyCapabilitiesValidateCode   `bson:"validateCode,omitempty" json:"validateCode,omitempty"`
+	Translation       *TerminologyCapabilitiesTranslation    `bson:"translation,omitempty" json:"translation,omitempty"`
+	Closure           *TerminologyCapabilitiesClosure        `bson:"closure,omitempty" json:"closure,omitempty"`
 }
 type TerminologyCapabilitiesSoftware struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Version           *string     `json:"version,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Version           *string     `bson:"version,omitempty" json:"version,omitempty"`
 }
 type TerminologyCapabilitiesImplementation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Description       string      `json:"description"`
-	Url               *string     `json:"url,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Description       string      `bson:"description" json:"description"`
+	Url               *string     `bson:"url,omitempty" json:"url,omitempty"`
 }
 type TerminologyCapabilitiesCodeSystem struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Uri               *string                                    `json:"uri,omitempty"`
-	Version           []TerminologyCapabilitiesCodeSystemVersion `json:"version,omitempty"`
-	Subsumption       *bool                                      `json:"subsumption,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Uri               *string                                    `bson:"uri,omitempty" json:"uri,omitempty"`
+	Version           []TerminologyCapabilitiesCodeSystemVersion `bson:"version,omitempty" json:"version,omitempty"`
+	Subsumption       *bool                                      `bson:"subsumption,omitempty" json:"subsumption,omitempty"`
 }
 type TerminologyCapabilitiesCodeSystemVersion struct {
-	Id                *string                                          `json:"id,omitempty"`
-	Extension         []Extension                                      `json:"extension,omitempty"`
-	ModifierExtension []Extension                                      `json:"modifierExtension,omitempty"`
-	Code              *string                                          `json:"code,omitempty"`
-	IsDefault         *bool                                            `json:"isDefault,omitempty"`
-	Compositional     *bool                                            `json:"compositional,omitempty"`
-	Language          []string                                         `json:"language,omitempty"`
-	Filter            []TerminologyCapabilitiesCodeSystemVersionFilter `json:"filter,omitempty"`
-	Property          []string                                         `json:"property,omitempty"`
+	Id                *string                                          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              *string                                          `bson:"code,omitempty" json:"code,omitempty"`
+	IsDefault         *bool                                            `bson:"isDefault,omitempty" json:"isDefault,omitempty"`
+	Compositional     *bool                                            `bson:"compositional,omitempty" json:"compositional,omitempty"`
+	Language          []string                                         `bson:"language,omitempty" json:"language,omitempty"`
+	Filter            []TerminologyCapabilitiesCodeSystemVersionFilter `bson:"filter,omitempty" json:"filter,omitempty"`
+	Property          []string                                         `bson:"property,omitempty" json:"property,omitempty"`
 }
 type TerminologyCapabilitiesCodeSystemVersionFilter struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Code              string      `json:"code"`
-	Op                []string    `json:"op"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string      `bson:"code" json:"code"`
+	Op                []string    `bson:"op" json:"op"`
 }
 type TerminologyCapabilitiesExpansion struct {
-	Id                *string                                     `json:"id,omitempty"`
-	Extension         []Extension                                 `json:"extension,omitempty"`
-	ModifierExtension []Extension                                 `json:"modifierExtension,omitempty"`
-	Hierarchical      *bool                                       `json:"hierarchical,omitempty"`
-	Paging            *bool                                       `json:"paging,omitempty"`
-	Incomplete        *bool                                       `json:"incomplete,omitempty"`
-	Parameter         []TerminologyCapabilitiesExpansionParameter `json:"parameter,omitempty"`
-	TextFilter        *string                                     `json:"textFilter,omitempty"`
+	Id                *string                                     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                 `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                 `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Hierarchical      *bool                                       `bson:"hierarchical,omitempty" json:"hierarchical,omitempty"`
+	Paging            *bool                                       `bson:"paging,omitempty" json:"paging,omitempty"`
+	Incomplete        *bool                                       `bson:"incomplete,omitempty" json:"incomplete,omitempty"`
+	Parameter         []TerminologyCapabilitiesExpansionParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	TextFilter        *string                                     `bson:"textFilter,omitempty" json:"textFilter,omitempty"`
 }
 type TerminologyCapabilitiesExpansionParameter struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	Documentation     *string     `json:"documentation,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	Documentation     *string     `bson:"documentation,omitempty" json:"documentation,omitempty"`
 }
 type TerminologyCapabilitiesValidateCode struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Translations      bool        `json:"translations"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Translations      bool        `bson:"translations" json:"translations"`
 }
 type TerminologyCapabilitiesTranslation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	NeedsMap          bool        `json:"needsMap"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	NeedsMap          bool        `bson:"needsMap" json:"needsMap"`
 }
 type TerminologyCapabilitiesClosure struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Translation       *bool       `json:"translation,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Translation       *bool       `bson:"translation,omitempty" json:"translation,omitempty"`
 }
 type OtherTerminologyCapabilities TerminologyCapabilities
 

--- a/fhir-models/fhir/testReport.go
+++ b/fhir-models/fhir/testReport.go
@@ -21,89 +21,89 @@ import "encoding/json"
 
 // TestReport is documented here http://hl7.org/fhir/StructureDefinition/TestReport
 type TestReport struct {
-	Id                *string                 `json:"id,omitempty"`
-	Meta              *Meta                   `json:"meta,omitempty"`
-	ImplicitRules     *string                 `json:"implicitRules,omitempty"`
-	Language          *string                 `json:"language,omitempty"`
-	Text              *Narrative              `json:"text,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Identifier        *Identifier             `json:"identifier,omitempty"`
-	Name              *string                 `json:"name,omitempty"`
-	Status            TestReportStatus        `json:"status"`
-	TestScript        Reference               `json:"testScript"`
-	Result            TestReportResult        `json:"result"`
-	Score             *string                 `json:"score,omitempty"`
-	Tester            *string                 `json:"tester,omitempty"`
-	Issued            *string                 `json:"issued,omitempty"`
-	Participant       []TestReportParticipant `json:"participant,omitempty"`
-	Setup             *TestReportSetup        `json:"setup,omitempty"`
-	Test              []TestReportTest        `json:"test,omitempty"`
-	Teardown          *TestReportTeardown     `json:"teardown,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Name              *string                 `bson:"name,omitempty" json:"name,omitempty"`
+	Status            TestReportStatus        `bson:"status" json:"status"`
+	TestScript        Reference               `bson:"testScript" json:"testScript"`
+	Result            TestReportResult        `bson:"result" json:"result"`
+	Score             *string                 `bson:"score,omitempty" json:"score,omitempty"`
+	Tester            *string                 `bson:"tester,omitempty" json:"tester,omitempty"`
+	Issued            *string                 `bson:"issued,omitempty" json:"issued,omitempty"`
+	Participant       []TestReportParticipant `bson:"participant,omitempty" json:"participant,omitempty"`
+	Setup             *TestReportSetup        `bson:"setup,omitempty" json:"setup,omitempty"`
+	Test              []TestReportTest        `bson:"test,omitempty" json:"test,omitempty"`
+	Teardown          *TestReportTeardown     `bson:"teardown,omitempty" json:"teardown,omitempty"`
 }
 type TestReportParticipant struct {
-	Id                *string                   `json:"id,omitempty"`
-	Extension         []Extension               `json:"extension,omitempty"`
-	ModifierExtension []Extension               `json:"modifierExtension,omitempty"`
-	Type              TestReportParticipantType `json:"type"`
-	Uri               string                    `json:"uri"`
-	Display           *string                   `json:"display,omitempty"`
+	Id                *string                   `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension               `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension               `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              TestReportParticipantType `bson:"type" json:"type"`
+	Uri               string                    `bson:"uri" json:"uri"`
+	Display           *string                   `bson:"display,omitempty" json:"display,omitempty"`
 }
 type TestReportSetup struct {
-	Id                *string                 `json:"id,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Action            []TestReportSetupAction `json:"action"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Action            []TestReportSetupAction `bson:"action" json:"action"`
 }
 type TestReportSetupAction struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Operation         *TestReportSetupActionOperation `json:"operation,omitempty"`
-	Assert            *TestReportSetupActionAssert    `json:"assert,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Operation         *TestReportSetupActionOperation `bson:"operation,omitempty" json:"operation,omitempty"`
+	Assert            *TestReportSetupActionAssert    `bson:"assert,omitempty" json:"assert,omitempty"`
 }
 type TestReportSetupActionOperation struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Result            TestReportActionResult `json:"result"`
-	Message           *string                `json:"message,omitempty"`
-	Detail            *string                `json:"detail,omitempty"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Result            TestReportActionResult `bson:"result" json:"result"`
+	Message           *string                `bson:"message,omitempty" json:"message,omitempty"`
+	Detail            *string                `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type TestReportSetupActionAssert struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Result            TestReportActionResult `json:"result"`
-	Message           *string                `json:"message,omitempty"`
-	Detail            *string                `json:"detail,omitempty"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Result            TestReportActionResult `bson:"result" json:"result"`
+	Message           *string                `bson:"message,omitempty" json:"message,omitempty"`
+	Detail            *string                `bson:"detail,omitempty" json:"detail,omitempty"`
 }
 type TestReportTest struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Name              *string                `json:"name,omitempty"`
-	Description       *string                `json:"description,omitempty"`
-	Action            []TestReportTestAction `json:"action"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              *string                `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string                `bson:"description,omitempty" json:"description,omitempty"`
+	Action            []TestReportTestAction `bson:"action" json:"action"`
 }
 type TestReportTestAction struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Operation         *TestReportSetupActionOperation `json:"operation,omitempty"`
-	Assert            *TestReportSetupActionAssert    `json:"assert,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Operation         *TestReportSetupActionOperation `bson:"operation,omitempty" json:"operation,omitempty"`
+	Assert            *TestReportSetupActionAssert    `bson:"assert,omitempty" json:"assert,omitempty"`
 }
 type TestReportTeardown struct {
-	Id                *string                    `json:"id,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Action            []TestReportTeardownAction `json:"action"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Action            []TestReportTeardownAction `bson:"action" json:"action"`
 }
 type TestReportTeardownAction struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Operation         TestReportSetupActionOperation `json:"operation,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Operation         TestReportSetupActionOperation `bson:"operation,omitempty" json:"operation,omitempty"`
 }
 type OtherTestReport TestReport
 

--- a/fhir-models/fhir/testScript.go
+++ b/fhir-models/fhir/testScript.go
@@ -21,194 +21,194 @@ import "encoding/json"
 
 // TestScript is documented here http://hl7.org/fhir/StructureDefinition/TestScript
 type TestScript struct {
-	Id                *string                 `json:"id,omitempty"`
-	Meta              *Meta                   `json:"meta,omitempty"`
-	ImplicitRules     *string                 `json:"implicitRules,omitempty"`
-	Language          *string                 `json:"language,omitempty"`
-	Text              *Narrative              `json:"text,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Url               string                  `json:"url"`
-	Identifier        *Identifier             `json:"identifier,omitempty"`
-	Version           *string                 `json:"version,omitempty"`
-	Name              string                  `json:"name"`
-	Title             *string                 `json:"title,omitempty"`
-	Status            PublicationStatus       `json:"status"`
-	Experimental      *bool                   `json:"experimental,omitempty"`
-	Date              *string                 `json:"date,omitempty"`
-	Publisher         *string                 `json:"publisher,omitempty"`
-	Contact           []ContactDetail         `json:"contact,omitempty"`
-	Description       *string                 `json:"description,omitempty"`
-	UseContext        []UsageContext          `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept       `json:"jurisdiction,omitempty"`
-	Purpose           *string                 `json:"purpose,omitempty"`
-	Copyright         *string                 `json:"copyright,omitempty"`
-	Origin            []TestScriptOrigin      `json:"origin,omitempty"`
-	Destination       []TestScriptDestination `json:"destination,omitempty"`
-	Metadata          *TestScriptMetadata     `json:"metadata,omitempty"`
-	Fixture           []TestScriptFixture     `json:"fixture,omitempty"`
-	Profile           []Reference             `json:"profile,omitempty"`
-	Variable          []TestScriptVariable    `json:"variable,omitempty"`
-	Setup             *TestScriptSetup        `json:"setup,omitempty"`
-	Test              []TestScriptTest        `json:"test,omitempty"`
-	Teardown          *TestScriptTeardown     `json:"teardown,omitempty"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                   `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                 `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                 `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative              `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string                  `bson:"url" json:"url"`
+	Identifier        *Identifier             `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string                 `bson:"version,omitempty" json:"version,omitempty"`
+	Name              string                  `bson:"name" json:"name"`
+	Title             *string                 `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus       `bson:"status" json:"status"`
+	Experimental      *bool                   `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string                 `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string                 `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail         `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string                 `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext          `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept       `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Purpose           *string                 `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string                 `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Origin            []TestScriptOrigin      `bson:"origin,omitempty" json:"origin,omitempty"`
+	Destination       []TestScriptDestination `bson:"destination,omitempty" json:"destination,omitempty"`
+	Metadata          *TestScriptMetadata     `bson:"metadata,omitempty" json:"metadata,omitempty"`
+	Fixture           []TestScriptFixture     `bson:"fixture,omitempty" json:"fixture,omitempty"`
+	Profile           []Reference             `bson:"profile,omitempty" json:"profile,omitempty"`
+	Variable          []TestScriptVariable    `bson:"variable,omitempty" json:"variable,omitempty"`
+	Setup             *TestScriptSetup        `bson:"setup,omitempty" json:"setup,omitempty"`
+	Test              []TestScriptTest        `bson:"test,omitempty" json:"test,omitempty"`
+	Teardown          *TestScriptTeardown     `bson:"teardown,omitempty" json:"teardown,omitempty"`
 }
 type TestScriptOrigin struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Index             int         `json:"index"`
-	Profile           Coding      `json:"profile"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Index             int         `bson:"index" json:"index"`
+	Profile           Coding      `bson:"profile" json:"profile"`
 }
 type TestScriptDestination struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Index             int         `json:"index"`
-	Profile           Coding      `json:"profile"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Index             int         `bson:"index" json:"index"`
+	Profile           Coding      `bson:"profile" json:"profile"`
 }
 type TestScriptMetadata struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Link              []TestScriptMetadataLink       `json:"link,omitempty"`
-	Capability        []TestScriptMetadataCapability `json:"capability"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Link              []TestScriptMetadataLink       `bson:"link,omitempty" json:"link,omitempty"`
+	Capability        []TestScriptMetadataCapability `bson:"capability" json:"capability"`
 }
 type TestScriptMetadataLink struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Url               string      `json:"url"`
-	Description       *string     `json:"description,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               string      `bson:"url" json:"url"`
+	Description       *string     `bson:"description,omitempty" json:"description,omitempty"`
 }
 type TestScriptMetadataCapability struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Required          bool        `json:"required"`
-	Validated         bool        `json:"validated"`
-	Description       *string     `json:"description,omitempty"`
-	Origin            []int       `json:"origin,omitempty"`
-	Destination       *int        `json:"destination,omitempty"`
-	Link              []string    `json:"link,omitempty"`
-	Capabilities      string      `json:"capabilities"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Required          bool        `bson:"required" json:"required"`
+	Validated         bool        `bson:"validated" json:"validated"`
+	Description       *string     `bson:"description,omitempty" json:"description,omitempty"`
+	Origin            []int       `bson:"origin,omitempty" json:"origin,omitempty"`
+	Destination       *int        `bson:"destination,omitempty" json:"destination,omitempty"`
+	Link              []string    `bson:"link,omitempty" json:"link,omitempty"`
+	Capabilities      string      `bson:"capabilities" json:"capabilities"`
 }
 type TestScriptFixture struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Autocreate        bool        `json:"autocreate"`
-	Autodelete        bool        `json:"autodelete"`
-	Resource          *Reference  `json:"resource,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Autocreate        bool        `bson:"autocreate" json:"autocreate"`
+	Autodelete        bool        `bson:"autodelete" json:"autodelete"`
+	Resource          *Reference  `bson:"resource,omitempty" json:"resource,omitempty"`
 }
 type TestScriptVariable struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
-	DefaultValue      *string     `json:"defaultValue,omitempty"`
-	Description       *string     `json:"description,omitempty"`
-	Expression        *string     `json:"expression,omitempty"`
-	HeaderField       *string     `json:"headerField,omitempty"`
-	Hint              *string     `json:"hint,omitempty"`
-	Path              *string     `json:"path,omitempty"`
-	SourceId          *string     `json:"sourceId,omitempty"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
+	DefaultValue      *string     `bson:"defaultValue,omitempty" json:"defaultValue,omitempty"`
+	Description       *string     `bson:"description,omitempty" json:"description,omitempty"`
+	Expression        *string     `bson:"expression,omitempty" json:"expression,omitempty"`
+	HeaderField       *string     `bson:"headerField,omitempty" json:"headerField,omitempty"`
+	Hint              *string     `bson:"hint,omitempty" json:"hint,omitempty"`
+	Path              *string     `bson:"path,omitempty" json:"path,omitempty"`
+	SourceId          *string     `bson:"sourceId,omitempty" json:"sourceId,omitempty"`
 }
 type TestScriptSetup struct {
-	Id                *string                 `json:"id,omitempty"`
-	Extension         []Extension             `json:"extension,omitempty"`
-	ModifierExtension []Extension             `json:"modifierExtension,omitempty"`
-	Action            []TestScriptSetupAction `json:"action"`
+	Id                *string                 `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension             `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension             `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Action            []TestScriptSetupAction `bson:"action" json:"action"`
 }
 type TestScriptSetupAction struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Operation         *TestScriptSetupActionOperation `json:"operation,omitempty"`
-	Assert            *TestScriptSetupActionAssert    `json:"assert,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Operation         *TestScriptSetupActionOperation `bson:"operation,omitempty" json:"operation,omitempty"`
+	Assert            *TestScriptSetupActionAssert    `bson:"assert,omitempty" json:"assert,omitempty"`
 }
 type TestScriptSetupActionOperation struct {
-	Id                *string                                       `json:"id,omitempty"`
-	Extension         []Extension                                   `json:"extension,omitempty"`
-	ModifierExtension []Extension                                   `json:"modifierExtension,omitempty"`
-	Type              *Coding                                       `json:"type,omitempty"`
-	Resource          *string                                       `json:"resource,omitempty"`
-	Label             *string                                       `json:"label,omitempty"`
-	Description       *string                                       `json:"description,omitempty"`
-	Accept            *string                                       `json:"accept,omitempty"`
-	ContentType       *string                                       `json:"contentType,omitempty"`
-	Destination       *int                                          `json:"destination,omitempty"`
-	EncodeRequestUrl  bool                                          `json:"encodeRequestUrl"`
-	Method            *TestScriptRequestMethodCode                  `json:"method,omitempty"`
-	Origin            *int                                          `json:"origin,omitempty"`
-	Params            *string                                       `json:"params,omitempty"`
-	RequestHeader     []TestScriptSetupActionOperationRequestHeader `json:"requestHeader,omitempty"`
-	RequestId         *string                                       `json:"requestId,omitempty"`
-	ResponseId        *string                                       `json:"responseId,omitempty"`
-	SourceId          *string                                       `json:"sourceId,omitempty"`
-	TargetId          *string                                       `json:"targetId,omitempty"`
-	Url               *string                                       `json:"url,omitempty"`
+	Id                *string                                       `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                   `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                   `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Type              *Coding                                       `bson:"type,omitempty" json:"type,omitempty"`
+	Resource          *string                                       `bson:"resource,omitempty" json:"resource,omitempty"`
+	Label             *string                                       `bson:"label,omitempty" json:"label,omitempty"`
+	Description       *string                                       `bson:"description,omitempty" json:"description,omitempty"`
+	Accept            *string                                       `bson:"accept,omitempty" json:"accept,omitempty"`
+	ContentType       *string                                       `bson:"contentType,omitempty" json:"contentType,omitempty"`
+	Destination       *int                                          `bson:"destination,omitempty" json:"destination,omitempty"`
+	EncodeRequestUrl  bool                                          `bson:"encodeRequestUrl" json:"encodeRequestUrl"`
+	Method            *TestScriptRequestMethodCode                  `bson:"method,omitempty" json:"method,omitempty"`
+	Origin            *int                                          `bson:"origin,omitempty" json:"origin,omitempty"`
+	Params            *string                                       `bson:"params,omitempty" json:"params,omitempty"`
+	RequestHeader     []TestScriptSetupActionOperationRequestHeader `bson:"requestHeader,omitempty" json:"requestHeader,omitempty"`
+	RequestId         *string                                       `bson:"requestId,omitempty" json:"requestId,omitempty"`
+	ResponseId        *string                                       `bson:"responseId,omitempty" json:"responseId,omitempty"`
+	SourceId          *string                                       `bson:"sourceId,omitempty" json:"sourceId,omitempty"`
+	TargetId          *string                                       `bson:"targetId,omitempty" json:"targetId,omitempty"`
+	Url               *string                                       `bson:"url,omitempty" json:"url,omitempty"`
 }
 type TestScriptSetupActionOperationRequestHeader struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Field             string      `json:"field"`
-	Value             string      `json:"value"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Field             string      `bson:"field" json:"field"`
+	Value             string      `bson:"value" json:"value"`
 }
 type TestScriptSetupActionAssert struct {
-	Id                        *string                      `json:"id,omitempty"`
-	Extension                 []Extension                  `json:"extension,omitempty"`
-	ModifierExtension         []Extension                  `json:"modifierExtension,omitempty"`
-	Label                     *string                      `json:"label,omitempty"`
-	Description               *string                      `json:"description,omitempty"`
-	Direction                 *AssertionDirectionType      `json:"direction,omitempty"`
-	CompareToSourceId         *string                      `json:"compareToSourceId,omitempty"`
-	CompareToSourceExpression *string                      `json:"compareToSourceExpression,omitempty"`
-	CompareToSourcePath       *string                      `json:"compareToSourcePath,omitempty"`
-	ContentType               *string                      `json:"contentType,omitempty"`
-	Expression                *string                      `json:"expression,omitempty"`
-	HeaderField               *string                      `json:"headerField,omitempty"`
-	MinimumId                 *string                      `json:"minimumId,omitempty"`
-	NavigationLinks           *bool                        `json:"navigationLinks,omitempty"`
-	Operator                  *AssertionOperatorType       `json:"operator,omitempty"`
-	Path                      *string                      `json:"path,omitempty"`
-	RequestMethod             *TestScriptRequestMethodCode `json:"requestMethod,omitempty"`
-	RequestURL                *string                      `json:"requestURL,omitempty"`
-	Resource                  *string                      `json:"resource,omitempty"`
-	Response                  *AssertionResponseTypes      `json:"response,omitempty"`
-	ResponseCode              *string                      `json:"responseCode,omitempty"`
-	SourceId                  *string                      `json:"sourceId,omitempty"`
-	ValidateProfileId         *string                      `json:"validateProfileId,omitempty"`
-	Value                     *string                      `json:"value,omitempty"`
-	WarningOnly               bool                         `json:"warningOnly"`
+	Id                        *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                 []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension         []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Label                     *string                      `bson:"label,omitempty" json:"label,omitempty"`
+	Description               *string                      `bson:"description,omitempty" json:"description,omitempty"`
+	Direction                 *AssertionDirectionType      `bson:"direction,omitempty" json:"direction,omitempty"`
+	CompareToSourceId         *string                      `bson:"compareToSourceId,omitempty" json:"compareToSourceId,omitempty"`
+	CompareToSourceExpression *string                      `bson:"compareToSourceExpression,omitempty" json:"compareToSourceExpression,omitempty"`
+	CompareToSourcePath       *string                      `bson:"compareToSourcePath,omitempty" json:"compareToSourcePath,omitempty"`
+	ContentType               *string                      `bson:"contentType,omitempty" json:"contentType,omitempty"`
+	Expression                *string                      `bson:"expression,omitempty" json:"expression,omitempty"`
+	HeaderField               *string                      `bson:"headerField,omitempty" json:"headerField,omitempty"`
+	MinimumId                 *string                      `bson:"minimumId,omitempty" json:"minimumId,omitempty"`
+	NavigationLinks           *bool                        `bson:"navigationLinks,omitempty" json:"navigationLinks,omitempty"`
+	Operator                  *AssertionOperatorType       `bson:"operator,omitempty" json:"operator,omitempty"`
+	Path                      *string                      `bson:"path,omitempty" json:"path,omitempty"`
+	RequestMethod             *TestScriptRequestMethodCode `bson:"requestMethod,omitempty" json:"requestMethod,omitempty"`
+	RequestURL                *string                      `bson:"requestURL,omitempty" json:"requestURL,omitempty"`
+	Resource                  *string                      `bson:"resource,omitempty" json:"resource,omitempty"`
+	Response                  *AssertionResponseTypes      `bson:"response,omitempty" json:"response,omitempty"`
+	ResponseCode              *string                      `bson:"responseCode,omitempty" json:"responseCode,omitempty"`
+	SourceId                  *string                      `bson:"sourceId,omitempty" json:"sourceId,omitempty"`
+	ValidateProfileId         *string                      `bson:"validateProfileId,omitempty" json:"validateProfileId,omitempty"`
+	Value                     *string                      `bson:"value,omitempty" json:"value,omitempty"`
+	WarningOnly               bool                         `bson:"warningOnly" json:"warningOnly"`
 }
 type TestScriptTest struct {
-	Id                *string                `json:"id,omitempty"`
-	Extension         []Extension            `json:"extension,omitempty"`
-	ModifierExtension []Extension            `json:"modifierExtension,omitempty"`
-	Name              *string                `json:"name,omitempty"`
-	Description       *string                `json:"description,omitempty"`
-	Action            []TestScriptTestAction `json:"action"`
+	Id                *string                `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension            `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension            `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              *string                `bson:"name,omitempty" json:"name,omitempty"`
+	Description       *string                `bson:"description,omitempty" json:"description,omitempty"`
+	Action            []TestScriptTestAction `bson:"action" json:"action"`
 }
 type TestScriptTestAction struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	Operation         *TestScriptSetupActionOperation `json:"operation,omitempty"`
-	Assert            *TestScriptSetupActionAssert    `json:"assert,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Operation         *TestScriptSetupActionOperation `bson:"operation,omitempty" json:"operation,omitempty"`
+	Assert            *TestScriptSetupActionAssert    `bson:"assert,omitempty" json:"assert,omitempty"`
 }
 type TestScriptTeardown struct {
-	Id                *string                    `json:"id,omitempty"`
-	Extension         []Extension                `json:"extension,omitempty"`
-	ModifierExtension []Extension                `json:"modifierExtension,omitempty"`
-	Action            []TestScriptTeardownAction `json:"action"`
+	Id                *string                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Action            []TestScriptTeardownAction `bson:"action" json:"action"`
 }
 type TestScriptTeardownAction struct {
-	Id                *string                        `json:"id,omitempty"`
-	Extension         []Extension                    `json:"extension,omitempty"`
-	ModifierExtension []Extension                    `json:"modifierExtension,omitempty"`
-	Operation         TestScriptSetupActionOperation `json:"operation,omitempty"`
+	Id                *string                        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Operation         TestScriptSetupActionOperation `bson:"operation,omitempty" json:"operation,omitempty"`
 }
 type OtherTestScript TestScript
 

--- a/fhir-models/fhir/timing.go
+++ b/fhir-models/fhir/timing.go
@@ -19,28 +19,28 @@ package fhir
 
 // Timing is documented here http://hl7.org/fhir/StructureDefinition/Timing
 type Timing struct {
-	Id                *string          `json:"id,omitempty"`
-	Extension         []Extension      `json:"extension,omitempty"`
-	ModifierExtension []Extension      `json:"modifierExtension,omitempty"`
-	Event             []string         `json:"event,omitempty"`
-	Repeat            *TimingRepeat    `json:"repeat,omitempty"`
-	Code              *CodeableConcept `json:"code,omitempty"`
+	Id                *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Event             []string         `bson:"event,omitempty" json:"event,omitempty"`
+	Repeat            *TimingRepeat    `bson:"repeat,omitempty" json:"repeat,omitempty"`
+	Code              *CodeableConcept `bson:"code,omitempty" json:"code,omitempty"`
 }
 type TimingRepeat struct {
-	Id           *string      `json:"id,omitempty"`
-	Extension    []Extension  `json:"extension,omitempty"`
-	Count        *int         `json:"count,omitempty"`
-	CountMax     *int         `json:"countMax,omitempty"`
-	Duration     *string      `json:"duration,omitempty"`
-	DurationMax  *string      `json:"durationMax,omitempty"`
-	DurationUnit *string      `json:"durationUnit,omitempty"`
-	Frequency    *int         `json:"frequency,omitempty"`
-	FrequencyMax *int         `json:"frequencyMax,omitempty"`
-	Period       *string      `json:"period,omitempty"`
-	PeriodMax    *string      `json:"periodMax,omitempty"`
-	PeriodUnit   *string      `json:"periodUnit,omitempty"`
-	DayOfWeek    []DaysOfWeek `json:"dayOfWeek,omitempty"`
-	TimeOfDay    []string     `json:"timeOfDay,omitempty"`
-	When         []string     `json:"when,omitempty"`
-	Offset       *int         `json:"offset,omitempty"`
+	Id           *string      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension    []Extension  `bson:"extension,omitempty" json:"extension,omitempty"`
+	Count        *int         `bson:"count,omitempty" json:"count,omitempty"`
+	CountMax     *int         `bson:"countMax,omitempty" json:"countMax,omitempty"`
+	Duration     *string      `bson:"duration,omitempty" json:"duration,omitempty"`
+	DurationMax  *string      `bson:"durationMax,omitempty" json:"durationMax,omitempty"`
+	DurationUnit *string      `bson:"durationUnit,omitempty" json:"durationUnit,omitempty"`
+	Frequency    *int         `bson:"frequency,omitempty" json:"frequency,omitempty"`
+	FrequencyMax *int         `bson:"frequencyMax,omitempty" json:"frequencyMax,omitempty"`
+	Period       *string      `bson:"period,omitempty" json:"period,omitempty"`
+	PeriodMax    *string      `bson:"periodMax,omitempty" json:"periodMax,omitempty"`
+	PeriodUnit   *string      `bson:"periodUnit,omitempty" json:"periodUnit,omitempty"`
+	DayOfWeek    []DaysOfWeek `bson:"dayOfWeek,omitempty" json:"dayOfWeek,omitempty"`
+	TimeOfDay    []string     `bson:"timeOfDay,omitempty" json:"timeOfDay,omitempty"`
+	When         []string     `bson:"when,omitempty" json:"when,omitempty"`
+	Offset       *int         `bson:"offset,omitempty" json:"offset,omitempty"`
 }

--- a/fhir-models/fhir/triggerDefinition.go
+++ b/fhir-models/fhir/triggerDefinition.go
@@ -19,10 +19,10 @@ package fhir
 
 // TriggerDefinition is documented here http://hl7.org/fhir/StructureDefinition/TriggerDefinition
 type TriggerDefinition struct {
-	Id        *string           `json:"id,omitempty"`
-	Extension []Extension       `json:"extension,omitempty"`
-	Type      TriggerType       `json:"type"`
-	Name      *string           `json:"name,omitempty"`
-	Data      []DataRequirement `json:"data,omitempty"`
-	Condition *Expression       `json:"condition,omitempty"`
+	Id        *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	Type      TriggerType       `bson:"type" json:"type"`
+	Name      *string           `bson:"name,omitempty" json:"name,omitempty"`
+	Data      []DataRequirement `bson:"data,omitempty" json:"data,omitempty"`
+	Condition *Expression       `bson:"condition,omitempty" json:"condition,omitempty"`
 }

--- a/fhir-models/fhir/usageContext.go
+++ b/fhir-models/fhir/usageContext.go
@@ -19,7 +19,7 @@ package fhir
 
 // UsageContext is documented here http://hl7.org/fhir/StructureDefinition/UsageContext
 type UsageContext struct {
-	Id        *string     `json:"id,omitempty"`
-	Extension []Extension `json:"extension,omitempty"`
-	Code      Coding      `json:"code"`
+	Id        *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	Code      Coding      `bson:"code" json:"code"`
 }

--- a/fhir-models/fhir/valueSet.go
+++ b/fhir-models/fhir/valueSet.go
@@ -21,104 +21,104 @@ import "encoding/json"
 
 // ValueSet is documented here http://hl7.org/fhir/StructureDefinition/ValueSet
 type ValueSet struct {
-	Id                *string            `json:"id,omitempty"`
-	Meta              *Meta              `json:"meta,omitempty"`
-	ImplicitRules     *string            `json:"implicitRules,omitempty"`
-	Language          *string            `json:"language,omitempty"`
-	Text              *Narrative         `json:"text,omitempty"`
-	Extension         []Extension        `json:"extension,omitempty"`
-	ModifierExtension []Extension        `json:"modifierExtension,omitempty"`
-	Url               *string            `json:"url,omitempty"`
-	Identifier        []Identifier       `json:"identifier,omitempty"`
-	Version           *string            `json:"version,omitempty"`
-	Name              *string            `json:"name,omitempty"`
-	Title             *string            `json:"title,omitempty"`
-	Status            PublicationStatus  `json:"status"`
-	Experimental      *bool              `json:"experimental,omitempty"`
-	Date              *string            `json:"date,omitempty"`
-	Publisher         *string            `json:"publisher,omitempty"`
-	Contact           []ContactDetail    `json:"contact,omitempty"`
-	Description       *string            `json:"description,omitempty"`
-	UseContext        []UsageContext     `json:"useContext,omitempty"`
-	Jurisdiction      []CodeableConcept  `json:"jurisdiction,omitempty"`
-	Immutable         *bool              `json:"immutable,omitempty"`
-	Purpose           *string            `json:"purpose,omitempty"`
-	Copyright         *string            `json:"copyright,omitempty"`
-	Compose           *ValueSetCompose   `json:"compose,omitempty"`
-	Expansion         *ValueSetExpansion `json:"expansion,omitempty"`
+	Id                *string            `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta              `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string            `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string            `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative         `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension        `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension        `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Url               *string            `bson:"url,omitempty" json:"url,omitempty"`
+	Identifier        []Identifier       `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Version           *string            `bson:"version,omitempty" json:"version,omitempty"`
+	Name              *string            `bson:"name,omitempty" json:"name,omitempty"`
+	Title             *string            `bson:"title,omitempty" json:"title,omitempty"`
+	Status            PublicationStatus  `bson:"status" json:"status"`
+	Experimental      *bool              `bson:"experimental,omitempty" json:"experimental,omitempty"`
+	Date              *string            `bson:"date,omitempty" json:"date,omitempty"`
+	Publisher         *string            `bson:"publisher,omitempty" json:"publisher,omitempty"`
+	Contact           []ContactDetail    `bson:"contact,omitempty" json:"contact,omitempty"`
+	Description       *string            `bson:"description,omitempty" json:"description,omitempty"`
+	UseContext        []UsageContext     `bson:"useContext,omitempty" json:"useContext,omitempty"`
+	Jurisdiction      []CodeableConcept  `bson:"jurisdiction,omitempty" json:"jurisdiction,omitempty"`
+	Immutable         *bool              `bson:"immutable,omitempty" json:"immutable,omitempty"`
+	Purpose           *string            `bson:"purpose,omitempty" json:"purpose,omitempty"`
+	Copyright         *string            `bson:"copyright,omitempty" json:"copyright,omitempty"`
+	Compose           *ValueSetCompose   `bson:"compose,omitempty" json:"compose,omitempty"`
+	Expansion         *ValueSetExpansion `bson:"expansion,omitempty" json:"expansion,omitempty"`
 }
 type ValueSetCompose struct {
-	Id                *string                  `json:"id,omitempty"`
-	Extension         []Extension              `json:"extension,omitempty"`
-	ModifierExtension []Extension              `json:"modifierExtension,omitempty"`
-	LockedDate        *string                  `json:"lockedDate,omitempty"`
-	Inactive          *bool                    `json:"inactive,omitempty"`
-	Include           []ValueSetComposeInclude `json:"include"`
-	Exclude           []ValueSetComposeInclude `json:"exclude,omitempty"`
+	Id                *string                  `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension              `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension              `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	LockedDate        *string                  `bson:"lockedDate,omitempty" json:"lockedDate,omitempty"`
+	Inactive          *bool                    `bson:"inactive,omitempty" json:"inactive,omitempty"`
+	Include           []ValueSetComposeInclude `bson:"include" json:"include"`
+	Exclude           []ValueSetComposeInclude `bson:"exclude,omitempty" json:"exclude,omitempty"`
 }
 type ValueSetComposeInclude struct {
-	Id                *string                         `json:"id,omitempty"`
-	Extension         []Extension                     `json:"extension,omitempty"`
-	ModifierExtension []Extension                     `json:"modifierExtension,omitempty"`
-	System            *string                         `json:"system,omitempty"`
-	Version           *string                         `json:"version,omitempty"`
-	Concept           []ValueSetComposeIncludeConcept `json:"concept,omitempty"`
-	Filter            []ValueSetComposeIncludeFilter  `json:"filter,omitempty"`
-	ValueSet          []string                        `json:"valueSet,omitempty"`
+	Id                *string                         `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                     `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                     `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	System            *string                         `bson:"system,omitempty" json:"system,omitempty"`
+	Version           *string                         `bson:"version,omitempty" json:"version,omitempty"`
+	Concept           []ValueSetComposeIncludeConcept `bson:"concept,omitempty" json:"concept,omitempty"`
+	Filter            []ValueSetComposeIncludeFilter  `bson:"filter,omitempty" json:"filter,omitempty"`
+	ValueSet          []string                        `bson:"valueSet,omitempty" json:"valueSet,omitempty"`
 }
 type ValueSetComposeIncludeConcept struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Code              string                                     `json:"code"`
-	Display           *string                                    `json:"display,omitempty"`
-	Designation       []ValueSetComposeIncludeConceptDesignation `json:"designation,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Code              string                                     `bson:"code" json:"code"`
+	Display           *string                                    `bson:"display,omitempty" json:"display,omitempty"`
+	Designation       []ValueSetComposeIncludeConceptDesignation `bson:"designation,omitempty" json:"designation,omitempty"`
 }
 type ValueSetComposeIncludeConceptDesignation struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Language          *string     `json:"language,omitempty"`
-	Use               *Coding     `json:"use,omitempty"`
-	Value             string      `json:"value"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Language          *string     `bson:"language,omitempty" json:"language,omitempty"`
+	Use               *Coding     `bson:"use,omitempty" json:"use,omitempty"`
+	Value             string      `bson:"value" json:"value"`
 }
 type ValueSetComposeIncludeFilter struct {
-	Id                *string        `json:"id,omitempty"`
-	Extension         []Extension    `json:"extension,omitempty"`
-	ModifierExtension []Extension    `json:"modifierExtension,omitempty"`
-	Property          string         `json:"property"`
-	Op                FilterOperator `json:"op"`
-	Value             string         `json:"value"`
+	Id                *string        `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension    `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension    `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Property          string         `bson:"property" json:"property"`
+	Op                FilterOperator `bson:"op" json:"op"`
+	Value             string         `bson:"value" json:"value"`
 }
 type ValueSetExpansion struct {
-	Id                *string                      `json:"id,omitempty"`
-	Extension         []Extension                  `json:"extension,omitempty"`
-	ModifierExtension []Extension                  `json:"modifierExtension,omitempty"`
-	Identifier        *string                      `json:"identifier,omitempty"`
-	Timestamp         string                       `json:"timestamp"`
-	Total             *int                         `json:"total,omitempty"`
-	Offset            *int                         `json:"offset,omitempty"`
-	Parameter         []ValueSetExpansionParameter `json:"parameter,omitempty"`
-	Contains          []ValueSetExpansionContains  `json:"contains,omitempty"`
+	Id                *string                      `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                  `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                  `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        *string                      `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Timestamp         string                       `bson:"timestamp" json:"timestamp"`
+	Total             *int                         `bson:"total,omitempty" json:"total,omitempty"`
+	Offset            *int                         `bson:"offset,omitempty" json:"offset,omitempty"`
+	Parameter         []ValueSetExpansionParameter `bson:"parameter,omitempty" json:"parameter,omitempty"`
+	Contains          []ValueSetExpansionContains  `bson:"contains,omitempty" json:"contains,omitempty"`
 }
 type ValueSetExpansionParameter struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Name              string      `json:"name"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Name              string      `bson:"name" json:"name"`
 }
 type ValueSetExpansionContains struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	System            *string                                    `json:"system,omitempty"`
-	Abstract          *bool                                      `json:"abstract,omitempty"`
-	Inactive          *bool                                      `json:"inactive,omitempty"`
-	Version           *string                                    `json:"version,omitempty"`
-	Code              *string                                    `json:"code,omitempty"`
-	Display           *string                                    `json:"display,omitempty"`
-	Designation       []ValueSetComposeIncludeConceptDesignation `json:"designation,omitempty"`
-	Contains          []ValueSetExpansionContains                `json:"contains,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	System            *string                                    `bson:"system,omitempty" json:"system,omitempty"`
+	Abstract          *bool                                      `bson:"abstract,omitempty" json:"abstract,omitempty"`
+	Inactive          *bool                                      `bson:"inactive,omitempty" json:"inactive,omitempty"`
+	Version           *string                                    `bson:"version,omitempty" json:"version,omitempty"`
+	Code              *string                                    `bson:"code,omitempty" json:"code,omitempty"`
+	Display           *string                                    `bson:"display,omitempty" json:"display,omitempty"`
+	Designation       []ValueSetComposeIncludeConceptDesignation `bson:"designation,omitempty" json:"designation,omitempty"`
+	Contains          []ValueSetExpansionContains                `bson:"contains,omitempty" json:"contains,omitempty"`
 }
 type OtherValueSet ValueSet
 

--- a/fhir-models/fhir/verificationResult.go
+++ b/fhir-models/fhir/verificationResult.go
@@ -21,60 +21,60 @@ import "encoding/json"
 
 // VerificationResult is documented here http://hl7.org/fhir/StructureDefinition/VerificationResult
 type VerificationResult struct {
-	Id                *string                           `json:"id,omitempty"`
-	Meta              *Meta                             `json:"meta,omitempty"`
-	ImplicitRules     *string                           `json:"implicitRules,omitempty"`
-	Language          *string                           `json:"language,omitempty"`
-	Text              *Narrative                        `json:"text,omitempty"`
-	Extension         []Extension                       `json:"extension,omitempty"`
-	ModifierExtension []Extension                       `json:"modifierExtension,omitempty"`
-	Target            []Reference                       `json:"target,omitempty"`
-	TargetLocation    []string                          `json:"targetLocation,omitempty"`
-	Need              *CodeableConcept                  `json:"need,omitempty"`
-	Status            string                            `json:"status"`
-	StatusDate        *string                           `json:"statusDate,omitempty"`
-	ValidationType    *CodeableConcept                  `json:"validationType,omitempty"`
-	ValidationProcess []CodeableConcept                 `json:"validationProcess,omitempty"`
-	Frequency         *Timing                           `json:"frequency,omitempty"`
-	LastPerformed     *string                           `json:"lastPerformed,omitempty"`
-	NextScheduled     *string                           `json:"nextScheduled,omitempty"`
-	FailureAction     *CodeableConcept                  `json:"failureAction,omitempty"`
-	PrimarySource     []VerificationResultPrimarySource `json:"primarySource,omitempty"`
-	Attestation       *VerificationResultAttestation    `json:"attestation,omitempty"`
-	Validator         []VerificationResultValidator     `json:"validator,omitempty"`
+	Id                *string                           `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                             `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                           `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                           `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                        `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Target            []Reference                       `bson:"target,omitempty" json:"target,omitempty"`
+	TargetLocation    []string                          `bson:"targetLocation,omitempty" json:"targetLocation,omitempty"`
+	Need              *CodeableConcept                  `bson:"need,omitempty" json:"need,omitempty"`
+	Status            string                            `bson:"status" json:"status"`
+	StatusDate        *string                           `bson:"statusDate,omitempty" json:"statusDate,omitempty"`
+	ValidationType    *CodeableConcept                  `bson:"validationType,omitempty" json:"validationType,omitempty"`
+	ValidationProcess []CodeableConcept                 `bson:"validationProcess,omitempty" json:"validationProcess,omitempty"`
+	Frequency         *Timing                           `bson:"frequency,omitempty" json:"frequency,omitempty"`
+	LastPerformed     *string                           `bson:"lastPerformed,omitempty" json:"lastPerformed,omitempty"`
+	NextScheduled     *string                           `bson:"nextScheduled,omitempty" json:"nextScheduled,omitempty"`
+	FailureAction     *CodeableConcept                  `bson:"failureAction,omitempty" json:"failureAction,omitempty"`
+	PrimarySource     []VerificationResultPrimarySource `bson:"primarySource,omitempty" json:"primarySource,omitempty"`
+	Attestation       *VerificationResultAttestation    `bson:"attestation,omitempty" json:"attestation,omitempty"`
+	Validator         []VerificationResultValidator     `bson:"validator,omitempty" json:"validator,omitempty"`
 }
 type VerificationResultPrimarySource struct {
-	Id                  *string           `json:"id,omitempty"`
-	Extension           []Extension       `json:"extension,omitempty"`
-	ModifierExtension   []Extension       `json:"modifierExtension,omitempty"`
-	Who                 *Reference        `json:"who,omitempty"`
-	Type                []CodeableConcept `json:"type,omitempty"`
-	CommunicationMethod []CodeableConcept `json:"communicationMethod,omitempty"`
-	ValidationStatus    *CodeableConcept  `json:"validationStatus,omitempty"`
-	ValidationDate      *string           `json:"validationDate,omitempty"`
-	CanPushUpdates      *CodeableConcept  `json:"canPushUpdates,omitempty"`
-	PushTypeAvailable   []CodeableConcept `json:"pushTypeAvailable,omitempty"`
+	Id                  *string           `bson:"id,omitempty" json:"id,omitempty"`
+	Extension           []Extension       `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension   []Extension       `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Who                 *Reference        `bson:"who,omitempty" json:"who,omitempty"`
+	Type                []CodeableConcept `bson:"type,omitempty" json:"type,omitempty"`
+	CommunicationMethod []CodeableConcept `bson:"communicationMethod,omitempty" json:"communicationMethod,omitempty"`
+	ValidationStatus    *CodeableConcept  `bson:"validationStatus,omitempty" json:"validationStatus,omitempty"`
+	ValidationDate      *string           `bson:"validationDate,omitempty" json:"validationDate,omitempty"`
+	CanPushUpdates      *CodeableConcept  `bson:"canPushUpdates,omitempty" json:"canPushUpdates,omitempty"`
+	PushTypeAvailable   []CodeableConcept `bson:"pushTypeAvailable,omitempty" json:"pushTypeAvailable,omitempty"`
 }
 type VerificationResultAttestation struct {
-	Id                        *string          `json:"id,omitempty"`
-	Extension                 []Extension      `json:"extension,omitempty"`
-	ModifierExtension         []Extension      `json:"modifierExtension,omitempty"`
-	Who                       *Reference       `json:"who,omitempty"`
-	OnBehalfOf                *Reference       `json:"onBehalfOf,omitempty"`
-	CommunicationMethod       *CodeableConcept `json:"communicationMethod,omitempty"`
-	Date                      *string          `json:"date,omitempty"`
-	SourceIdentityCertificate *string          `json:"sourceIdentityCertificate,omitempty"`
-	ProxyIdentityCertificate  *string          `json:"proxyIdentityCertificate,omitempty"`
-	ProxySignature            *Signature       `json:"proxySignature,omitempty"`
-	SourceSignature           *Signature       `json:"sourceSignature,omitempty"`
+	Id                        *string          `bson:"id,omitempty" json:"id,omitempty"`
+	Extension                 []Extension      `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension         []Extension      `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Who                       *Reference       `bson:"who,omitempty" json:"who,omitempty"`
+	OnBehalfOf                *Reference       `bson:"onBehalfOf,omitempty" json:"onBehalfOf,omitempty"`
+	CommunicationMethod       *CodeableConcept `bson:"communicationMethod,omitempty" json:"communicationMethod,omitempty"`
+	Date                      *string          `bson:"date,omitempty" json:"date,omitempty"`
+	SourceIdentityCertificate *string          `bson:"sourceIdentityCertificate,omitempty" json:"sourceIdentityCertificate,omitempty"`
+	ProxyIdentityCertificate  *string          `bson:"proxyIdentityCertificate,omitempty" json:"proxyIdentityCertificate,omitempty"`
+	ProxySignature            *Signature       `bson:"proxySignature,omitempty" json:"proxySignature,omitempty"`
+	SourceSignature           *Signature       `bson:"sourceSignature,omitempty" json:"sourceSignature,omitempty"`
 }
 type VerificationResultValidator struct {
-	Id                   *string     `json:"id,omitempty"`
-	Extension            []Extension `json:"extension,omitempty"`
-	ModifierExtension    []Extension `json:"modifierExtension,omitempty"`
-	Organization         Reference   `json:"organization"`
-	IdentityCertificate  *string     `json:"identityCertificate,omitempty"`
-	AttestationSignature *Signature  `json:"attestationSignature,omitempty"`
+	Id                   *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension            []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension    []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Organization         Reference   `bson:"organization" json:"organization"`
+	IdentityCertificate  *string     `bson:"identityCertificate,omitempty" json:"identityCertificate,omitempty"`
+	AttestationSignature *Signature  `bson:"attestationSignature,omitempty" json:"attestationSignature,omitempty"`
 }
 type OtherVerificationResult VerificationResult
 

--- a/fhir-models/fhir/visionPrescription.go
+++ b/fhir-models/fhir/visionPrescription.go
@@ -21,47 +21,47 @@ import "encoding/json"
 
 // VisionPrescription is documented here http://hl7.org/fhir/StructureDefinition/VisionPrescription
 type VisionPrescription struct {
-	Id                *string                               `json:"id,omitempty"`
-	Meta              *Meta                                 `json:"meta,omitempty"`
-	ImplicitRules     *string                               `json:"implicitRules,omitempty"`
-	Language          *string                               `json:"language,omitempty"`
-	Text              *Narrative                            `json:"text,omitempty"`
-	Extension         []Extension                           `json:"extension,omitempty"`
-	ModifierExtension []Extension                           `json:"modifierExtension,omitempty"`
-	Identifier        []Identifier                          `json:"identifier,omitempty"`
-	Status            FinancialResourceStatusCodes          `json:"status"`
-	Created           string                                `json:"created"`
-	Patient           Reference                             `json:"patient"`
-	Encounter         *Reference                            `json:"encounter,omitempty"`
-	DateWritten       string                                `json:"dateWritten"`
-	Prescriber        Reference                             `json:"prescriber"`
-	LensSpecification []VisionPrescriptionLensSpecification `json:"lensSpecification"`
+	Id                *string                               `bson:"id,omitempty" json:"id,omitempty"`
+	Meta              *Meta                                 `bson:"meta,omitempty" json:"meta,omitempty"`
+	ImplicitRules     *string                               `bson:"implicitRules,omitempty" json:"implicitRules,omitempty"`
+	Language          *string                               `bson:"language,omitempty" json:"language,omitempty"`
+	Text              *Narrative                            `bson:"text,omitempty" json:"text,omitempty"`
+	Extension         []Extension                           `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                           `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Identifier        []Identifier                          `bson:"identifier,omitempty" json:"identifier,omitempty"`
+	Status            FinancialResourceStatusCodes          `bson:"status" json:"status"`
+	Created           string                                `bson:"created" json:"created"`
+	Patient           Reference                             `bson:"patient" json:"patient"`
+	Encounter         *Reference                            `bson:"encounter,omitempty" json:"encounter,omitempty"`
+	DateWritten       string                                `bson:"dateWritten" json:"dateWritten"`
+	Prescriber        Reference                             `bson:"prescriber" json:"prescriber"`
+	LensSpecification []VisionPrescriptionLensSpecification `bson:"lensSpecification" json:"lensSpecification"`
 }
 type VisionPrescriptionLensSpecification struct {
-	Id                *string                                    `json:"id,omitempty"`
-	Extension         []Extension                                `json:"extension,omitempty"`
-	ModifierExtension []Extension                                `json:"modifierExtension,omitempty"`
-	Product           CodeableConcept                            `json:"product"`
-	Eye               VisionEyes                                 `json:"eye"`
-	Sphere            *string                                    `json:"sphere,omitempty"`
-	Cylinder          *string                                    `json:"cylinder,omitempty"`
-	Axis              *int                                       `json:"axis,omitempty"`
-	Prism             []VisionPrescriptionLensSpecificationPrism `json:"prism,omitempty"`
-	Add               *string                                    `json:"add,omitempty"`
-	Power             *string                                    `json:"power,omitempty"`
-	BackCurve         *string                                    `json:"backCurve,omitempty"`
-	Diameter          *string                                    `json:"diameter,omitempty"`
-	Duration          *Quantity                                  `json:"duration,omitempty"`
-	Color             *string                                    `json:"color,omitempty"`
-	Brand             *string                                    `json:"brand,omitempty"`
-	Note              []Annotation                               `json:"note,omitempty"`
+	Id                *string                                    `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension                                `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension                                `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Product           CodeableConcept                            `bson:"product" json:"product"`
+	Eye               VisionEyes                                 `bson:"eye" json:"eye"`
+	Sphere            *string                                    `bson:"sphere,omitempty" json:"sphere,omitempty"`
+	Cylinder          *string                                    `bson:"cylinder,omitempty" json:"cylinder,omitempty"`
+	Axis              *int                                       `bson:"axis,omitempty" json:"axis,omitempty"`
+	Prism             []VisionPrescriptionLensSpecificationPrism `bson:"prism,omitempty" json:"prism,omitempty"`
+	Add               *string                                    `bson:"add,omitempty" json:"add,omitempty"`
+	Power             *string                                    `bson:"power,omitempty" json:"power,omitempty"`
+	BackCurve         *string                                    `bson:"backCurve,omitempty" json:"backCurve,omitempty"`
+	Diameter          *string                                    `bson:"diameter,omitempty" json:"diameter,omitempty"`
+	Duration          *Quantity                                  `bson:"duration,omitempty" json:"duration,omitempty"`
+	Color             *string                                    `bson:"color,omitempty" json:"color,omitempty"`
+	Brand             *string                                    `bson:"brand,omitempty" json:"brand,omitempty"`
+	Note              []Annotation                               `bson:"note,omitempty" json:"note,omitempty"`
 }
 type VisionPrescriptionLensSpecificationPrism struct {
-	Id                *string     `json:"id,omitempty"`
-	Extension         []Extension `json:"extension,omitempty"`
-	ModifierExtension []Extension `json:"modifierExtension,omitempty"`
-	Amount            string      `json:"amount"`
-	Base              VisionBase  `json:"base"`
+	Id                *string     `bson:"id,omitempty" json:"id,omitempty"`
+	Extension         []Extension `bson:"extension,omitempty" json:"extension,omitempty"`
+	ModifierExtension []Extension `bson:"modifierExtension,omitempty" json:"modifierExtension,omitempty"`
+	Amount            string      `bson:"amount" json:"amount"`
+	Base              VisionBase  `bson:"base" json:"base"`
 }
 type OtherVisionPrescription VisionPrescription
 

--- a/fhir-models/go.mod
+++ b/fhir-models/go.mod
@@ -1,3 +1,3 @@
-module github.com/samply/golang-fhir-models/fhir-models
+module fhir-models
 
 go 1.13

--- a/fhir-models/go.mod
+++ b/fhir-models/go.mod
@@ -1,3 +1,3 @@
-module fhir-models
+module github.com/Universal-Health-Chain/golang-fhir-models/fhir-models
 
 go 1.13


### PR DESCRIPTION
This pull request adds the tag bson to the struct fhir models. This is important when working with mongodb, otherwise the data is saved only with lower case. This is a problem that we encountered when using golang-fhir-models.

